### PR TITLE
Auth.canRequestToken and Auth.validate revision

### DIFF
--- a/ably-ios/ARTAuth.m
+++ b/ably-ios/ARTAuth.m
@@ -40,20 +40,30 @@
         if (!options.tls) {
             [NSException raise:@"ARTAuthException" format:@"Basic authentication only connects over HTTPS (tls)."];
         }
-        [self.logger debug:@"ARTAuth: setting up auth method Basic"];
+        // Basic
+        [self.logger debug:@"ARTAuth: setting up auth method Basic (anonymous)"];
         _method = ARTAuthMethodBasic;
     } else if (options.tokenDetails) {
+        // TokenDetails
+        [self.logger debug:@"ARTAuth: setting up auth method Token with token details"];
+        _method = ARTAuthMethodToken;
+    } else if (options.token) {
+        // Token
         [self.logger debug:@"ARTAuth: setting up auth method Token with supplied token only"];
         _method = ARTAuthMethodToken;
+        options.tokenDetails = [[ARTAuthTokenDetails alloc] initWithToken:options.token];
     } else if (options.authUrl && options.authCallback) {
         [NSException raise:@"ARTAuthException" format:@"Incompatible authentication configuration: please specify either authCallback and authUrl."];
     } else if (options.authUrl) {
+        // Authentication url
         [self.logger debug:@"ARTAuth: setting up auth method Token with authUrl"];
         _method = ARTAuthMethodToken;
     } else if (options.authCallback) {
+        // Authentication callback
         [self.logger debug:@"ARTAuth: setting up auth method Token with authCallback"];
         _method = ARTAuthMethodToken;
-    } else if (options.key && options.useTokenAuth) {
+    } else if (options.key) {
+        // Token
         [self.logger debug:@"ARTAuth: setting up auth method Token with key"];
         _method = ARTAuthMethodToken;
     } else {
@@ -221,23 +231,6 @@
         }];
     } else {
         callback([tokenParams sign:mergedOptions.key], nil);
-    }
-}
-
-- (BOOL)canRequestToken {
-    // FIXME: not used?!
-    if (self.options.authCallback) {
-        [self.logger verbose:@"ARTAuth can request token via authCallback"];
-        return YES;
-    } else if (self.options.authUrl) {
-        [self.logger verbose:@"ARTAuth can request token via authURL"];
-        return YES;
-    } else if (self.options.key) {
-        [self.logger verbose:@"ARTAuth can request token via key"];
-        return YES;
-    } else {
-        [self.logger error:@"ARTAuth cannot request token"];
-        return NO;
     }
 }
 

--- a/ably-ios/ARTAuthOptions.m
+++ b/ably-ios/ARTAuthOptions.m
@@ -10,10 +10,6 @@
 
 #import "ARTAuthTokenDetails.h"
 
-static __GENERIC(NSArray, NSString *) *decomposeKey(NSString *key) {
-    return [key componentsSeparatedByString:@":"];
-}
-
 @implementation ARTAuthOptions
 
 NSString *const ARTAuthOptionsMethodDefault = @"GET";

--- a/ably-ios/ARTAuthOptions.m
+++ b/ably-ios/ARTAuthOptions.m
@@ -108,7 +108,7 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
 }
 
 - (BOOL)isBasicAuth {
-    return self.key != nil && !self.useTokenAuth;
+    return self.useTokenAuth == false && self.key != nil && self.clientId == nil;
 }
 
 - (BOOL)isMethodPOST {

--- a/ably-ios/ARTAuthTokenParams.m
+++ b/ably-ios/ARTAuthTokenParams.m
@@ -15,11 +15,6 @@
 #import "ARTPayload.h"
 #import "ARTAuthTokenRequest.h"
 
-// FIXME: reuse
-static __GENERIC(NSArray, NSString *) *decomposeKey(NSString *key) {
-    return [key componentsSeparatedByString:@":"];
-}
-
 @implementation ARTAuthTokenParams
 
 - (instancetype)init {

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -40,6 +40,11 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeChannelState) {
 
 ART_ASSUME_NONNULL_BEGIN
 
+/// Decompose API key
+__GENERIC(NSArray, NSString *) *decomposeKey(NSString *key);
+
+// MARK: Callbacks definitions
+
 typedef void (^ARTRealtimeChannelMessageCb)(ARTMessage *);
 
 typedef void (^ARTRealtimeChannelStateCb)(ARTRealtimeChannelState, ARTStatus *);

--- a/ably-ios/ARTTypes.m
+++ b/ably-ios/ARTTypes.m
@@ -8,6 +8,14 @@
 
 #import "ARTTypes.h"
 
+// MARK: Global helper functions
+
+__GENERIC(NSArray, NSString *) *decomposeKey(NSString *key) {
+    return [key componentsSeparatedByString:@":"];
+}
+
+// MARK: ARTIndirectCancellable
+
 @interface ARTIndirectCancellable ()
 
 @property (readwrite, assign, nonatomic) BOOL isCancelled;


### PR DESCRIPTION
I removed `canRequestToken`. It isn't necessary because the constructor does the validation.

Fixed `isBasicAuth` with:
> _It defaults to basic auth if the `keyValue` is provided, and there is no `clientId` specified. In this case, however, `useTokenAuth` forces token auth to be used._