### PR TITLE
ObjC tests: ARTRealtimePresenceTest

### DIFF
--- a/ably-ios/ARTRealtimeChannel.m
+++ b/ably-ios/ARTRealtimeChannel.m
@@ -96,7 +96,7 @@
     if (!msg.clientId) {
         msg.clientId = self.clientId;
     }
-    if(!msg.clientId) {
+    if (!msg.clientId) {
         cb([ARTStatus state:ARTStateNoClientId]);
         return;
     }

--- a/ably-ios/ARTRealtimePresence.m
+++ b/ably-ios/ARTRealtimePresence.m
@@ -24,7 +24,7 @@
     return (ARTRealtimeChannel *)super.channel;
 }
 
-- (void)get:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult *result, NSError *error))callback {
+- (void)get:(void (^)(ARTPaginatedResult *result, NSError *error))callback {
     [[self channel] throwOnDisconnectedOrFailed];
     [super get:callback];
 }

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -58,7 +58,7 @@
     if (!_realtime) {
         ARTClientOptions * options = [ARTTestUtil clientOptions];
         options.clientId = [self getClientId];
-        [ARTTestUtil setupApp:options withDebug:YES cb:^(ARTClientOptions *options) {
+        [ARTTestUtil setupApp:options cb:^(ARTClientOptions *options) {
             if (options) {
                 _realtime = [[ARTRealtime alloc] initWithOptions:options];
                 _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -759,10 +759,11 @@
 }
 
 - (void)testEnterClient {
+    NSString *clientId = @"otherClientId";
+    NSString *clientId2 = @"yetAnotherClientId";
+
     XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClient"];
-    NSString * clientId = @"otherClientId";
-    NSString * clientId2 = @"yetAnotherClientId";
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
+    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime channel:@"channelName"];
         [channel.presence  enterClient:clientId data:@"" cb:^(ARTStatus *status) {
             XCTAssertEqual(ARTStateOk, status.state);

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -826,7 +826,7 @@
             XCTAssertEqualObjects(otherClientId, message.clientId);
             if(messageCount ==0) {
                 XCTAssertEqual(message.action, ARTPresenceEnter);
-                XCTAssertEqualObjects( message.content, nil);
+                XCTAssertEqualObjects(message.content, @"");
             }
             else if(messageCount ==1) {
                 XCTAssertEqual(message.action, ARTPresenceUpdate);

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -765,9 +765,9 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClient"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime channel:@"channelName"];
-        [channel.presence  enterClient:clientId data:@"" cb:^(ARTStatus *status) {
+        [channel.presence  enterClient:clientId data:nil cb:^(ARTStatus *status) {
             XCTAssertEqual(ARTStateOk, status.state);
-            [channel.presence  enterClient:clientId2 data:@"" cb:^(ARTStatus *status) {
+            [channel.presence  enterClient:clientId2 data:nil cb:^(ARTStatus *status) {
                 XCTAssertEqual(ARTStateOk, status.state);
                 [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -58,7 +58,7 @@
     if (!_realtime) {
         ARTClientOptions * options = [ARTTestUtil clientOptions];
         options.clientId = [self getClientId];
-        [ARTTestUtil setupApp:options cb:^(ARTClientOptions *options) {
+        [ARTTestUtil setupApp:options withDebug:YES cb:^(ARTClientOptions *options) {
             if (options) {
                 _realtime = [[ARTRealtime alloc] initWithOptions:options];
                 _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -338,7 +338,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message content], presenceEnter);
-                [channel.presence update:@"" cb:^(ARTStatus *status) {
+                [channel.presence update:nil cb:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateOk, status.state);
                 }];
             }
@@ -743,12 +743,12 @@
             if(state == ARTRealtimeConnected) {
                 [realtime onDisconnected:nil];
             }
-            if(state == ARTRealtimeDisconnected) {
+            else if(state == ARTRealtimeDisconnected) {
                 hasDisconnected = true;
                 XCTAssertThrows([channel.presence get:^(ARTPaginatedResult *result, NSError *error) {}]);
                 [realtime onError:nil withErrorInfo:nil];
             }
-            if(state == ARTRealtimeFailed) {
+            else if(state == ARTRealtimeFailed) {
                 XCTAssertTrue(hasDisconnected);
                 XCTAssertThrows([channel.presence get:^(ARTPaginatedResult *result, NSError *error) {}]);
                 [exp fulfill];


### PR DESCRIPTION
Tests passing:
 - [x] testTwoConnections
 - [x] testEnterSimple
 - [x] testEnterAttachesTheChannel
 - [x] testSubscribeConnects
 - [x] testUpdateConnects
 - [x] testEnterBeforeConnect
 - [x] testEnterLeaveSimple
 - [x] testEnterEnter
 - [x] testEnterUpdateSimple
 - [x] testUpdateNull
 - [x] testEnterLeaveWithoutData
 - [x] testUpdateNoEnter
 - [x] testEnterAndGet
 - [x] testEnterNoClientId
 - [x] testEnterOnDetached
 - [x] testEnterOnFailed
 - [x] testLeaveAndGet
 - [x] testLeaveNoData
 - [x] testLeaveNoMessage
 - [x] testLeaveWithMessage
 - [x] testLeaveOnDetached
 - [x] testLeaveOnFailed
 - [x] testEnterFailsOnError
 - [x] testGetFailsOnDetachedOrFailed
 - [x] testEnterClient
 - [x] testEnterClientIdFailsOnError
 - [x] testWithNoClientIdUpdateLeaveEnterAnotherClient
 - [x] test250ClientsEnter
 - [x] testPresenceMap
 - [x] testLeaveBeforeEnterThrows
 - [x] testSubscribeToAction
 - [x] testSyncResumes
 - [x] testPresenceNoSideEffects
 - [ ] testPresenceWithData
 - [ ] testPresenceWithDataOnLeave