### PR TITLE
Client manage token requests

### DIFF
--- a/ably-ios/ARTAuth.h
+++ b/ably-ios/ARTAuth.h
@@ -22,11 +22,6 @@ ART_ASSUME_NONNULL_BEGIN
 
 #pragma mark - ARTAuth
 
-typedef NS_ENUM(NSUInteger, ARTAuthMethod) {
-    ARTAuthMethodBasic,
-    ARTAuthMethodToken
-};
-
 @interface ARTAuth : NSObject
 
 @property (nonatomic, readonly, strong) ARTAuthOptions *options;

--- a/ably-ios/ARTAuth.m
+++ b/ably-ios/ARTAuth.m
@@ -135,7 +135,7 @@
         
         [_rest.logger debug:@"%@ %@", request.HTTPMethod, request.URL];
         
-        [_rest.httpExecutor executeRequest:request callback:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        [_rest executeRequest:request withAuthOption:ARTAuthenticationUseBasic completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
             if (error) {
                 callback(nil, error);
             } else {
@@ -173,7 +173,7 @@
     [request setValue:[defaultEncoder mimeType] forHTTPHeaderField:@"Accept"];
     [request setValue:[defaultEncoder mimeType] forHTTPHeaderField:@"Content-Type"];
     
-    [_rest.httpExecutor executeRequest:request callback:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [_rest executeRequest:request withAuthOption:ARTAuthenticationUseBasic completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, error);
         } else {
@@ -191,7 +191,7 @@
 - (void)authorise:(ARTAuthTokenParams *)tokenParams options:(ARTAuthOptions *)options force:(BOOL)force callback:(void (^)(ARTAuthTokenDetails *, NSError *))callback {
     BOOL requestNewToken = NO;
 
-    // Reuse or not reuse
+    // Reuse or not reuse the current token
     if (!force && self.tokenDetails) {
         if (self.tokenDetails.expires == nil) {
             [self.logger verbose:@"ARTAuth: reuse current token."];

--- a/ably-ios/ARTAuth.m
+++ b/ably-ios/ARTAuth.m
@@ -40,20 +40,30 @@
         if (!options.tls) {
             [NSException raise:@"ARTAuthException" format:@"Basic authentication only connects over HTTPS (tls)."];
         }
-        [self.logger debug:@"ARTAuth: setting up auth method Basic"];
+        // Basic
+        [self.logger debug:@"ARTAuth: setting up auth method Basic (anonymous)"];
         _method = ARTAuthMethodBasic;
     } else if (options.tokenDetails) {
+        // TokenDetails
+        [self.logger debug:@"ARTAuth: setting up auth method Token with token details"];
+        _method = ARTAuthMethodToken;
+    } else if (options.token) {
+        // Token
         [self.logger debug:@"ARTAuth: setting up auth method Token with supplied token only"];
         _method = ARTAuthMethodToken;
+        options.tokenDetails = [[ARTAuthTokenDetails alloc] initWithToken:options.token];
     } else if (options.authUrl && options.authCallback) {
         [NSException raise:@"ARTAuthException" format:@"Incompatible authentication configuration: please specify either authCallback and authUrl."];
     } else if (options.authUrl) {
+        // Authentication url
         [self.logger debug:@"ARTAuth: setting up auth method Token with authUrl"];
         _method = ARTAuthMethodToken;
     } else if (options.authCallback) {
+        // Authentication callback
         [self.logger debug:@"ARTAuth: setting up auth method Token with authCallback"];
         _method = ARTAuthMethodToken;
-    } else if (options.key && options.useTokenAuth) {
+    } else if (options.key) {
+        // Token
         [self.logger debug:@"ARTAuth: setting up auth method Token with key"];
         _method = ARTAuthMethodToken;
     } else {
@@ -221,23 +231,6 @@
         }];
     } else {
         callback([tokenParams sign:mergedOptions.key], nil);
-    }
-}
-
-- (BOOL)canRequestToken {
-    // FIXME: not used?!
-    if (self.options.authCallback) {
-        [self.logger verbose:@"ARTAuth can request token via authCallback"];
-        return YES;
-    } else if (self.options.authUrl) {
-        [self.logger verbose:@"ARTAuth can request token via authURL"];
-        return YES;
-    } else if (self.options.key) {
-        [self.logger verbose:@"ARTAuth can request token via key"];
-        return YES;
-    } else {
-        [self.logger error:@"ARTAuth cannot request token"];
-        return NO;
     }
 }
 

--- a/ably-ios/ARTAuthOptions.h
+++ b/ably-ios/ARTAuthOptions.h
@@ -79,7 +79,7 @@ ART_ASSUME_NONNULL_BEGIN
  The id of the client represented by this instance.
  The clientId is relevant to presence operations, where the clientId is the principal identifier of the client in presence update messages. The clientId is also relevant to authentication; a token issued for a specific client may be used to authenticate the bearer of that token to the service.
  */
-@property (readwrite, strong, nonatomic) NSString *clientId;
+@property (readwrite, strong, nonatomic, art_nullable) NSString *clientId;
 
 - (instancetype)init;
 - (instancetype)initWithKey:(NSString *)key;

--- a/ably-ios/ARTAuthOptions.m
+++ b/ably-ios/ARTAuthOptions.m
@@ -10,10 +10,6 @@
 
 #import "ARTAuthTokenDetails.h"
 
-static __GENERIC(NSArray, NSString *) *decomposeKey(NSString *key) {
-    return [key componentsSeparatedByString:@":"];
-}
-
 @implementation ARTAuthOptions
 
 NSString *const ARTAuthOptionsMethodDefault = @"GET";

--- a/ably-ios/ARTAuthOptions.m
+++ b/ably-ios/ARTAuthOptions.m
@@ -108,7 +108,7 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
 }
 
 - (BOOL)isBasicAuth {
-    return self.key != nil && !self.useTokenAuth;
+    return self.useTokenAuth == false && self.key != nil && self.clientId == nil;
 }
 
 - (BOOL)isMethodPOST {

--- a/ably-ios/ARTAuthTokenDetails.m
+++ b/ably-ios/ARTAuthTokenDetails.m
@@ -18,7 +18,6 @@
         _capability = [capability copy];
         _clientId = [clientId copy];
     }
-    
     return self;
 }
 
@@ -26,7 +25,6 @@
     if (self = [super init]) {
         _token = [token copy];
     }
-    
     return self;
 }
 

