### PR TITLE
RestClient#stats

### DIFF
--- a/ably-ios/ARTHttpPaginatedResult.h
+++ b/ably-ios/ARTHttpPaginatedResult.h
@@ -10,13 +10,23 @@
 #import <ably/ARTHttp.h>
 #import <ably/ARTPaginatedResult.h>
 
-@interface ARTHttpPaginatedResult : NSObject <ARTPaginatedResult>
+@interface ARTHttpPaginatedResult : ARTPaginatedResult
 
-typedef id (^ARTHttpResponseProcessor)(ARTHttpResponse *);
+typedef NSArray *(^ARTHttpResponseProcessor)(ARTHttpResponse *);
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
-- (instancetype)initWithHttp:(ARTHttp *)http current:(id)current contentType:(NSString *)contentType relFirst:(ARTHttpRequest *)relFirst relCurrent:(ARTHttpRequest *)relCurrent relNext:(ARTHttpRequest *)relNext responseProcessor:(ARTHttpResponseProcessor)responseProcessor;
 
-+ (id<ARTCancellable>)makePaginatedRequest:(ARTHttp *)http request:(ARTHttpRequest *)request responseProcessor:(ARTHttpResponseProcessor)responseProcessor cb:(ARTPaginatedResultCb)cb;
+- (instancetype)initWithHttp:(ARTHttp *)http
+                     items:(NSArray *)items
+                 contentType:(NSString *)contentType
+                    relFirst:(ARTHttpRequest *)relFirst
+                  relCurrent:(ARTHttpRequest *)relCurrent
+                     relNext:(ARTHttpRequest *)relNext
+           responseProcessor:(ARTHttpResponseProcessor)responseProcessor;
+
++ (id<ARTCancellable>)makePaginatedRequest:(ARTHttp *)http
+                                   request:(ARTHttpRequest *)request
+                         responseProcessor:(ARTHttpResponseProcessor)responseProcessor
+                                  callback:(ARTPaginatedResultCallback)callback;
 
 @end

--- a/ably-ios/ARTHttpPaginatedResult.h
+++ b/ably-ios/ARTHttpPaginatedResult.h
@@ -17,7 +17,7 @@ typedef NSArray *(^ARTHttpResponseProcessor)(ARTHttpResponse *);
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
 - (instancetype)initWithHttp:(ARTHttp *)http
-                     items:(NSArray *)items
+                       items:(NSArray *)items
                  contentType:(NSString *)contentType
                     relFirst:(ARTHttpRequest *)relFirst
                   relCurrent:(ARTHttpRequest *)relCurrent

--- a/ably-ios/ARTHttpPaginatedResult.m
+++ b/ably-ios/ARTHttpPaginatedResult.m
@@ -41,15 +41,15 @@
     return self;
 }
 
