### PR TITLE
ObjC tests: fixed bad response

### DIFF
--- a/ably-ios/ARTAuthOptions.m
+++ b/ably-ios/ARTAuthOptions.m
@@ -65,11 +65,16 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
 }
 
 - (NSString *)token {
-    return self.tokenDetails.token;
+    if (self.tokenDetails) {
+        return self.tokenDetails.token;
+    }
+    return nil;
 }
 
 - (void)setToken:(NSString *)token {
-    self.tokenDetails = [[ARTAuthTokenDetails alloc] initWithToken:token];
+    if (token && ![token isEqualToString:@""]) {
+        self.tokenDetails = [[ARTAuthTokenDetails alloc] initWithToken:token];
+    }
 }
 
 - (void)setAuthMethod:(NSString *)authMethod {

--- a/ably-ios/ARTPresence.m
+++ b/ably-ios/ARTPresence.m
@@ -14,8 +14,9 @@
 #import "ARTPresenceMap.h"
 #import "ARTStatus.h"
 #import "ARTRealtimeChannelSubscription.h"
-
 #import "ARTDataQuery+Private.h"
+#import "ARTRest.h"
+#import "ARTAuth.h"
 
 @interface ARTPresence ()
 
@@ -46,8 +47,8 @@
     [self enterClient:self.channel.clientId data:data cb:cb];
 }
 