--- a/ably-ios/ARTAuthTokenParams.h
+++ b/ably-ios/ARTAuthTokenParams.h
@@ -31,7 +31,7 @@ ART_ASSUME_NONNULL_BEGIN
 /**
  A clientId to associate with this token.
  */
-@property (nonatomic, copy) NSString *clientId;
+@property (art_nullable, nonatomic, copy) NSString *clientId;
 
 /**
  Timestamp (in millis since the epoch) of this request. Timestamps, in conjunction with the nonce, are used to prevent n requests from being replayed.

--- a/ably-ios/ARTAuthTokenParams.h
+++ b/ably-ios/ARTAuthTokenParams.h
@@ -39,6 +39,7 @@ ART_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, null_resettable) NSDate *timestamp;
 
 - (instancetype)init;
+- (instancetype)initWithClientId:(NSString *)clientId;
 
 - (__GENERIC(NSMutableArray, NSURLQueryItem *) *)toArray;
 - (__GENERIC(NSArray, NSURLQueryItem *) *)toArrayWithUnion:(NSArray *)items;

--- a/ably-ios/ARTAuthTokenParams.m
+++ b/ably-ios/ARTAuthTokenParams.m
@@ -22,7 +22,7 @@
         _ttl = 60 * 60;
         _timestamp = [NSDate date];
         _capability = @"{\"*\":[\"*\"]}"; // allow all
-        _clientId = @"";
+        _clientId = nil;
     }
     return self;
 }
@@ -145,7 +145,7 @@ static NSString *hmacForDataAndKey(NSData *data, NSData *key) {
     NSString *keyName = keyComponents[0];
     NSString *keySecret = keyComponents[1];
     NSString *nonce = generateNonce();
-    NSString *clientId = self.clientId ? self.clientId : @"*";
+    NSString *clientId = self.clientId ? self.clientId : @"";
     
     NSString *signText = [NSString stringWithFormat:@"%@\n%lld\n%@\n%@\n%lld\n%@\n", keyName, (int64_t)(self.ttl * 1000), self.capability, clientId, (int64_t)(self.timestamp.timeIntervalSince1970 * 1000), nonce];
     NSString *mac = hmacForDataAndKey([signText dataUsingEncoding:NSUTF8StringEncoding], [keySecret dataUsingEncoding:NSUTF8StringEncoding]);

--- a/ably-ios/ARTAuthTokenParams.m
+++ b/ably-ios/ARTAuthTokenParams.m
@@ -15,11 +15,6 @@
 #import "ARTPayload.h"
 #import "ARTAuthTokenRequest.h"
 
-// FIXME: reuse
-static __GENERIC(NSArray, NSString *) *decomposeKey(NSString *key) {
-    return [key componentsSeparatedByString:@":"];
-}
-
 @implementation ARTAuthTokenParams
 
 - (instancetype)init {

--- a/ably-ios/ARTAuthTokenParams.m
+++ b/ably-ios/ARTAuthTokenParams.m
@@ -22,8 +22,15 @@
         _ttl = 60 * 60;
         _timestamp = [NSDate date];
         _capability = @"{\"*\":[\"*\"]}"; // allow all
+        _clientId = @"";
     }
-    
+    return self;
+}
+
+- (instancetype)initWithClientId:(NSString *)clientId {
+    if (self = [self init]) {
+        _clientId = clientId;
+    }
     return self;
 }
 
@@ -138,7 +145,7 @@ static NSString *hmacForDataAndKey(NSData *data, NSData *key) {
     NSString *keyName = keyComponents[0];
     NSString *keySecret = keyComponents[1];
     NSString *nonce = generateNonce();
-    NSString *clientId = self.clientId ? self.clientId : @"";
+    NSString *clientId = self.clientId ? self.clientId : @"*";
     
     NSString *signText = [NSString stringWithFormat:@"%@\n%lld\n%@\n%@\n%lld\n%@\n", keyName, (int64_t)(self.ttl * 1000), self.capability, clientId, (int64_t)(self.timestamp.timeIntervalSince1970 * 1000), nonce];
     NSString *mac = hmacForDataAndKey([signText dataUsingEncoding:NSUTF8StringEncoding], [keySecret dataUsingEncoding:NSUTF8StringEncoding]);

--- a/ably-ios/ARTAuthTokenRequest.h
+++ b/ably-ios/ARTAuthTokenRequest.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "ARTAuthTokenParams.h"
 
+ART_ASSUME_NONNULL_BEGIN
+
 /**
  Type containing the token request details.
  */