-- (void)getFirst:(ARTPaginatedResultCallback)callback {
+- (void)first:(ARTPaginatedResultCallback)callback {
     [ARTHttpPaginatedResult makePaginatedRequest:_http request:_relFirst responseProcessor:_responseProcessor callback:callback];
 }
 
-- (void)getCurrent:(ARTPaginatedResultCallback)callback {
+- (void)current:(ARTPaginatedResultCallback)callback {
     [ARTHttpPaginatedResult makePaginatedRequest:_http request:_relCurrent responseProcessor:_responseProcessor callback:callback];
 }
 
-- (void)getNext:(ARTPaginatedResultCallback)callback {
+- (void)next:(ARTPaginatedResultCallback)callback {
     [ARTHttpPaginatedResult makePaginatedRequest:_http request:_relNext responseProcessor:_responseProcessor callback:callback];
 }
 

--- a/ably-ios/ARTHttpPaginatedResult.m
+++ b/ably-ios/ARTHttpPaginatedResult.m
@@ -9,82 +9,70 @@
 #import "ARTHttpPaginatedResult.h"
 #import "ARTLog.h"
 #import "ARTStatus.h"
-@interface ARTHttpPaginatedResult ()
 
-@property (readonly, strong, nonatomic) ARTHttp *http;
-@property (readonly, strong, nonatomic) id currentValue;
-@property (readonly, strong, nonatomic) NSString *contentType;
-@property (readonly, strong, nonatomic) ARTHttpRequest *relFirst;
-@property (readonly, strong, nonatomic) ARTHttpRequest *relCurrent;
-@property (readonly, strong, nonatomic) ARTHttpRequest *relNext;
-@property (readonly, strong, nonatomic) ARTHttpResponseProcessor responseProcessor;
+@implementation ARTHttpPaginatedResult {
+    ARTHttp *_http;
+    NSString *_contentType;
+    ARTHttpRequest *_relFirst;
+    ARTHttpRequest *_relCurrent;
+    ARTHttpRequest *_relNext;
+    ARTHttpResponseProcessor _responseProcessor;
+}
 
-@end
-
-@implementation ARTHttpPaginatedResult
-
-- (instancetype)initWithHttp:(ARTHttp *)http current:(id)current contentType:(NSString *)contentType relFirst:(ARTHttpRequest *)relFirst relCurrent:(ARTHttpRequest *)relCurrent relNext:(ARTHttpRequest *)relNext responseProcessor:(ARTHttpResponseProcessor)responseProcessor {
+- (instancetype)initWithHttp:(ARTHttp *)http items:(NSArray *)items contentType:(NSString *)contentType relFirst:(ARTHttpRequest *)relFirst relCurrent:(ARTHttpRequest *)relCurrent relNext:(ARTHttpRequest *)relNext responseProcessor:(ARTHttpResponseProcessor)responseProcessor {
     self = [super init];
     if (self) {
         _http = http;
-        _currentValue = current;
-        _contentType = contentType;
+
+        _items = [items copy];
+        _contentType = [contentType copy];
+
+        _hasFirst = !!relFirst;
         _relFirst = relFirst;
+
+        _hasCurrent = !!relCurrent;
         _relCurrent = relCurrent;
+
+        _hasNext = !!relNext;
         _relNext = relNext;
+
         _responseProcessor = responseProcessor;
     }
     return self;
 }
 
-- (id)currentItems {
-    return self.currentValue;
+- (void)getFirst:(ARTPaginatedResultCallback)callback {
+    [ARTHttpPaginatedResult makePaginatedRequest:_http request:_relFirst responseProcessor:_responseProcessor callback:callback];
 }
 
-- (BOOL)hasFirst {
-    return !!self.relFirst;
+- (void)getCurrent:(ARTPaginatedResultCallback)callback {
+    [ARTHttpPaginatedResult makePaginatedRequest:_http request:_relCurrent responseProcessor:_responseProcessor callback:callback];
 }
 
-- (BOOL)hasCurrent {
-    return !!self.relCurrent;
-}
-
-- (BOOL)hasNext {
-    return !!self.relNext;
-}
-
-- (void)first:(ARTPaginatedResultCb)cb {
-    [ARTHttpPaginatedResult makePaginatedRequest:self.http request:self.relFirst responseProcessor:self.responseProcessor cb:cb];
-}
-
-- (void)current:(ARTPaginatedResultCb)cb {
-    [ARTHttpPaginatedResult makePaginatedRequest:self.http request:self.relCurrent responseProcessor:self.responseProcessor cb:cb];
-}
-
-- (void)next:(ARTPaginatedResultCb)cb {
-    [ARTHttpPaginatedResult makePaginatedRequest:self.http request:self.relNext responseProcessor:self.responseProcessor cb:cb];
+- (void)getNext:(ARTPaginatedResultCallback)callback {
+    [ARTHttpPaginatedResult makePaginatedRequest:_http request:_relNext responseProcessor:_responseProcessor callback:callback];
 }
 
 
-+ (id<ARTCancellable>)makePaginatedRequest:(ARTHttp *)http request:(ARTHttpRequest *)request responseProcessor:(ARTHttpResponseProcessor)responseProcessor cb:(ARTPaginatedResultCb)cb {
++ (id<ARTCancellable>)makePaginatedRequest:(ARTHttp *)http request:(ARTHttpRequest *)request responseProcessor:(ARTHttpResponseProcessor)responseProcessor callback:(ARTPaginatedResultCallback)callback {
     return [http makeRequest:request cb:^(ARTHttpResponse *response) {
         if (!response) {
             ARTErrorInfo * info = [[ARTErrorInfo alloc] init];
             [info setCode:40000 message:@"ARTHttpPaginatedResult got no response"];
             [ARTStatus state:ARTStatusError info:info];
-            cb([ARTStatus state:ARTStatusError info:info], nil);
+            callback([ARTStatus state:ARTStatusError info:info], nil);
             return;
         }
 
         if (response.status < 200 || response.status >= 300) {
             ARTErrorInfo * info = [[ARTErrorInfo alloc] init];
             [info setCode:40000 message:[NSString stringWithFormat:@"ARTHttpPaginatedResult response.status invalid: %d", response.status]];
-            cb([ARTStatus state:ARTStatusError info:info], nil);
+            callback([ARTStatus state:ARTStatusError info:info], nil);
             
             return;
         }
 
-        id currentValue = responseProcessor(response);
+        NSArray *items = responseProcessor(response);
 
         NSString *contentType = response.contentType;
         NSDictionary *links = response.links;
@@ -93,7 +81,13 @@
         ARTHttpRequest *currentRelRequest = [request requestWithRelativeUrl:[links objectForKey:@"current"]];
         ARTHttpRequest *nextRelRequest = [request requestWithRelativeUrl:[links objectForKey:@"next"]];
 
-        cb(ARTStatusOk, [[ARTHttpPaginatedResult alloc] initWithHttp:http current:currentValue contentType:contentType relFirst:firstRelRequest relCurrent:currentRelRequest relNext:nextRelRequest responseProcessor:responseProcessor]);
+        ARTPaginatedResult *result = [[ARTHttpPaginatedResult alloc] initWithHttp:http
+                                                                            items:items
+                                                                      contentType:contentType
+                                                                         relFirst:firstRelRequest
+                                                                       relCurrent:currentRelRequest
+                                                                          relNext:nextRelRequest responseProcessor:responseProcessor];
+        callback([ARTStatus state:ARTStatusOk], result);
     }];
 }
 

--- a/ably-ios/ARTPaginatedResult.h
+++ b/ably-ios/ARTPaginatedResult.h
@@ -23,10 +23,12 @@
 @property (nonatomic, readonly) BOOL hasCurrent;
 @property (nonatomic, readonly) BOOL hasNext;
 
+@property (nonatomic, readonly) BOOL isLast;
+
 typedef void(^ARTPaginatedResultCallback)(ARTStatus *status, ARTPaginatedResult *result);
 
-- (void)getFirst:(ARTPaginatedResultCallback)callback;
-- (void)getCurrent:(ARTPaginatedResultCallback)callback;
-- (void)getNext:(ARTPaginatedResultCallback)callback;
+- (void)first:(ARTPaginatedResultCallback)callback;
+- (void)current:(ARTPaginatedResultCallback)callback;
+- (void)next:(ARTPaginatedResultCallback)callback;
 
 @end

--- a/ably-ios/ARTPaginatedResult.h
+++ b/ably-ios/ARTPaginatedResult.h
@@ -9,16 +9,24 @@
 #import <Foundation/Foundation.h>
 #import <ably/ARTStatus.h>
 
-@protocol ARTPaginatedResult
+@interface ARTPaginatedResult : NSObject {
+    @protected
+    NSArray *_items;
+    BOOL _hasFirst;
+    BOOL _hasCurrent;
+    BOOL _hasNext;
+}
 
-- (id)currentItems;
-- (BOOL)hasFirst;
-- (BOOL)hasCurrent;
-- (BOOL)hasNext;
+@property (nonatomic, strong, readonly) NSArray *items;
 
-typedef void (^ARTPaginatedResultCb)(ARTStatus *status, id<ARTPaginatedResult> result);
-- (void)first:(ARTPaginatedResultCb)cb;
-- (void)current:(ARTPaginatedResultCb)cb;
-- (void)next:(ARTPaginatedResultCb)cb;
+@property (nonatomic, readonly) BOOL hasFirst;
+@property (nonatomic, readonly) BOOL hasCurrent;
+@property (nonatomic, readonly) BOOL hasNext;
+
+typedef void(^ARTPaginatedResultCallback)(ARTStatus *status, ARTPaginatedResult *result);
+
+- (void)getFirst:(ARTPaginatedResultCallback)callback;
+- (void)getCurrent:(ARTPaginatedResultCallback)callback;
+- (void)getNext:(ARTPaginatedResultCallback)callback;
 
 @end

--- a/ably-ios/ARTPaginatedResult.m
+++ b/ably-ios/ARTPaginatedResult.m
@@ -10,16 +10,20 @@
 
 @implementation ARTPaginatedResult
 
-- (void)getFirst:(ARTPaginatedResultCallback)callback {
-    NSAssert(false, @"-[ARTPaginatedResult getFirst] should always be overriden.");
+- (void)first:(ARTPaginatedResultCallback)callback {
+    NSAssert(false, @"-[ARTPaginatedResult first] should always be overriden.");
 }
 
-- (void)getCurrent:(ARTPaginatedResultCallback)callback {
-    NSAssert(false, @"-[ARTPaginatedResult getCurrent] should always be overriden.");
+- (void)current:(ARTPaginatedResultCallback)callback {
+    NSAssert(false, @"-[ARTPaginatedResult current] should always be overriden.");
 }
 
-- (void)getNext:(ARTPaginatedResultCallback)callback {
-    NSAssert(false, @"-[ARTPaginatedResult getNext] should always be overriden.");
+- (void)next:(ARTPaginatedResultCallback)callback {
+    NSAssert(false, @"-[ARTPaginatedResult next] should always be overriden.");
+}
+
+- (BOOL)isLast {
+    return !self.hasNext;
 }
 
 @end

--- a/ably-ios/ARTPaginatedResult.m
+++ b/ably-ios/ARTPaginatedResult.m
@@ -1,0 +1,25 @@
+//
+//  ARTPaginatedResult.m
+//  ably
+//
+//  Created by Yavor Georgiev on 10.08.15.
+//  Copyright (c) 2015 г. Ably. All rights reserved.
+//
+
+#import "ARTPaginatedResult.h"
+
+@implementation ARTPaginatedResult
+
+- (void)getFirst:(ARTPaginatedResultCallback)callback {
+    NSAssert(false, @"-[ARTPaginatedResult getFirst] should always be overriden.");
+}
+
+- (void)getCurrent:(ARTPaginatedResultCallback)callback {
+    NSAssert(false, @"-[ARTPaginatedResult getCurrent] should always be overriden.");
+}
+
+- (void)getNext:(ARTPaginatedResultCallback)callback {
+    NSAssert(false, @"-[ARTPaginatedResult getNext] should always be overriden.");
+}
+
+@end

--- a/ably-ios/ARTRealtime.h
+++ b/ably-ios/ARTRealtime.h
@@ -13,6 +13,7 @@
 #import <ably/ARTClientOptions.h>
 #import <ably/ARTPresenceMessage.h>
 #import <ably/ARTPaginatedResult.h>
+#import <ably/ARTStats.h>
 
 
 #define ART_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
@@ -125,8 +126,8 @@ typedef void (^ARTRealtimeChannelPresenceCb)(ARTPresenceMessage *);
 
 typedef void (^ARTRealtimePingCb)(ARTStatus *);
 - (void)ping:(ARTRealtimePingCb) cb;
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback;
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
+
+- (id<ARTCancellable>)stats:(ARTStatsQuery *)query callback:(ARTPaginatedResultCallback)callback;
 
 - (ARTRealtimeChannel *)channel:(NSString *)channelName;
 - (ARTRealtimeChannel *)channel:(NSString *)channelName cipherParams:(ARTCipherParams *)cipherParams;

--- a/ably-ios/ARTRealtime.h
+++ b/ably-ios/ARTRealtime.h
@@ -54,8 +54,8 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeConnectionState) {
 - (void)publish:(id)payload withName:(NSString *)name cb:(ARTStatusCallback)cb;
 - (void)publish:(id)payload cb:(ARTStatusCallback)cb;
 
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
 
 
 
@@ -80,10 +80,10 @@ typedef void (^ARTRealtimeChannelStateCb)(ARTRealtimeChannelState, ARTStatus *);
 
 @interface ARTPresence : NSObject
 - (instancetype) initWithChannel:(ARTRealtimeChannel *) channel;
-- (id<ARTCancellable>)get:(ARTPaginatedResultCb) cb;
-- (id<ARTCancellable>)getWithParams:(NSDictionary *) queryParams cb:(ARTPaginatedResultCb) cb;
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
+- (id<ARTCancellable>)get:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)getWithParams:(NSDictionary *) queryParams cb:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
 
 - (void)enter:(id)data cb:(ARTStatusCallback)cb;
 - (void)update:(id)data cb:(ARTStatusCallback)cb;
@@ -125,8 +125,8 @@ typedef void (^ARTRealtimeChannelPresenceCb)(ARTPresenceMessage *);
 
 typedef void (^ARTRealtimePingCb)(ARTStatus *);
 - (void)ping:(ARTRealtimePingCb) cb;
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
+- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
 
 - (ARTRealtimeChannel *)channel:(NSString *)channelName;
 - (ARTRealtimeChannel *)channel:(NSString *)channelName cipherParams:(ARTCipherParams *)cipherParams;

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -471,17 +471,17 @@
         [NSException raise:@"realtime cannot perform action in disconnected or failed state" format:@"state: %d", (int)self.realtime.state];
     }
 }
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback {
     [self throwOnDisconnectedOrFailed];
-    return [self.restChannel history:cb];
+    return [self.restChannel history:callback];
 }
 
-- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
     [self throwOnDisconnectedOrFailed];
     if([queryParams objectForKey:@"until_attach"] != nil  && self.state != ARTRealtimeChannelAttached) {
         [NSException raise:@"Cannot ask for history with param untilAttach when not attached" format:@""];
     }
-    return [self.restChannel historyWithParams:queryParams cb:cb];
+    return [self.restChannel historyWithParams:queryParams cb:callback];
 }
 
 
@@ -903,12 +903,12 @@
     [self.transport sendPing];
 }
 
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCb)cb {
-    return [self.rest stats:cb];
+- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback {
+    return [self.rest stats:callback];
 }
 
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
-    return [self.rest statsWithParams:queryParams cb:cb];
+- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
+    return [self.rest statsWithParams:queryParams cb:callback];
 }
 
 - (ARTRealtimeChannel *)channel:(NSString *)channelName {
@@ -1591,23 +1591,23 @@
     }
     return self;
 }
--(id<ARTCancellable>) getWithParams:(NSDictionary *) queryParams cb:(ARTPaginatedResultCb) cb {
+-(id<ARTCancellable>) getWithParams:(NSDictionary *) queryParams cb:(ARTPaginatedResultCallback)callback {
     [self.channel throwOnDisconnectedOrFailed];
-    return [self.channel.restChannel.presence getWithParams:queryParams cb:cb];
+    return [self.channel.restChannel.presence getWithParams:queryParams cb:callback];
 }
 
--(id<ARTCancellable>) get:(ARTPaginatedResultCb) cb {
+-(id<ARTCancellable>) get:(ARTPaginatedResultCallback)callback {
     [self.channel throwOnDisconnectedOrFailed];
-    return [self.channel.restChannel.presence get:cb];
+    return [self.channel.restChannel.presence get:callback];
 }
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback {
     [self.channel throwOnDisconnectedOrFailed];
-    return [self.channel.restChannel.presence history:cb];
+    return [self.channel.restChannel.presence history:callback];
 }
 
-- (id<ARTCancellable>) historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>) historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
     [self.channel throwOnDisconnectedOrFailed];
-    return [self.channel.restChannel.presence historyWithParams:queryParams cb:cb];
+    return [self.channel.restChannel.presence historyWithParams:queryParams cb:callback];
 }
 
 

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -903,12 +903,8 @@
     [self.transport sendPing];
 }
 
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback {
-    return [self.rest stats:callback];
-}
-
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
-    return [self.rest statsWithParams:queryParams cb:callback];
+- (id<ARTCancellable>)stats:(ARTStatsQuery *)query callback:(ARTPaginatedResultCallback)callback {
+    return [self.rest stats:query callback:callback];
 }
 
 - (ARTRealtimeChannel *)channel:(NSString *)channelName {

--- a/ably-ios/ARTRest.h
+++ b/ably-ios/ARTRest.h
@@ -11,7 +11,7 @@
 #import <ably/ARTTypes.h>
 #import <ably/ARTClientOptions.h>
 #import <ably/ARTPaginatedResult.h>
-
+#import <ably/ARTStats.h>
 
 @class ARTLog;
 @class ARTCipherParams;
@@ -50,8 +50,7 @@
 - (id<ARTCancellable>) token:(ARTAuthTokenParams *) keyName tokenCb:(void (^)(ARTStatus * status, ARTTokenDetails *)) cb;
 
 - (id<ARTCancellable>)time:(void(^)(ARTStatus * status, NSDate *time))cb;
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback;
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)stats:(ARTStatsQuery *)query callback:(ARTPaginatedResultCallback)callback;
 - (id<ARTCancellable>)internetIsUp:(void (^)(bool isUp)) cb;
 - (ARTRestChannel *)channel:(NSString *)channelName;
 - (ARTRestChannel *)channel:(NSString *)channelName cipherParams:(ARTCipherParams *)cipherParams;

--- a/ably-ios/ARTRest.h
+++ b/ably-ios/ARTRest.h
@@ -24,18 +24,18 @@
 - (id<ARTCancellable>)publish:(id)payload withName:(NSString *)name cb:(ARTStatusCallback)cb;
 - (id<ARTCancellable>)publish:(id)payload cb:(ARTStatusCallback)cb;
 
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
 
 @property (readonly, strong, nonatomic) ARTRestPresence *presence;
 @end
 
 @interface ARTRestPresence : NSObject
 - (instancetype) initWithChannel:(ARTRestChannel *) channel;
-- (id<ARTCancellable>)get:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)getWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
+- (id<ARTCancellable>)get:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)getWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
 @end
 
 @interface ARTRest : NSObject
@@ -50,8 +50,8 @@
 - (id<ARTCancellable>) token:(ARTAuthTokenParams *) keyName tokenCb:(void (^)(ARTStatus * status, ARTTokenDetails *)) cb;
 
 - (id<ARTCancellable>)time:(void(^)(ARTStatus * status, NSDate *time))cb;
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCb)cb;
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb;
+- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback;
+- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback;
 - (id<ARTCancellable>)internetIsUp:(void (^)(bool isUp)) cb;
 - (ARTRestChannel *)channel:(NSString *)channelName;
 - (ARTRestChannel *)channel:(NSString *)channelName cipherParams:(ARTCipherParams *)cipherParams;

