### PR TITLE
Swift tests: RSC9

### DIFF
--- a/ably-ios/ARTAuth+Private.h
+++ b/ably-ios/ARTAuth+Private.h
@@ -20,6 +20,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 // CONNECTED ProtocolMessage may contain a clientId
 - (void)setProtocolClientId:(NSString *)clientId;
+- (void)setTokenDetails:(ARTAuthTokenDetails *)tokenDetails;
 
 @end
 

--- a/ably-ios/ARTAuth.m
+++ b/ably-ios/ARTAuth.m
@@ -224,9 +224,9 @@
                     callback(nil, error);
                 }
             } else {
-                _tokenDetails = tokenDetails;
+                [self setTokenDetails:tokenDetails];
                 if (callback) {
-                    callback(tokenDetails, nil);
+                    callback(self.tokenDetails, nil);
                 }
             }
         }];
@@ -260,6 +260,10 @@
 
 - (void)setProtocolClientId:(NSString *)clientId {
     _protocolClientId = clientId;
+}
+
+- (void)setTokenDetails:(ARTAuthTokenDetails *)tokenDetails {
+    _tokenDetails = tokenDetails;
 }
 
 - (NSString *)getClientId {

--- a/ablySpec/RestClient.swift
+++ b/ablySpec/RestClient.swift
@@ -222,6 +222,29 @@ class RestClient: QuickSpec {
                 }
             }
 
+            // RSC9
+            it("should use Auth to manage authentication") {
+                let options = AblyTests.commonAppSetup()
+                let auth = ARTAuth(ARTRest(options: options), withOptions: options)
+
+                expect(auth.method.rawValue).to(equal(ARTAuthMethod.Basic.rawValue))
+
+                auth.requestToken(nil, withOptions: options, callback: { tokenDetailsA, errorA in
+                    if let e = errorA {
+                        XCTFail(e.description)
+                    }
+                    options.token = tokenDetailsA?.token ?? ""
+
+                    auth.authorise(nil, options: options, force: false, callback: { tokenDetailsB, errorB in
+                        if let e = errorB {
+                            XCTFail(e.description)
+                        }
+                        // Use the same token because it is valid
+                        expect(options.token).to(equal(tokenDetailsB?.token ?? ""))
+                    })
+                })
+            }
+
         } //RestClient
     }
 }

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -172,6 +172,15 @@ func getTestToken() -> String {
     return token ?? ""
 }
 
+public func delay(seconds: NSTimeInterval, closure: ()->()) {
+    dispatch_after(
+        dispatch_time(
+            DISPATCH_TIME_NOW,
+            Int64(seconds * Double(NSEC_PER_SEC))
+        ),
+        dispatch_get_main_queue(), closure)
+}
+
 // TODO: after merge use robrix/Box
 class Box<T> {
     let unbox: T


### PR DESCRIPTION
Reference:
> (RSC9) Uses Auth to establish what authentication scheme to use, how to authenticate, and automatic issuing of tokens when necessary