@@ -33,3 +35,5 @@
 - (instancetype)initWithTokenParams:(ARTAuthTokenParams *)tokenParams keyName:(NSString *)keyName nonce:(NSString *)nonce mac:(NSString *)mac;
 
 @end
+
+ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTAuthTokenRequest.m
+++ b/ably-ios/ARTAuthTokenRequest.m
@@ -24,7 +24,6 @@
         _nonce = [nonce copy];
         _mac = [mac copy];
     }
-    
     return self;
 }
 

--- a/ably-ios/ARTHttp.h
+++ b/ably-ios/ARTHttp.h
@@ -12,12 +12,13 @@
 
 @class ARTErrorInfo;
 
-// FIXME:
+ART_ASSUME_NONNULL_BEGIN
+
 @protocol ARTHTTPExecutor
 
 @property (nonatomic, weak) ARTLog *logger;
 
-- (void)executeRequest:(NSMutableURLRequest *)request callback:(void (^)(NSHTTPURLResponse *response, NSData *data, NSError *error))callback;
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(art_nullable ARTHttpRequestCallback)callback;
 
 @end
 
@@ -25,11 +26,11 @@
 
 @property (readonly, strong, nonatomic) NSString *method;
 @property (readonly, strong, nonatomic) NSURL *url;
-@property (readonly, strong, nonatomic) NSDictionary *headers;
-@property (readonly, strong, nonatomic) NSData *body;
+@property (art_nullable, readonly, strong, nonatomic) NSDictionary *headers;
+@property (art_nullable, readonly, strong, nonatomic) NSData *body;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
-- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body;
+- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body;
 - (ARTHttpRequest *)requestWithRelativeUrl:(NSString *)relUrl;
 
 @end
@@ -38,14 +39,14 @@
 
 @property (readonly, assign, nonatomic) int status;
 @property (readwrite, strong, nonatomic) ARTErrorInfo *error;
-@property (readonly, strong, nonatomic) NSDictionary *headers;
-@property (readonly, strong, nonatomic) NSData *body;
+@property (art_nullable, readonly, strong, nonatomic) NSDictionary *headers;
+@property (art_nullable, readonly, strong, nonatomic) NSData *body;
 
 - (instancetype)init;
-- (instancetype)initWithStatus:(int)status headers:(NSDictionary *)headers body:(NSData *)body;
+- (instancetype)initWithStatus:(int)status headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body;
 
 + (instancetype)response;
-+ (instancetype)responseWithStatus:(int)status headers:(NSDictionary *)headers body:(NSData *)body;
++ (instancetype)responseWithStatus:(int)status headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body;
 
 - (NSString *)contentType;
 - (NSDictionary *)links;