--- a/ably-ios/ARTRest.m
+++ b/ably-ios/ARTRest.m
@@ -134,11 +134,11 @@
     }
 }
 
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb {
-    return [self historyWithParams:nil cb:cb];
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback {
+    return [self historyWithParams:nil cb:callback];
 }
 
-- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>)historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
     [self.rest throwOnHighLimitCheck:queryParams];
     return [self.rest withAuthHeaders:^(NSDictionary *authHeaders) {
         NSString *relUrl = [NSString stringWithFormat:@"%@/messages", self.basePath];
@@ -149,7 +149,7 @@
             return [messages artMap:^id(ARTMessage *message) {
                 return [message decode:self.payloadEncoder];
             }];
-        } cb:cb];
+        } callback:callback];
     }];
 }
 
@@ -260,8 +260,8 @@
      
 }
 
-- (id<ARTCancellable>)stats:(ARTPaginatedResultCb)cb {
-    return [self statsWithParams:nil cb:cb];
+- (id<ARTCancellable>)stats:(ARTPaginatedResultCallback)callback {
+    return [self statsWithParams:nil cb:callback];
 }
 
 -(void) throwOnHighLimitCheck:(NSDictionary *) params {
@@ -275,14 +275,14 @@
     }
 }
 
-- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>)statsWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
     [self throwOnHighLimitCheck:queryParams];
     return [self withAuthHeaders:^(NSDictionary *authHeaders) {
         ARTHttpRequest *req = [[ARTHttpRequest alloc] initWithMethod:@"GET" url:[self resolveUrl:@"/stats" queryParams:queryParams] headers:authHeaders body:nil];
         return [ARTHttpPaginatedResult makePaginatedRequest:self.http request:req responseProcessor:^(ARTHttpResponse *response) {
             id<ARTEncoder> encoder = [self.encoders objectForKey:response.contentType];
             return [encoder decodeStats:response.body];
-        } cb:cb];
+        } callback:callback];
     }];
 }
 
