### PR TITLE
ObjC tests: ARTRealtimeChannelTest

### DIFF
--- a/ably-ios/ARTAuth.h
+++ b/ably-ios/ARTAuth.h
@@ -24,7 +24,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTAuth : NSObject
 
-@property (nonatomic, readonly, strong) ARTAuthOptions *options;
+@property (nonatomic, readonly, weak) ARTAuthOptions *options;
 @property (nonatomic, readonly, assign) ARTAuthMethod method;
 
 @property (nonatomic, weak) ARTLog *logger;

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -50,10 +50,10 @@
 @property (readwrite, strong, nonatomic) NSMutableArray *queuedMessages;
 @property (readonly, strong, nonatomic) NSMutableArray *pendingMessages;
 @property (readwrite, assign, nonatomic) int64_t pendingMessageStartSerial;
-@property (readonly, strong, nonatomic) NSString *clientId;
 
 @property (nonatomic, copy) ARTRealtimePingCb pingCb;
-@property (readonly, weak, nonatomic) ARTClientOptions *options;
+@property (readonly, getter=getClientOptions) ARTClientOptions *options;
+@property (readonly, getter=getClientId) NSString *clientId;
 
 - (BOOL)connect;
 
@@ -127,8 +127,6 @@
         _queuedMessages = [NSMutableArray array];
         _pendingMessages = [NSMutableArray array];
         _pendingMessageStartSerial = 0;
-        _clientId = options.clientId;
-        _options = options;
         _stateSubscriptions = [NSMutableArray array];
         
         if (options.autoConnect) {
@@ -140,6 +138,18 @@
 
 - (ARTLog *)getLogger {
     return _rest.logger;
+}
+
+- (ARTClientOptions *)getClientOptions {
+    return _rest.options;
+}
+
+- (NSString *)getClientId {
+    return _rest.options.clientId;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"Realtime: %@", self.clientId];
 }
 
 - (int64_t)connectionSerial {

--- a/ably-ios/ARTRest.m
+++ b/ably-ios/ARTRest.m
@@ -54,7 +54,7 @@
     self = [super init];
     if (self) {
         NSAssert(options, @"ARTRest: No options provided");
-        _options = options;
+        _options = [options copy];
         _baseUrl = [options restUrl];
         
         if (logger) {
@@ -78,7 +78,7 @@
         _defaultEncoding = [defaultEncoder mimeType];
         _fallbackCount = 0;
         
-        _auth = [[ARTAuth alloc] init:self withOptions:options];
+        _auth = [[ARTAuth alloc] init:self withOptions:_options];
         _channels = [[ARTChannelCollection alloc] initWithRest:self];
     }
     return self;

--- a/ably-iosTests/ARTRealtimeChannelTest.m
+++ b/ably-iosTests/ARTRealtimeChannelTest.m
@@ -353,7 +353,7 @@
     NSString *channelName = @"channelName";
 
     XCTestExpectation *exp = [self expectationWithDescription:@"testClientIdPreserved"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:YES cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO cb:^(ARTClientOptions *options) {
         // First instance
         options.clientId = firstClientId;
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -364,17 +364,19 @@
         options.clientId = @"secondClientId";
         ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = realtime2;
-        ARTRealtimeChannel *channel2 = [realtime channel:channelName];
+        ARTRealtimeChannel *channel2 = [realtime2 channel:channelName];
 
         [channel2.presence subscribe:^(ARTPresenceMessage * message) {
             XCTAssertEqualObjects(message.clientId, firstClientId);
             [exp fulfill];
         }];
 
-        [channel.presence enter:@"enter" cb:^(ARTStatus *status) {
+        // Enters "firstClientId"
+        [channel.presence enter:@"First Client" cb:^(ARTStatus *status) {
             XCTAssertEqual(ARTStateOk, status.state);
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
+
 @end

--- a/ably-iosTests/ARTTestUtil.h
+++ b/ably-iosTests/ARTTestUtil.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSUInteger, TestAlteration) {
 // FIXME: why is `setupApp` using a callback? hard reading... could be a blocking method (only once per test)
 + (void)setupApp:(ARTClientOptions *)options cb:(void(^)(ARTClientOptions *options))cb;
 + (void)setupApp:(ARTClientOptions *)options withAlteration:(TestAlteration) alt cb:(void (^)(ARTClientOptions *))cb;
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug cb:(void (^)(ARTClientOptions *))cb;
 + (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration) alt cb:(void (^)(ARTClientOptions *))cb;
 + (float)timeout;
 

--- a/ably-iosTests/ARTTestUtil.m
+++ b/ably-iosTests/ARTTestUtil.m
@@ -131,8 +131,12 @@
     [ARTTestUtil setupApp:options withDebug:NO withAlteration:alt cb:cb];
 }
 
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug cb:(void (^)(ARTClientOptions *))cb {
+    [ARTTestUtil setupApp:options withDebug:debug withAlteration:TestAlterationNone cb:cb];
+}
+
 + (void)setupApp:(ARTClientOptions *)options cb:(void (^)(ARTClientOptions *))cb {
-    [ARTTestUtil setupApp:options withAlteration:TestAlterationNone cb:cb];
+    [ARTTestUtil setupApp:options withDebug:NO withAlteration:TestAlterationNone cb:cb];
 }
 
 + (ARTClientOptions *)clientOptions {
@@ -244,7 +248,7 @@
 
 + (void)testRealtimeV2:(XCTestCase *)testCase withDebug:(BOOL)debug callback:(ARTRealtimeTestCallback)callback {
     XCTestExpectation *expectation = [testCase expectationWithDescription:@"testRealtime"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug withAlteration:TestAlterationNone cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug cb:^(ARTClientOptions *options) {
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
             if (state == ARTRealtimeFailed) {


### PR DESCRIPTION
Tests passing:
 - [x] testAttach
 - [x] testAttachBeforeConnect
 - [x] testAttachDetach
 - [x] testAttachDetachAttach
 - [x] testSubscribeUnsubscribe
 - [x] testSuspendingDetachesChannel
 - [x] testFailingFailsChannel
 - [x] testGetChannels
 - [x] testGetSameChannelWithParams
 - [x] testAttachFails
 - [x] testDetachFails
 - [x] testPublishTooManyInArray
 - [x] testClientIdPreserved