@@ -61,7 +62,9 @@
 
 - (instancetype)init;
 
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body cb:(ARTHttpCb)cb;
+- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body cb:(ARTHttpCb)cb;
 - (id<ARTCancellable>)makeRequest:(ARTHttpRequest *)req cb:(ARTHttpCb)cb;
 
 @end
+
+ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTHttp.m
+++ b/ably-ios/ARTHttp.m
@@ -167,10 +167,10 @@
     return self;
 }
 
-- (void)executeRequest:(NSMutableURLRequest *)request callback:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))callback {
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(ARTHttpRequestCallback)callback {
     [self.logger debug:@"%@ %@", request.HTTPMethod, request.URL.absoluteString];
     [self.logger verbose:@"Headers %@", request.allHTTPHeaderFields];
-    
+
     CFRunLoopRef currentRunloop = CFRunLoopGetCurrent();
 
     NSURLSessionDataTask *task = [_urlSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
@@ -186,7 +186,6 @@
             callback(httpResponse, data, error);
         });
         CFRunLoopWakeUp(currentRunloop);
-        
     }];
     [task resume];
 }

--- a/ably-ios/ARTJsonEncoder.m
+++ b/ably-ios/ARTJsonEncoder.m
@@ -373,15 +373,20 @@
     
     NSNumber *timestamp = [NSNumber numberWithInteger:[NSNumber numberWithDouble:tokenRequest.timestamp.timeIntervalSince1970 * 1000].integerValue];
 
-    return @{
+    NSMutableDictionary *dictionary = [@{
              @"keyName":tokenRequest.keyName ? tokenRequest.keyName : @"",
              @"ttl":[NSString stringWithFormat:@"%lld", (int64_t)(tokenRequest.ttl * 1000)],
              @"capability":tokenRequest.capability ? tokenRequest.capability : @"",
-             @"clientId":tokenRequest.clientId ? tokenRequest.clientId : @"*",
              @"timestamp":timestamp ? timestamp : [NSNumber numberWithInteger:[NSNumber numberWithDouble:[NSDate date].timeIntervalSince1970 * 1000].integerValue],
              @"nonce":tokenRequest.nonce ? tokenRequest.nonce : @"",
              @"mac":tokenRequest.mac ? tokenRequest.mac : @""
-             };
+        } mutableCopy];
+
+    if (tokenRequest.clientId) {
+        dictionary[@"clientId"] = tokenRequest.clientId;
+    }
+
+    return dictionary;
 }
 
 - (ARTProtocolMessage *)protocolMessageFromDictionary:(NSDictionary *)input {

--- a/ably-ios/ARTJsonEncoder.m
+++ b/ably-ios/ARTJsonEncoder.m
@@ -164,7 +164,7 @@
     return output;
 }
 