@@ -495,11 +495,11 @@
     return self;
 }
 
-- (id<ARTCancellable>)get:(ARTPaginatedResultCb)cb {
-    return [self getWithParams:nil cb:cb];
+- (id<ARTCancellable>)get:(ARTPaginatedResultCallback)callback {
+    return [self getWithParams:nil cb:callback];
 }
 
-- (id<ARTCancellable>)getWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>)getWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
     [self.channel.rest throwOnHighLimitCheck:queryParams];
     return [self.channel.rest withAuthHeaders:^(NSDictionary *authHeaders) {
         NSString *relUrl = [NSString stringWithFormat:@"%@/presence", self.channel.basePath];
@@ -510,15 +510,15 @@
             return [messages artMap:^id(ARTPresenceMessage *pm) {
                 return [pm decode:self.channel.payloadEncoder];
             }];
-        } cb:cb];
+        } callback:callback];
     }];
 }
 
-- (id<ARTCancellable>)history:(ARTPaginatedResultCb)cb {
-    return [self historyWithParams:nil cb:cb];
+- (id<ARTCancellable>)history:(ARTPaginatedResultCallback)callback {
+    return [self historyWithParams:nil cb:callback];
 }
 
-- (id<ARTCancellable>) historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCb)cb {
+- (id<ARTCancellable>) historyWithParams:(NSDictionary *)queryParams cb:(ARTPaginatedResultCallback)callback {
     [self.channel.rest throwOnHighLimitCheck:queryParams];
     return [self.channel.rest withAuthHeaders:^(NSDictionary *authHeaders) {
         NSString *relUrl = [NSString stringWithFormat:@"%@/presence/history", self.channel.basePath];
@@ -529,7 +529,7 @@
             return [messages artMap:^id(ARTPresenceMessage *pm) {
                 return [pm decode:self.channel.payloadEncoder];
             }];
-        } cb:cb];
+        } callback:callback];
     }];
 }
 

--- a/ably-ios/ARTStats.h
+++ b/ably-ios/ARTStats.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSUInteger, ARTStatsUnit) {
 @property (nonatomic, strong) NSDate *start;
 @property (nonatomic, strong) NSDate *end;
 
-@property (nonatomic, assign) NSUInteger limit;
+@property (nonatomic, assign) uint64_t limit;
 
 @property (nonatomic, assign) ARTQueryDirection direction;
 

--- a/ably-ios/ARTStats.h
+++ b/ably-ios/ARTStats.h
@@ -8,6 +8,33 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSUInteger, ARTQueryDirection) {
+    ARTQueryDirectionForwards,
+    ARTQueryDirectionBackwards
+};
+
+typedef NS_ENUM(NSUInteger, ARTStatsUnit) {
+    ARTStatsUnitMinute,
+    ARTStatsUnitHour,
+    ARTStatsUnitDay,
+    ARTStatsUnitMonth
+};
+
+@interface ARTStatsQuery : NSObject
+
+@property (nonatomic, strong) NSDate *start;
+@property (nonatomic, strong) NSDate *end;
+
+@property (nonatomic, assign) NSUInteger limit;
+
+@property (nonatomic, assign) ARTQueryDirection direction;
+
+@property (nonatomic, assign) ARTStatsUnit unit;
+
+- (NSArray *)asQueryItems;
+
+@end
+
 @interface ARTStatsMessageCount : NSObject
 
 @property (readonly, assign, nonatomic) double count;

