### PR TITLE
Travis: Freeze dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 
-osx_image: xcode6.4
+osx_image: xcode7.1
 
 before_install:
   - gem install cocoapods -v '0.39.0'

--- a/Podfile
+++ b/Podfile
@@ -1,13 +1,12 @@
-pod 'SocketRocket', '~> 0.4.1'
-#pod 'msgpack', '~> 0.1.3'
+pod 'SocketRocket', '0.4.2'
+#pod 'msgpack', '0.1.3'
 
 target 'ablySpec' do
     platform :ios, '8.0'
     use_frameworks!
 
-    pod 'Quick', '~> 0.6.0'
-    pod 'Nimble', '~> 2.0.0'
+    pod 'Quick', '0.8.0'
+    pod 'Nimble', '3.0.0'
     # Helpers
-    pod 'Runes', '~> 3.0.0'
-    pod 'SwiftyJSON', '~> 2.3.0'
+    pod 'SwiftyJSON', '2.3.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,22 +1,19 @@
 PODS:
-  - Nimble (2.0.0)
-  - Quick (0.6.0)
-  - Runes (3.0.0)
-  - SocketRocket (0.4.1)
-  - SwiftyJSON (2.3.0)
+  - Nimble (3.0.0)
+  - Quick (0.8.0)
+  - SocketRocket (0.4.2)
+  - SwiftyJSON (2.3.1)
 
 DEPENDENCIES:
-  - Nimble (~> 2.0.0)
-  - Quick (~> 0.6.0)
-  - Runes (~> 3.0.0)
-  - SocketRocket (~> 0.4.1)
-  - SwiftyJSON (~> 2.3.0)
+  - Nimble (= 3.0.0)
+  - Quick (= 0.8.0)
+  - SocketRocket (= 0.4.2)
+  - SwiftyJSON (= 2.3.1)
 
 SPEC CHECKSUMS:
-  Nimble: 472e75466819eb8c06299233e87c694a9b51328a
-  Quick: 563686dbcf0ae0f9f7401ac9cd2d786ee1b7f3d7
-  Runes: b0ffeed58b9577155e53571508b4309c904ef587
-  SocketRocket: ee0b5c34182d37bb4f1f8d628bbe737718126daa
-  SwiftyJSON: 8d6b61a70277ef2a5d710d372e06e7e2d87fb9e4
+  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
+  Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
+  SocketRocket: ffe08119b00ef982f6c37052a4705a057c8494ad
+  SwiftyJSON: 592b53bee5ef3dd9b3bebc6b9cb7ee35426ae8c3
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
Updated pods:
 - Nimble 3.0.0 (was 2.0.0)
 - Quick 0.8.0 (was 0.6.0)
 - SocketRocket 0.4.2 (was 0.4.1)
 - SwiftyJSON 2.3.1 (was 2.3.0)