--(ARTPresenceAction) presenceActionFromInt:(int) action
+- (ARTPresenceAction)presenceActionFromInt:(int) action
 {
     switch (action) {
         case 0:
@@ -183,7 +183,7 @@
     
 }
 
--(int) intFromPresenceMessageAction:(ARTPresenceAction) action
+- (int)intFromPresenceMessageAction:(ARTPresenceAction) action
 {
     switch (action) {
         case ARTPresenceAbsent:
@@ -374,13 +374,13 @@
     NSNumber *timestamp = [NSNumber numberWithInteger:[NSNumber numberWithDouble:tokenRequest.timestamp.timeIntervalSince1970 * 1000].integerValue];
 
     return @{
-             @"keyName":tokenRequest.keyName,
+             @"keyName":tokenRequest.keyName ? tokenRequest.keyName : @"",
              @"ttl":[NSString stringWithFormat:@"%lld", (int64_t)(tokenRequest.ttl * 1000)],
-             @"capability":tokenRequest.capability,
-             @"clientId":tokenRequest.clientId ? tokenRequest.clientId : @"",
+             @"capability":tokenRequest.capability ? tokenRequest.capability : @"",
+             @"clientId":tokenRequest.clientId ? tokenRequest.clientId : @"*",
              @"timestamp":timestamp ? timestamp : [NSNumber numberWithInteger:[NSNumber numberWithDouble:[NSDate date].timeIntervalSince1970 * 1000].integerValue],
-             @"nonce":tokenRequest.nonce,
-             @"mac":tokenRequest.mac,
+             @"nonce":tokenRequest.nonce ? tokenRequest.nonce : @"",
+             @"mac":tokenRequest.mac ? tokenRequest.mac : @""
              };
 }
 

--- a/ably-ios/ARTPaginatedResult.m
+++ b/ably-ios/ARTPaginatedResult.m
@@ -99,8 +99,9 @@ static NSMutableURLRequest *requestRelativeTo(NSMutableURLRequest *request, NSSt
 + (void)executePaginatedRequest:(NSMutableURLRequest *)request executor:(id<ARTHTTPExecutor>)executor
               responseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
                        callback:(ARTPaginatedResultCallback)callback {
-    
-    [executor executeRequest:request callback:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+
+    // FIXME: review (no auth?!)
+    [executor executeRequest:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, error);
         } else {

--- a/ably-ios/ARTRest+Private.h
+++ b/ably-ios/ARTRest+Private.h
@@ -11,12 +11,6 @@
 @protocol ARTEncoder;
 @protocol ARTHTTPExecutor;
 
-typedef NS_ENUM(NSUInteger, ARTAuthentication) {
-    ARTAuthenticationOff,
-    ARTAuthenticationOn,
-    ARTAuthenticationUseBasic
-};
-
 ART_ASSUME_NONNULL_BEGIN
 
 /// ARTRest private methods that are used for whitebox testing
@@ -30,20 +24,18 @@ ART_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSURL *baseUrl;
 
-- (NSURL *)getBaseURL;
+// FIXME: used for Realtime. Review because ARTRealtime does not use ARTRest as base class
 - (NSString *)formatQueryParams:(NSDictionary *)queryParams;
 
-- (NSURL *)resolveUrl:(NSString *)relUrl;
-- (NSURL *)resolveUrl:(NSString *)relUrl queryParams:(NSDictionary *)queryParams;
+// MARK: ARTHTTPExecutor
 
-- (id<ARTCancellable>)get:(NSString *)relUrl authenticated:(BOOL)authenticated cb:(ARTHttpCb)cb;
-- (id<ARTCancellable>)get:(NSString *)relUrl headers:(NSDictionary *)headers authenticated:(BOOL)authenticated cb:(ARTHttpCb)cb;
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(ARTHttpRequestCallback)callback;
 
-- (id<ARTCancellable>)post:(NSString *)relUrl headers:(NSDictionary *)headers body:(NSData *)body authenticated:(ARTAuthentication)authenticated cb:(ARTHttpCb)cb;
+// MARK: Internal
 
-- (void)executeRequest:(NSMutableURLRequest *)request callback:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))callback;
+- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(ARTHttpRequestCallback)callback;
 
-- (void)calculateAuthorization:(void (^)(NSString *__art_nonnull authorization, NSError *__art_nullable error))callback;
+- (void)calculateAuthorization:(ARTAuthMethod)method completion:(void (^)(NSString *__art_nonnull authorization, NSError *__art_nullable error))callback;
 
 - (id<ARTCancellable>)postTestStats:(NSArray *)stats cb:(void(^)(ARTStatus * status)) cb;
 

--- a/ably-ios/ARTRest+Private.h
+++ b/ably-ios/ARTRest+Private.h
@@ -17,6 +17,8 @@ typedef NS_ENUM(NSUInteger, ARTAuthentication) {
     ARTAuthenticationUseBasic
 };
 
+ART_ASSUME_NONNULL_BEGIN
+
 /// ARTRest private methods that are used for whitebox testing
 @interface ARTRest (Private)
 
@@ -41,8 +43,10 @@ typedef NS_ENUM(NSUInteger, ARTAuthentication) {
 
 - (void)executeRequest:(NSMutableURLRequest *)request callback:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))callback;
 
+- (void)calculateAuthorization:(void (^)(NSString *__art_nonnull authorization, NSError *__art_nullable error))callback;
+
 - (id<ARTCancellable>)postTestStats:(NSArray *)stats cb:(void(^)(ARTStatus * status)) cb;
 
-- (void)authorise:(ARTTokenCallback)completion;
-
 @end
+
+ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTRest.m
+++ b/ably-ios/ARTRest.m
@@ -32,14 +32,18 @@
 
 @interface ARTRest ()
 
-@property (nonatomic, strong) NSURL *baseUrl;
+@property (readonly, strong, nonatomic) id<ARTEncoder> defaultEncoder;
+@property (readonly, strong, nonatomic) NSString *defaultEncoding; //Content-Type
+
 @property (nonatomic, strong) id<ARTHTTPExecutor> httpExecutor;
 @property (readonly, nonatomic, assign) Class channelClass;
 
+@property (nonatomic, strong) NSURL *baseUrl;
+
+// MARK: Not accessible by tests
 @property (readonly, strong, nonatomic) ARTHttp *http;
 @property (strong, nonatomic) ARTAuth *auth;
 @property (readonly, strong, nonatomic) NSDictionary *encoders;
-@property (readonly, strong, nonatomic) NSString *defaultEncoding; //Content-Type
 @property (readwrite, assign, nonatomic) int fallbackCount;
 
 @end
@@ -88,46 +92,58 @@
     return [self initWithOptions:[[ARTClientOptions alloc] initWithKey:key]];
 }
 
-- (void)executeRequest:(NSMutableURLRequest *)request callback:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))callback {
+- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(ARTHttpRequestCallback)callback {
     request.URL = [NSURL URLWithString:request.URL.relativeString relativeToURL:self.baseUrl];
     
     NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
     [request setValue:accept forHTTPHeaderField:@"Accept"];
 
-    [self executeRequestWithAuthentication:request completion:callback];
+    switch (authOption) {
+        case ARTAuthenticationOff:
+            [self executeRequest:request completion:callback];
+            break;
+        case ARTAuthenticationOn:
+            [self executeRequestWithAuthentication:request withMethod:self.auth.method completion:callback];
+            break;
+        case ARTAuthenticationUseBasic:
+            [self executeRequestWithAuthentication:request withMethod:ARTAuthMethodBasic completion:callback];
+            break;
+    }
 }
 
-- (void)executeRequestWithAuthentication:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *, NSData *, NSError *))completion {
-    if (!completion)
-        return;
-    
-    [self calculateAuthorization:^(NSString *authorization, NSError *error) {
-        if (error) {
-            completion(nil, nil, error);
+- (void)executeRequestWithAuthentication:(NSMutableURLRequest *)request withMethod:(ARTAuthMethod)method completion:(ARTHttpRequestCallback)callback {
+    [self calculateAuthorization:method completion:^(NSString *authorization, NSError *error) {
+        if (error && callback) {
+            callback(nil, nil, error);
         } else {
             // RFC7235
             [request setValue:authorization forHTTPHeaderField:@"Authorization"];
-            
-            [self.httpExecutor executeRequest:request callback:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
-                if (response.statusCode >= 400) {
-                    NSError *error = [self->_encoders[response.MIMEType] decodeError:data];
-                    if (error.code == 40140) {
-                        // TODO: request token or error if no token information
-                        NSAssert(false, @"Request token or error if no token information");
-                    } else {
-                        completion(nil, nil, error);
-                    }
-                } else {
-                    completion(response, data, error);
-                }
-            }];
+            [self executeRequest:request completion:callback];
         }
     }];
 }
 
-- (void)calculateAuthorization:(void (^)(NSString *authorization, NSError *error))callback {
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(ARTHttpRequestCallback)callback {
+    [self.logger debug:@"ARTRest: executing request %@", request];
+    [self.httpExecutor executeRequest:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+        if (response.statusCode >= 400) {
+            NSError *error = [self->_encoders[response.MIMEType] decodeError:data];
+            if (error.code == 40140) {
+                // TODO: request token or error if no token information
+                NSAssert(false, @"Request token or error if no token information");
+            } else if (callback) {
+                callback(nil, nil, error);
+            }
+        } else if (callback) {
+            callback(response, data, error);
+        }
+    }];
+}
+
+- (void)calculateAuthorization:(ARTAuthMethod)method completion:(void (^)(NSString *authorization, NSError *error))callback {
+    [self.logger debug:@"ARTRest: calculating authorization %lu", (unsigned long)method];
     // FIXME: use encoder and should be managed on ARTAuth
-    if (self.auth.method == ARTAuthMethodBasic) {
+    if (method == ARTAuthMethodBasic) {
         // Include key Base64 encoded in an Authorization header (RFC7235)
         NSData *keyData = [self.options.key dataUsingEncoding:NSUTF8StringEncoding];
         NSString *keyBase64 = [keyData base64EncodedStringWithOptions:0];
@@ -135,12 +151,8 @@
     }
     else {
         [self.auth authorise:nil options:self.options force:NO callback:^(ARTAuthTokenDetails *tokenDetails, NSError *error) {
-            NSData *keyData;
-            if (tokenDetails) {
-                keyData = [tokenDetails.token dataUsingEncoding:NSUTF8StringEncoding];
-            }
-            NSString *keyBase64 = [keyData base64EncodedStringWithOptions:0];
-            callback([NSString stringWithFormat:@"Bearer %@", keyBase64], nil);
+            [self.logger verbose:@"ARTRest: authorization bearer in Base64 %@", tokenDetails.token];
+            callback([NSString stringWithFormat:@"Bearer %@", tokenDetails.token], nil);
         }];
     }
 }
@@ -152,7 +164,7 @@
     NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
     [request setValue:accept forHTTPHeaderField:@"Accept"];
     
-    [self.httpExecutor executeRequest:request callback:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self executeRequest:request withAuthOption:ARTAuthenticationOff completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode >= 400) {
             callback(nil, [self->_encoders[response.MIMEType] decodeError:data]);
         } else {

--- a/ably-ios/ARTRestChannel.m
+++ b/ably-ios/ARTRestChannel.m
@@ -71,7 +71,7 @@
         [request setValue:self.rest.defaultEncoding forHTTPHeaderField:@"Content-Type"];
     }
     
-    [self.rest executeRequest:request callback:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [self.rest executeRequest:request withAuthOption:ARTAuthenticationOn completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (callback) {
             callback(error);
         }

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -17,6 +17,17 @@
 @class ARTAuthTokenRequest;
 @class ARTAuthTokenDetails;
 
+typedef NS_ENUM(NSUInteger, ARTAuthentication) {
+    ARTAuthenticationOff,
+    ARTAuthenticationOn,
+    ARTAuthenticationUseBasic
+};
+
+typedef NS_ENUM(NSUInteger, ARTAuthMethod) {
+    ARTAuthMethodBasic,
+    ARTAuthMethodToken
+};
+
 typedef NS_ENUM(NSUInteger, ARTRealtimeConnectionState) {
     ARTRealtimeInitialized,
     ARTRealtimeConnecting,
@@ -58,6 +69,8 @@ typedef void (^ARTStatusCallback)(ARTStatus *status);
 typedef void (^ARTHttpCb)(ARTHttpResponse *response);
 
 typedef void (^ARTErrorCallback)(NSError *__art_nullable error);
+
+typedef void (^ARTHttpRequestCallback)(NSHTTPURLResponse *__art_nullable response, NSData *__art_nullable data, NSError *__art_nullable error);
 
 // FIXME: review
 typedef void (^ARTAuthCallback)(ARTAuthTokenParams *tokenParams, void(^callback)(ARTAuthTokenRequest *__art_nullable tokenRequest, NSError *__art_nullable error));

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -40,6 +40,11 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeChannelState) {
 
 ART_ASSUME_NONNULL_BEGIN
 
+/// Decompose API key
+__GENERIC(NSArray, NSString *) *decomposeKey(NSString *key);
+
+// MARK: Callbacks definitions
+
 typedef void (^ARTRealtimeChannelMessageCb)(ARTMessage *);
 
 typedef void (^ARTRealtimeChannelStateCb)(ARTRealtimeChannelState, ARTStatus *);

--- a/ably-ios/ARTTypes.m
+++ b/ably-ios/ARTTypes.m
@@ -8,6 +8,14 @@
 
 #import "ARTTypes.h"
 
+// MARK: Global helper functions
+
+__GENERIC(NSArray, NSString *) *decomposeKey(NSString *key) {
+    return [key componentsSeparatedByString:@":"];
+}
+
+// MARK: ARTIndirectCancellable
+
 @interface ARTIndirectCancellable ()
 
 @property (readwrite, assign, nonatomic) BOOL isCancelled;

--- a/ablySpec/Auth.swift
+++ b/ablySpec/Auth.swift
@@ -81,7 +81,7 @@ class Auth : QuickSpec {
                     if let request = mockExecutor.requests.first, let url = request.URL {
                         expect(url.scheme).to(equal("http"), description: "No HTTP support")
                     }
-                    
+
                     // Check HTTPS
                     options.tls = true
                     let clientHTTPS = ARTRest(options: options)
@@ -181,9 +181,11 @@ class Auth : QuickSpec {
                     
                     waitUntil(timeout: 10) { done in
                         // Token
-                        client.authorise { tokenDetails, error in
-                            expect(tokenDetails).toNot(beNil(), description: "TokenDetails is nil")
-                            expect(tokenDetails?.clientId).to(equal(expectedClientId))
+                        client.calculateAuthorization { token, error in
+                            if let e = error {
+                                XCTFail(e.description)
+                            }
+                            expect(client.auth.clientId).to(equal(expectedClientId))
                             done()
                         }
                     }
@@ -202,23 +204,31 @@ class Auth : QuickSpec {
                 // RSA15b
                 it("should permit to be unauthenticated") {
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                    options.clientId = "*"
+                    options.clientId = nil
                     
+                    let clientBasic = ARTRest(options: options)
+
                     waitUntil(timeout: 10) { done in
-                        // Token
-                        ARTRest(options: options).authorise { tokenDetails, error in
-                            expect(tokenDetails).toNot(beNil(), description: "TokenDetails is nil")
-                            expect(tokenDetails?.clientId).to(equal(options.clientId))
-                            options.tokenDetails = tokenDetails
+                        // Basic
+                        clientBasic.calculateAuthorization { token, error in
+                            if let e = error {
+                                XCTFail(e.description)
+                            }
+                            expect(clientBasic.auth.clientId).to(beNil())
+                            options.tokenDetails = clientBasic.auth.tokenDetails
                             done()
                         }
                     }
 
+                    let clientToken = ARTRest(options: options)
+
                     waitUntil(timeout: 10) { done in
-                        // Token
-                        ARTRest(options: options).authorise { tokenDetails, error in
-                            expect(tokenDetails).toNot(beNil(), description: "TokenDetails is nil")
-                            expect(tokenDetails?.clientId).to(equal("*"))
+                        // Last TokenDetails
+                        clientToken.calculateAuthorization { token, error in
+                            if let e = error {
+                                XCTFail(e.description)
+                            }
+                            expect(clientToken.auth.clientId).to(beNil())
                             done()
                         }
                     }
@@ -229,25 +239,33 @@ class Auth : QuickSpec {
                 // RSA15c
                 it("should cancel request when clientId is invalid") {
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
+
+                    let client = ARTRest(options: options)
                     
                     // Check unquoted
-                    options.clientId = "\"client_string\""
+                    let clientIdQuoted = "\"client_string\""
+                    options.clientId = clientIdQuoted
                     waitUntil(timeout: 10) { done in
                         // Token
-                        ARTRest(options: options).authorise { tokenDetails, error in
-                            expect(tokenDetails).toNot(beNil(), description: "TokenDetails is nil")
-                            expect(tokenDetails?.clientId).to(equal(options.clientId))
+                        client.calculateAuthorization { token, error in
+                            if let e = error {
+                                XCTFail(e.description)
+                            }
+                            expect(client.auth.clientId).to(equal(clientIdQuoted))
                             done()
                         }
                     }
                     
                     // Check unescaped
-                    options.clientId = "client_string\n"
+                    let clientIdBreaklined = "client_string\n"
+                    options.clientId = clientIdBreaklined
                     waitUntil(timeout: 10) { done in
                         // Token
-                        ARTRest(options: options).authorise { tokenDetails, error in
-                            expect(tokenDetails).toNot(beNil(), description: "TokenDetails is nil")
-                            expect(tokenDetails?.clientId).to(equal(options.clientId))
+                        client.calculateAuthorization { token, error in
+                            if let e = error {
+                                XCTFail(e.description)
+                            }
+                            expect(client.auth.clientId).to(equal(clientIdBreaklined))
                             done()
                         }
                     }
@@ -310,7 +328,7 @@ class Auth : QuickSpec {
                 }
                 
                 // RSA7a2
-                fit("should obtain a token if clientId is assigned") {
+                it("should obtain a token if clientId is assigned") {
                     let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
                     options.clientId = "client_string"
                     
@@ -370,9 +388,11 @@ class Auth : QuickSpec {
                         // TokenDetails
                         waitUntil(timeout: 10) { done in
                             // Token
-                            client.authorise { tokenDetails, error in
-                                expect(tokenDetails).toNot(beNil(), description: "TokenDetails is nil")
-                                expect(client.auth.clientId).to(equal(tokenDetails?.clientId))
+                            client.calculateAuthorization { token, error in
+                                if let e = error {
+                                    XCTFail(e.description)
+                                }
+                                expect(client.auth.clientId).to(equal(options.clientId))
                                 done()
                             }
                         }

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -218,9 +218,9 @@ class MockHTTPExecutor: NSObject, ARTHTTPExecutor {
     var logger: ARTLog?
     
     var requests: [NSMutableURLRequest] = []
-    
-    func executeRequest(request: NSMutableURLRequest!, callback: ((NSHTTPURLResponse!, NSData!, NSError!) -> Void)!) {
+
+    func executeRequest(request: NSMutableURLRequest, completion callback: ARTHttpRequestCallback?) {
         self.requests.append(request)
-        self.executor.executeRequest(request, callback: callback)
+        self.executor.executeRequest(request, completion: callback)
     }
 }


### PR DESCRIPTION
 - Auth.authorise was missing the possibility of receiving just an access token.
 - Auth.options.clientId can be nil.
 - Sign TokenRequest with clientId=* when the user is anonymous.
 - Rest.calculateAuthorization was missing the Auth.authorise for token reusability.

⚠️
`RAS7a1` and `RAS7a2` are failing. Will check that on the next PR.