--- a/ably-ios/ARTStats.m
+++ b/ably-ios/ARTStats.m
@@ -48,13 +48,13 @@ static NSString *queryDirectionToString(ARTQueryDirection direction) {
     NSMutableArray *items = [NSMutableArray array];
 
     if (self.start) {
-        [items addObject:[NSURLQueryItem queryItemWithName:@"start" value:[NSString stringWithFormat:@"%ld", (NSUInteger)(self.start.timeIntervalSince1970 * 1000)]]];
+        [items addObject:[NSURLQueryItem queryItemWithName:@"start" value:[NSString stringWithFormat:@"%llu", (uint64_t)(self.start.timeIntervalSince1970 * 1000)]]];
     }
     if (self.end) {
-        [items addObject:[NSURLQueryItem queryItemWithName:@"end" value:[NSString stringWithFormat:@"%ld", (NSUInteger)(self.end.timeIntervalSince1970 * 1000)]]];
+        [items addObject:[NSURLQueryItem queryItemWithName:@"end" value:[NSString stringWithFormat:@"%llu", (uint64_t)(self.end.timeIntervalSince1970 * 1000)]]];
     }
 
-    [items addObject:[NSURLQueryItem queryItemWithName:@"limit" value:[NSString stringWithFormat:@"%ld", self.limit]]];
+    [items addObject:[NSURLQueryItem queryItemWithName:@"limit" value:[NSString stringWithFormat:@"%llu", self.limit]]];
     [items addObject:[NSURLQueryItem queryItemWithName:@"direction" value:queryDirectionToString(self.direction)]];
     [items addObject:[NSURLQueryItem queryItemWithName:@"unit" value:statsUnitToString(self.unit)]];
 

--- a/ably-ios/ARTStats.m
+++ b/ably-ios/ARTStats.m
@@ -8,6 +8,61 @@
 
 #import "ARTStats.h"
 
+@implementation ARTStatsQuery
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _limit = 100;
+        _direction = ARTQueryDirectionBackwards;
+        _unit = ARTStatsUnitMinute;
+    }
+
+    return self;
+}
+
+static NSString *statsUnitToString(ARTStatsUnit unit) {
+    switch (unit) {
+        case ARTStatsUnitMonth:
+            return @"month";
+        case ARTStatsUnitDay:
+            return @"day";
+        case ARTStatsUnitHour:
+            return @"hour";
+        case ARTStatsUnitMinute:
+        default:
+            return @"minute";
+    }
+}
+
+static NSString *queryDirectionToString(ARTQueryDirection direction) {
+    switch (direction) {
+        case ARTQueryDirectionForwards:
+            return @"forwards";
+        case ARTQueryDirectionBackwards:
+        default:
+            return @"backwards";
+    }
+}
+
+- (NSArray *)asQueryItems {
+    NSMutableArray *items = [NSMutableArray array];
+
+    if (self.start) {
+        [items addObject:[NSURLQueryItem queryItemWithName:@"start" value:[NSString stringWithFormat:@"%ld", (NSUInteger)(self.start.timeIntervalSince1970 * 1000)]]];
+    }
+    if (self.end) {
+        [items addObject:[NSURLQueryItem queryItemWithName:@"end" value:[NSString stringWithFormat:@"%ld", (NSUInteger)(self.end.timeIntervalSince1970 * 1000)]]];
+    }
+
+    [items addObject:[NSURLQueryItem queryItemWithName:@"limit" value:[NSString stringWithFormat:@"%ld", self.limit]]];
+    [items addObject:[NSURLQueryItem queryItemWithName:@"direction" value:queryDirectionToString(self.direction)]];
+    [items addObject:[NSURLQueryItem queryItemWithName:@"unit" value:statsUnitToString(self.unit)]];
+
+    return [items copy];
+}
+
+@end
+
 @implementation ARTStatsMessageCount
 
 - (instancetype)initWithCount:(double)count data:(double)data {

--- a/ably-ios/ably.h
+++ b/ably-ios/ably.h
@@ -27,3 +27,4 @@ FOUNDATION_EXPORT const unsigned char ablyVersionString[];
 #import <ably/ARTHttpPaginatedResult.h>
 #import <ably/ARTPayload.h>
 #import <Ably/ARTLog.h>
+#import <Ably/ARTStats.h>

--- a/ably.xcodeproj/project.pbxproj
+++ b/ably.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		1CD8DCA01B1C7315007EAF36 /* ARTDefault.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CD8DC9E1B1C7315007EAF36 /* ARTDefault.m */; };
 		1CEFC60E1B0F9EF500D84463 /* ARTTokenDetails+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CEFC60D1B0F9EF500D84463 /* ARTTokenDetails+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2EBDBEEBF881A49F795F1D2E /* Pods_ablySpec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52CD0A2BB89BAA3D8353FBF3 /* Pods_ablySpec.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		850BFB4C1B79323C009D0ADD /* ARTPaginatedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		850BFB4D1B79323C009D0ADD /* ARTPaginatedResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 850BFB4B1B79323C009D0ADD /* ARTPaginatedResult.m */; };
 		856AAC8F1B6E304B00B07119 /* ably.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96BF61311A35B2AB004CF2B3 /* ably.framework */; };
 		856AAC971B6E30C800B07119 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856AAC961B6E30C800B07119 /* TestUtilities.swift */; };
 		856AAC991B6E312F00B07119 /* RestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856AAC981B6E312F00B07119 /* RestClient.swift */; };
@@ -68,7 +70,6 @@
 		967A43221A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.m in Sources */ = {isa = PBXBuildFile; fileRef = 967A43201A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.m */; };
 		96A507951A370F860077CDF8 /* ARTStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A507931A370F860077CDF8 /* ARTStats.h */; };
 		96A507961A370F860077CDF8 /* ARTStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A507941A370F860077CDF8 /* ARTStats.m */; };
-		96A507991A371E910077CDF8 /* ARTPaginatedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A507971A371E910077CDF8 /* ARTPaginatedResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96A5079D1A371F800077CDF8 /* ARTHttpPaginatedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A5079B1A371F800077CDF8 /* ARTHttpPaginatedResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96A5079E1A371F800077CDF8 /* ARTHttpPaginatedResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A5079C1A371F800077CDF8 /* ARTHttpPaginatedResult.m */; };
 		96A507A11A377AA50077CDF8 /* ARTPresenceMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A5079F1A377AA50077CDF8 /* ARTPresenceMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -190,6 +191,8 @@
 		1CD8DC9E1B1C7315007EAF36 /* ARTDefault.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDefault.m; sourceTree = "<group>"; };
 		1CEFC60D1B0F9EF500D84463 /* ARTTokenDetails+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTTokenDetails+Private.h"; sourceTree = "<group>"; };
 		52CD0A2BB89BAA3D8353FBF3 /* Pods_ablySpec.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ablySpec.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTPaginatedResult.h; sourceTree = "<group>"; };
+		850BFB4B1B79323C009D0ADD /* ARTPaginatedResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTPaginatedResult.m; sourceTree = "<group>"; };
 		856AAC8A1B6E304B00B07119 /* ablySpec.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ablySpec.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		856AAC8E1B6E304B00B07119 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		856AAC951B6E30C800B07119 /* ablySpec-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ablySpec-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -210,7 +213,6 @@
 		967A43201A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ARTNSArray+ARTFunctional.m"; sourceTree = "<group>"; };
 		96A507931A370F860077CDF8 /* ARTStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTStats.h; sourceTree = "<group>"; };
 		96A507941A370F860077CDF8 /* ARTStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTStats.m; sourceTree = "<group>"; };
-		96A507971A371E910077CDF8 /* ARTPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTPaginatedResult.h; sourceTree = "<group>"; };
 		96A5079B1A371F800077CDF8 /* ARTHttpPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTHttpPaginatedResult.h; sourceTree = "<group>"; };
 		96A5079C1A371F800077CDF8 /* ARTHttpPaginatedResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTHttpPaginatedResult.m; sourceTree = "<group>"; };
 		96A5079F1A377AA50077CDF8 /* ARTPresenceMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTPresenceMessage.h; sourceTree = "<group>"; };
@@ -371,7 +373,8 @@
 				96BF616F1A35FB7C004CF2B3 /* ARTAuth.m */,
 				96A507931A370F860077CDF8 /* ARTStats.h */,
 				96A507941A370F860077CDF8 /* ARTStats.m */,