-- (void)enterClient:(NSString *) clientId data:(id) data cb:(ARTStatusCallback) cb {
-    if(!clientId) {
+- (void)enterClient:(NSString *)clientId data:(id)data cb:(ARTStatusCallback)cb {
+    if (!clientId) {
         [NSException raise:@"Cannot publish presence without a clientId" format:@""];
     }
     ARTPresenceMessage *msg = [[ARTPresenceMessage alloc] init];

--- a/ably-ios/ARTRealtimeChannel.h
+++ b/ably-ios/ARTRealtimeChannel.h
@@ -35,7 +35,7 @@
 @property (readonly, strong, nonatomic) NSMutableDictionary *subscriptions;
 @property (readonly, strong, nonatomic) NSMutableArray *presenceSubscriptions;
 @property (readonly, strong, nonatomic) NSMutableDictionary *presenceDict;
-@property (readonly, strong, nonatomic) NSString *clientId;
+@property (readonly, getter=getClientId) NSString *clientId;
 @property (readonly, strong, nonatomic) NSMutableArray *stateSubscriptions;
 @property (readonly, strong, nonatomic) id<ARTPayloadEncoder> payloadEncoder;
 @property (readwrite, strong, nonatomic) ARTPresenceMap * presenceMap;
@@ -68,8 +68,6 @@
 
 - (void)publish:(id)payload withName:(NSString *)name cb:(ARTStatusCallback)cb;
 - (void)publish:(id)payload cb:(ARTStatusCallback)cb;
-
-- (void)history:(ARTDataQuery *)query callback:(void (^)(ARTStatus *status, ARTPaginatedResult /* <ARTMessage *> */ *result))callback;
 
 - (id<ARTSubscription>)subscribe:(ARTRealtimeChannelMessageCb)cb;
 - (id<ARTSubscription>)subscribeToName:(NSString *)name cb:(ARTRealtimeChannelMessageCb)cb;

--- a/ably-ios/ARTRealtimeChannel.m
+++ b/ably-ios/ARTRealtimeChannel.m
@@ -37,7 +37,6 @@
         _subscriptions = [NSMutableDictionary dictionary];
         _presenceSubscriptions = [NSMutableArray array];
         _stateSubscriptions = [NSMutableArray array];
-        _clientId = realtime.auth.clientId;
         _payloadEncoder = [ARTPayload defaultPayloadEncoder:options.cipherParams];
         _presenceMap =[[ARTPresenceMap alloc] init];
         _lastPresenceAction = ARTPresenceAbsent;
@@ -460,6 +459,10 @@
     for (ARTQueuedMessage *qm in qms) {
         qm.cb(status);
     }
+}
+
+- (NSString *)getClientId {
+    return self.realtime.auth.clientId;
 }
 
 @end

--- a/ably-ios/ARTRestChannel.m
+++ b/ably-ios/ARTRestChannel.m
@@ -37,7 +37,7 @@
     return _rest.logger;
 }
 
-- (void)history:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult *, NSError *))callback {
+- (void)history:(ARTDataQuery *)query callback:(void(^)(ARTPaginatedResult *result, NSError *error))callback {
     NSParameterAssert(query.limit < 1000);
     NSParameterAssert([query.start compare:query.end] != NSOrderedDescending);
 

--- a/ably-iosTests/ARTRealtimeChannelHistoryTest.m
+++ b/ably-iosTests/ARTRealtimeChannelHistoryTest.m
@@ -45,8 +45,8 @@
             XCTAssertEqual(ARTStateOk, status.state);
             [channel publish:@"testString2" cb:^(ARTStatus *status) {
                 XCTAssertEqual(ARTStateOk, status.state);
-                [channel history:[[ARTDataQuery alloc] init] callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                    XCTAssertEqual(ARTStateOk, status.state);
+                [channel history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
+                    XCTAssert(!error);
                     NSArray *messages = [result items];
                     XCTAssertEqual(2, messages.count);
                     ARTMessage *m0 = messages[0];
@@ -106,8 +106,8 @@
             XCTAssertEqual(ARTStateOk, status.state);
             [channel2 publish:@"testString2" cb:^(ARTStatus *status) {
                 XCTAssertEqual(ARTStateOk, status.state);
-                [channel1 history:[[ARTDataQuery alloc] init] callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                    XCTAssertEqual(ARTStateOk, status.state);
+                [channel1 history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
+                    XCTAssert(!error);
                     NSArray *messages = [result items];
                     XCTAssertEqual(2, messages.count);
                     ARTMessage *m0 = messages[0];
@@ -117,8 +117,8 @@
                     [expectation1 fulfill];
                     
                 }];
-                [channel2 history:[[ARTDataQuery alloc] init] callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                    XCTAssertEqual(ARTStateOk, status.state);
+                [channel2 history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
+                    XCTAssert(!error);
                     NSArray *messages = [result items];
                     XCTAssertEqual(2, messages.count);
                     ARTMessage *m0 = messages[0];
@@ -147,8 +147,8 @@
                 XCTAssertEqual(ARTStateOk, status.state);
                 ARTDataQuery* query = [[ARTDataQuery alloc] init];
                 query.direction = ARTQueryDirectionForwards;
-                [channel history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                    XCTAssertEqual(ARTStateOk, status.state);
+                [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                    XCTAssert(!error);
                     NSArray *messages = [result items];
                     XCTAssertEqual(2, messages.count);
                     ARTMessage *m0 = messages[0];
@@ -177,8 +177,8 @@
             query.limit = 2;
             query.direction = ARTQueryDirectionForwards;
             
-            [channel history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                 XCTAssertEqual(ARTStateOk, status.state);
+            [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                 XCTAssert(!error);
                  XCTAssertTrue([result hasFirst]);
                  XCTAssertTrue([result hasNext]);
                  NSArray * items = [result items];
@@ -238,8 +238,8 @@
             query.limit = 2;
             query.direction = ARTQueryDirectionBackwards;
 
-            [channel history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                 XCTAssertEqual(ARTStateOk, status.state);
+            [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                 XCTAssert(!error);
                  XCTAssertTrue([result hasFirst]);
                  XCTAssertTrue([result hasNext]);
                  NSArray * items = [result items];
@@ -359,8 +359,8 @@
         query.end = [NSDate dateWithTimeIntervalSinceReferenceDate:intervalEnd];
         query.direction = ARTQueryDirectionBackwards;
 
-        [channel history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                                    XCTAssertEqual(ARTStateOk, status.state);
+        [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                                    XCTAssert(!error);
                                     XCTAssertFalse([result hasNext]);
                                     NSArray * items = [result items];
                                     XCTAssertTrue(items != nil);
@@ -438,8 +438,8 @@
         query.end = [NSDate dateWithTimeIntervalSinceReferenceDate:intervalEnd];
         query.direction = ARTQueryDirectionForwards;
 
-        [channel history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                                    XCTAssertEqual(ARTStateOk, status.state);
+        [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                                    XCTAssert(!error);
                                     XCTAssertFalse([result hasNext]);
                                     NSArray * items = [result items];
                                     XCTAssertTrue(items != nil);
@@ -505,8 +505,8 @@
         ARTDataQuery *query = [[ARTDataQuery alloc] init];
         query.direction = ARTQueryDirectionBackwards;
 
-        [channel2 history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                XCTAssertEqual(ARTStateOk, status.state);
+        [channel2 history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                XCTAssert(!error);
                 XCTAssertFalse([result hasNext]);
                 NSArray * items = [result items];
                 XCTAssertTrue(items != nil);

--- a/ably-iosTests/ARTRealtimeCryptoTest.m
+++ b/ably-iosTests/ARTRealtimeCryptoTest.m
@@ -56,8 +56,8 @@
             [channel publish:stringPayload cb:^(ARTStatus *status) {
                 XCTAssertEqual(ARTStateOk, status.state);
                 ARTDataQuery *query = [[ARTDataQuery alloc] init];
-                [channel history:query callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                    XCTAssertEqual(ARTStateOk, status.state);
+                [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
+                    XCTAssert(!error);
                     XCTAssertFalse([result hasNext]);
                     NSArray *page = [result items];
                     XCTAssertTrue(page != nil);
@@ -96,8 +96,8 @@
                 XCTAssertEqual(ARTStateOk, status.state);
                 [c publish:stringPayload cb:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateOk, status.state);
-                    [c history:[[ARTDataQuery alloc] init] callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                        XCTAssertEqual(ARTStateOk, status.state);
+                    [c history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
+                        XCTAssert(!error);
                         XCTAssertFalse([result hasNext]);
                         NSArray * page = [result items];
                         XCTAssertTrue(page != nil);

--- a/ably-iosTests/ARTRealtimeMessageTest.m
+++ b/ably-iosTests/ARTRealtimeMessageTest.m
@@ -265,8 +265,8 @@
             ARTRealtimeChannel *c2 = [_realtime2 channel:channelName];
             [c2 publish:@"message2" cb:^(ARTStatus *status) {
                 XCTAssertEqual(ARTStateOk, status.state);
-                [c1 history:[[ARTDataQuery alloc] init] callback:^(ARTStatus *status, ARTPaginatedResult *result) {
-                    XCTAssertEqual(ARTStateOk, status.state);
+                [c1 history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
+                    XCTAssert(!error);
                     NSArray *messages = [result items];
                     XCTAssertEqual(2, messages.count);
                     ARTMessage *m0 = messages[0];


### PR DESCRIPTION
 - Bugfix: Channel had is own clientId string. Changed to readonly property (proxy of auth.clientId)
 - Bugfix: when we copy a ClientOptions, the tokenDetails were always instanciated
 - Bugfix: ARTRealtimeChannel wasn't overriding the history method