-				96A507971A371E910077CDF8 /* ARTPaginatedResult.h */,
+				850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */,
+				850BFB4B1B79323C009D0ADD /* ARTPaginatedResult.m */,
 				96A5079B1A371F800077CDF8 /* ARTHttpPaginatedResult.h */,
 				96A5079C1A371F800077CDF8 /* ARTHttpPaginatedResult.m */,
 				96A5079F1A377AA50077CDF8 /* ARTPresenceMessage.h */,
@@ -483,12 +486,12 @@
 				96BF615E1A35C1C8004CF2B3 /* ARTTypes.h in Headers */,
 				1C1EC3FA1AE26A8B00AAADD7 /* ARTStatus.h in Headers */,
 				96E408431A38939E00087F77 /* ARTProtocolMessage.h in Headers */,
-				96A507991A371E910077CDF8 /* ARTPaginatedResult.h in Headers */,
 				96BF61581A35B52C004CF2B3 /* ARTHttp.h in Headers */,
 				96BF61641A35CDE1004CF2B3 /* ARTMessage.h in Headers */,
 				96BF61701A35FB7C004CF2B3 /* ARTAuth.h in Headers */,
 				96A507A11A377AA50077CDF8 /* ARTPresenceMessage.h in Headers */,
 				1C2B0FFD1B136A6D00E3633C /* ARTPresenceMap.h in Headers */,
+				850BFB4C1B79323C009D0ADD /* ARTPaginatedResult.h in Headers */,
 				1CD8DC9F1B1C7315007EAF36 /* ARTDefault.h in Headers */,
 				96A5079D1A371F800077CDF8 /* ARTHttpPaginatedResult.h in Headers */,
 				1C8065051AE7C8FA00D49357 /* ARTPayload+Private.h in Headers */,
@@ -748,6 +751,7 @@
 				96BF61591A35B52C004CF2B3 /* ARTHttp.m in Sources */,
 				1C578E201B3435CA00EF46EC /* ARTFallback.m in Sources */,
 				96A507B61A37881C0077CDF8 /* ARTNSDate+ARTUtil.m in Sources */,
+				850BFB4D1B79323C009D0ADD /* ARTPaginatedResult.m in Sources */,
 				961343D91A42E0B7006DC822 /* ARTClientOptions.m in Sources */,
 				96BF615F1A35C1C8004CF2B3 /* ARTTypes.m in Sources */,
 				96A507AE1A3780F60077CDF8 /* ARTJsonEncoder.m in Sources */,

--- a/ably.xcodeproj/project.pbxproj
+++ b/ably.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		2EBDBEEBF881A49F795F1D2E /* Pods_ablySpec.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52CD0A2BB89BAA3D8353FBF3 /* Pods_ablySpec.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		850BFB4C1B79323C009D0ADD /* ARTPaginatedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		850BFB4D1B79323C009D0ADD /* ARTPaginatedResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 850BFB4B1B79323C009D0ADD /* ARTPaginatedResult.m */; };
+		853ED7C41B7A1A3C006F1C6F /* RestClient.stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853ED7C31B7A1A3C006F1C6F /* RestClient.stats.swift */; };
 		856AAC8F1B6E304B00B07119 /* ably.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96BF61311A35B2AB004CF2B3 /* ably.framework */; };
 		856AAC971B6E30C800B07119 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856AAC961B6E30C800B07119 /* TestUtilities.swift */; };
 		856AAC991B6E312F00B07119 /* RestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856AAC981B6E312F00B07119 /* RestClient.swift */; };
@@ -68,7 +69,7 @@
 		961343E91A432E7C006DC822 /* ARTPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 961343E71A432E7C006DC822 /* ARTPayload.m */; };
 		967A43211A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.h in Headers */ = {isa = PBXBuildFile; fileRef = 967A431F1A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.h */; };
 		967A43221A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.m in Sources */ = {isa = PBXBuildFile; fileRef = 967A43201A39AEAF00E4CE23 /* ARTNSArray+ARTFunctional.m */; };
-		96A507951A370F860077CDF8 /* ARTStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A507931A370F860077CDF8 /* ARTStats.h */; };
+		96A507951A370F860077CDF8 /* ARTStats.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A507931A370F860077CDF8 /* ARTStats.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96A507961A370F860077CDF8 /* ARTStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A507941A370F860077CDF8 /* ARTStats.m */; };
 		96A5079D1A371F800077CDF8 /* ARTHttpPaginatedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 96A5079B1A371F800077CDF8 /* ARTHttpPaginatedResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96A5079E1A371F800077CDF8 /* ARTHttpPaginatedResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 96A5079C1A371F800077CDF8 /* ARTHttpPaginatedResult.m */; };
@@ -193,6 +194,7 @@
 		52CD0A2BB89BAA3D8353FBF3 /* Pods_ablySpec.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ablySpec.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		850BFB4A1B79323C009D0ADD /* ARTPaginatedResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTPaginatedResult.h; sourceTree = "<group>"; };
 		850BFB4B1B79323C009D0ADD /* ARTPaginatedResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTPaginatedResult.m; sourceTree = "<group>"; };
+		853ED7C31B7A1A3C006F1C6F /* RestClient.stats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestClient.stats.swift; sourceTree = "<group>"; };
 		856AAC8A1B6E304B00B07119 /* ablySpec.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ablySpec.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		856AAC8E1B6E304B00B07119 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		856AAC951B6E30C800B07119 /* ablySpec-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ablySpec-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -327,6 +329,7 @@
 				856AAC961B6E30C800B07119 /* TestUtilities.swift */,
 				856AAC951B6E30C800B07119 /* ablySpec-Bridging-Header.h */,
 				856AAC981B6E312F00B07119 /* RestClient.swift */,
+				853ED7C31B7A1A3C006F1C6F /* RestClient.stats.swift */,
 			);
 			path = ablySpec;
 			sourceTree = "<group>";
@@ -735,6 +738,7 @@
 			files = (
 				856AAC991B6E312F00B07119 /* RestClient.swift in Sources */,
 				856AAC971B6E30C800B07119 /* TestUtilities.swift in Sources */,
+				853ED7C41B7A1A3C006F1C6F /* RestClient.stats.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -827,7 +831,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = ablySpec/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.ably.ablySpec;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -845,7 +849,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = ablySpec/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.ably.ablySpec;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ablySpec/RestClient.stats.swift
+++ b/ablySpec/RestClient.stats.swift
@@ -241,18 +241,21 @@ class RestClientStats: QuickSpec {
                         expect(firstPage.items.count).to(equal(1))
                         expect((firstPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(7000))
                         expect(firstPage.hasNext).to(beTrue())
+                        expect(firstPage.isLast).to(beFalse())
 
-                        let secondPage = getPage(firstPage.getNext)
+                        let secondPage = getPage(firstPage.next)
                         expect(secondPage.items.count).to(equal(1))
                         expect((secondPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(6000))
                         expect(secondPage.hasNext).to(beTrue())
+                        expect(secondPage.isLast).to(beFalse())
 
-                        let thirdPage = getPage(secondPage.getNext)
+                        let thirdPage = getPage(secondPage.next)
                         expect(thirdPage.items.count).to(equal(1))
                         expect((thirdPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(5000))
                         expect(thirdPage.hasFirst).to(beTrue())
+                        expect(thirdPage.isLast).to(beTrue())
 
-                        let firstPageAgain = getPage(thirdPage.getFirst)
+                        let firstPageAgain = getPage(thirdPage.first)
                         expect(firstPageAgain.items.count).to(equal(1))
                         expect((firstPageAgain.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(7000))
                     }
@@ -269,18 +272,21 @@ class RestClientStats: QuickSpec {
                         expect(firstPage.items.count).to(equal(1))
                         expect((firstPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(5000))
                         expect(firstPage.hasNext).to(beTrue())
+                        expect(firstPage.isLast).to(beFalse())
 
-                        let secondPage = getPage(firstPage.getNext)
+                        let secondPage = getPage(firstPage.next)
                         expect(secondPage.items.count).to(equal(1))
                         expect((secondPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(6000))
                         expect(secondPage.hasNext).to(beTrue())
+                        expect(secondPage.isLast).to(beFalse())
 
-                        let thirdPage = getPage(secondPage.getNext)
+                        let thirdPage = getPage(secondPage.next)
                         expect(thirdPage.items.count).to(equal(1))
                         expect((thirdPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(7000))
                         expect(thirdPage.hasFirst).to(beTrue())
+                        expect(thirdPage.isLast).to(beTrue())
 
-                        let firstPageAgain = getPage(thirdPage.getFirst)
+                        let firstPageAgain = getPage(thirdPage.first)
                         expect(firstPageAgain.items.count).to(equal(1))
                         expect((firstPageAgain.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(5000))
                     }

--- a/ablySpec/RestClient.stats.swift
+++ b/ablySpec/RestClient.stats.swift
@@ -1,0 +1,343 @@
+//
+//  RestClient.stats.swift
+//  ably
+//
+//  Created by Yavor Georgiev on 11.08.15.
+//  Copyright (c) 2015 г. Ably. All rights reserved.
+//
+
+import Nimble
+import Quick
+import ably
+import SwiftyJSON
+import Foundation
+
+private func postTestStats(stats: JSON) -> ARTClientOptions {
+    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions);
+    let key = ("\(options.authOptions.keyName):\(options.authOptions.keySecret)" as NSString)
+        .dataUsingEncoding(NSUTF8StringEncoding)!
+        .base64EncodedStringWithOptions(NSDataBase64EncodingOptions(0))
+
+    let request = NSMutableURLRequest(URL: NSURL(string: "https://\(restHost)/stats")!)
+    request.HTTPMethod = "POST"
+    request.HTTPBody = stats.rawData()
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("Basic \(key)", forHTTPHeaderField: "Authorization")
+
+    var responseError: NSError?
+    var httpResponse: NSHTTPURLResponse?
+    var requestCompleted = false
+
+    NSURLSession.sharedSession()
+        .dataTaskWithRequest(request) { _, response, error in
+            responseError = error
+            httpResponse = response as? NSHTTPURLResponse
+            requestCompleted = true
+        }.resume()
+
+    while !requestCompleted {
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, CFTimeInterval(0.1), Boolean(0))
+    }
+
+    if let error = responseError {
+        XCTFail(error.localizedDescription)
+    } else if let response = httpResponse {
+        if response.statusCode != 201 {
+            XCTFail("Posting stats fixtures failed")
+        }
+    }
+
+    return options
+}
+
+private func queryStats(client: ARTRest, query: ARTStatsQuery) -> ARTPaginatedResult {
+    var stats: ARTPaginatedResult?
+    var status: ARTStatus?
+    client.stats(query, callback: { (statsStatus, result) in
+        stats = result
+        status = statsStatus
+    })
+
+    while status == nil {
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, CFTimeInterval(0.1), Boolean(0))
+    }
+
+    if status!.status != .StatusOk {
+        XCTFail(status!.errorInfo.message)
+    }
+
+    return stats!
+}
+
+private func getPage(paginator: (ARTPaginatedResultCallback!) -> Void) -> ARTPaginatedResult {
+    var newResult: ARTPaginatedResult?
+    var status: ARTStatus?
+    paginator({ (paginatorStatus, paginatorResult) in
+        newResult = paginatorResult
+        status = paginatorStatus
+    })
+
+    while status == nil {
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, CFTimeInterval(0.1), Boolean(0))
+    }
+
+    if status!.status != .StatusOk {
+        XCTFail(status!.errorInfo.message)
+    }
+
+    return newResult!
+}
+
+class RestClientStats: QuickSpec {
+    override func spec() {
+        describe("RestClient") {
+            // RSC6
+            context("stats") {
+                // RSC6a
+                context("result") {
+                    let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)!
+                    let dateComponents = NSDateComponents()
+                    dateComponents.year = calendar.component(.CalendarUnitYear, fromDate: NSDate()) - 1
+                    dateComponents.month = 2
+                    dateComponents.day = 3
+                    dateComponents.hour = 16
+                    dateComponents.minute = 3
+                    let date = calendar.dateFromComponents(dateComponents)!
+                    let dateFormatter = NSDateFormatter()
+                    dateFormatter.timeZone = NSTimeZone(name: "UTC")
+                    dateFormatter.dateFormat = "YYYY-MM-dd:HH:mm"
+
+                    let statsFixtures: JSON = [
+                        [
+                            "intervalId": dateFormatter.stringFromDate(date), // 20XX-02-03:16:03
+                            "inbound": [ "realtime": [ "messages": [ "count": 50, "data": 5000 ] ] ],
+                            "outbound": [ "realtime": [ "messages": [ "count": 20, "data": 2000 ] ] ]
+                        ],
+                        [
+                            "intervalId": dateFormatter.stringFromDate(date.dateByAddingTimeInterval(60)), // 20XX-02-03:16:04
+                            "inbound": [ "realtime": [ "messages": [ "count": 60, "data": 6000 ] ] ],
+                            "outbound": [ "realtime": [ "messages": [ "count": 10, "data": 1000 ] ] ]
+                        ],
+                        [
+                            "intervalId": dateFormatter.stringFromDate(date.dateByAddingTimeInterval(120)), // 20XX-02-03:16:05
+                            "inbound": [ "realtime": [ "messages": [ "count": 70, "data": 7000 ] ] ],
+                            "outbound": [ "realtime": [ "messages": [ "count": 40, "data": 4000 ] ] ],
+                            "persisted": [ "presence": [ "count": 20, "data": 2000 ] ],
+                            "connections": [ "tls": [ "peak": 20,  "opened": 10 ] ],
+                            "channels": [ "peak": 50, "opened": 30 ],
+                            "apiRequests": [ "succeeded": 50, "failed": 10 ],
+                            "tokenRequests": [ "succeeded": 60, "failed": 20 ]
+                        ]
+                    ]
+
+                    var statsOptions = ARTClientOptions()
+                    beforeEach {
+                        statsOptions = postTestStats(statsFixtures)
+                    }
+
+                    it("should match minute-level inbound and outbound fixture data (forwards)") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.start = date
+                        query.direction = .Forwards
+
+                        let result = queryStats(client, query)
+                        expect(result.items.count).to(equal(3))
+
+                        let totalInbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.inbound.all.messages.count })
+                        expect(totalInbound).to(equal(50 + 60 + 70))
+
+                        let totalOutbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.outbound.all.messages.count })
+                        expect(totalOutbound).to(equal(20 + 10 + 40))
+                    }
+
+                    it("should match hour-level inbound and outbound fixture data (forwards)") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.start = date
+                        query.direction = .Forwards
+                        query.unit = .Hour
+
+                        let result = queryStats(client, query)
+                        let totalInbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.inbound.all.messages.count })
+                        let totalOutbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.outbound.all.messages.count })
+
+                        expect(result.items.count).to(equal(1))
+                        expect(totalInbound).to(equal(50 + 60 + 70))
+                        expect(totalOutbound).to(equal(20 + 10 + 40))
+                    }
+
+                    it("should match day-level inbound and outbound fixture data (forwards)") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.end = calendar.dateByAddingUnit(.CalendarUnitDay, value: 1, toDate: date, options: NSCalendarOptions(0))
+                        query.direction = .Forwards
+                        query.unit = .Month
+
+                        let result = queryStats(client, query)
+                        let totalInbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.inbound.all.messages.count })
+                        let totalOutbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.outbound.all.messages.count })
+
+                        expect(result.items.count).to(equal(1))
+                        expect(totalInbound).to(equal(50 + 60 + 70))
+                        expect(totalOutbound).to(equal(20 + 10 + 40))
+                    }
+
+                    it("should match month-level inbound and outbound fixture data (forwards)") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.end = calendar.dateByAddingUnit(.CalendarUnitMonth, value: 1, toDate: date, options: NSCalendarOptions(0))
+                        query.direction = .Forwards
+                        query.unit = .Month
+
+                        let result = queryStats(client, query)
+                        let totalInbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.inbound.all.messages.count })
+                        let totalOutbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.outbound.all.messages.count })
+
+                        expect(result.items.count).to(equal(1))
+                        expect(totalInbound).to(equal(50 + 60 + 70))
+                        expect(totalOutbound).to(equal(20 + 10 + 40))
+                    }
+
+                    it("should contain only one item when limit is 1 (backwards") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.end = date.dateByAddingTimeInterval(60) // 20XX-02-03:16:04
+                        query.limit = 1
+
+                        let result = queryStats(client, query)
+                        let totalInbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.inbound.all.messages.count })
+                        let totalOutbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.outbound.all.messages.count })
+
+                        expect(result.items.count).to(equal(1))
+                        expect(totalInbound).to(equal(60))
+                        expect(totalOutbound).to(equal(10))
+                    }
+
+                    it("should contain only one item when limit is 1 (forwards") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.end = date.dateByAddingTimeInterval(60) // 20XX-02-03:16:04
+                        query.limit = 1
+                        query.direction = .Forwards
+
+                        let result = queryStats(client, query)
+                        let totalInbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.inbound.all.messages.count })
+                        let totalOutbound = (result.items as! [ARTStats]).reduce(0, combine: { $0 + $1.outbound.all.messages.count })
+
+                        expect(result.items.count).to(equal(1))
+                        expect(totalInbound).to(equal(50))
+                        expect(totalOutbound).to(equal(20))
+                    }
+
+                    it("should be paginated according to the limit (backwards") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.end = date.dateByAddingTimeInterval(120) // 20XX-02-03:16:05
+                        query.limit = 1
+
+
+                        let firstPage = queryStats(client, query)
+                        expect(firstPage.items.count).to(equal(1))
+                        expect((firstPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(7000))
+                        expect(firstPage.hasNext).to(beTrue())
+
+                        let secondPage = getPage(firstPage.getNext)
+                        expect(secondPage.items.count).to(equal(1))
+                        expect((secondPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(6000))
+                        expect(secondPage.hasNext).to(beTrue())
+
+                        let thirdPage = getPage(secondPage.getNext)
+                        expect(thirdPage.items.count).to(equal(1))
+                        expect((thirdPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(5000))
+                        expect(thirdPage.hasFirst).to(beTrue())
+
+                        let firstPageAgain = getPage(thirdPage.getFirst)
+                        expect(firstPageAgain.items.count).to(equal(1))
+                        expect((firstPageAgain.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(7000))
+                    }
+
+                    it("should be paginated according to the limit (fowards)") {
+                        let client = ARTRest(options: statsOptions)
+                        let query = ARTStatsQuery()
+                        query.end = date.dateByAddingTimeInterval(120) // 20XX-02-03:16:05
+                        query.limit = 1
+                        query.direction = .Forwards
+
+
+                        let firstPage = queryStats(client, query)
+                        expect(firstPage.items.count).to(equal(1))
+                        expect((firstPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(5000))
+                        expect(firstPage.hasNext).to(beTrue())
+
+                        let secondPage = getPage(firstPage.getNext)
+                        expect(secondPage.items.count).to(equal(1))
+                        expect((secondPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(6000))
+                        expect(secondPage.hasNext).to(beTrue())
+
+                        let thirdPage = getPage(secondPage.getNext)
+                        expect(thirdPage.items.count).to(equal(1))
+                        expect((thirdPage.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(7000))
+                        expect(thirdPage.hasFirst).to(beTrue())
+
+                        let firstPageAgain = getPage(thirdPage.getFirst)
+                        expect(firstPageAgain.items.count).to(equal(1))
+                        expect((firstPageAgain.items as! [ARTStats])[0].inbound.all.messages.data).to(equal(5000))
+                    }
+                }
+
+                // RSC6b
+                context("query") {
+                    // RSC6b1
+                    context("start") {
+                        it("should throw when later than end") {
+                            let client = ARTRest(key: "fake:key")
+                            let query = ARTStatsQuery()
+
+                            query.start = NSDate.distantFuture() as! NSDate
+                            query.end = NSDate.distantPast() as! NSDate
+
+                            expect{ client.stats(query, callback: nil) }.to(raiseException())
+                        }
+                    }
+
+                    // RSC6b2
+                    context("direction") {
+                        it("should be backwards by default") {
+                            let query = ARTStatsQuery()
+
+                            expect(query.direction).to(equal(ARTQueryDirection.Backwards));
+                        }
+                    }
+
+                    // RSC6b3
+                    context("limit") {
+                        it("should have a default value of 100") {
+                            let query = ARTStatsQuery()
+
+                            expect(query.limit).to(equal(100));
+                        }
+
+                        it("should throw when greater than 1000") {
+                            let client = ARTRest(key: "fake:key")
+                            let query = ARTStatsQuery()
+
+                            query.limit = 1001;
+
+                            expect{ client.stats(query, callback: nil) }.to(raiseException())
+                        }
+                    }
+
+                    // RSC6b4
+                    context("unit") {
+                        it("should default to minute") {
+                            let query = ARTStatsQuery()
+
+                            expect(query.unit).to(equal(ARTStatsUnit.Minute))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ablySpec/RestClient.swift
+++ b/ablySpec/RestClient.swift
@@ -50,10 +50,6 @@ func getTestToken() -> String {
 class RestClient: QuickSpec {
     override func spec() {
         describe("RestClient") {
-            beforeEach {
-                ARTClientOptions.getDefaultRestHost("sandbox-rest.ably.io", modify: true)
-            }
-
             // RSC1
             context("initializer") {
                 it("should accept an API key") {

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -11,6 +11,15 @@ import Foundation
 import XCTest
 import SwiftyJSON
 import ably
+import Quick
+
+class Configuration : QuickConfiguration {
+    override class func configure(configuration: Quick.Configuration!) {
+        configuration.beforeEach {
+            ARTClientOptions.getDefaultRestHost("sandbox-rest.ably.io", modify: true)
+        }
+    }
+}
 
 func pathForTestResource(resourcePath: String) -> String {
     let testBundle = NSBundle(forClass: AblyTests.self)


### PR DESCRIPTION
Add a new -[ARTRest stats:callback:] method that replaces the old stats API. Along with it comes ARTStatsQuery that describes query options such as direction, limit, etc.

Add tests for it all.