### PR TITLE
Swift tests: RSC14c

### DIFF
--- a/ably-ios/ARTAuthOptions.m
+++ b/ably-ios/ARTAuthOptions.m
@@ -108,7 +108,13 @@ NSString *const ARTAuthOptionsMethodDefault = @"GET";
 }
 
 - (BOOL)isBasicAuth {
-    return self.useTokenAuth == false && self.key != nil && self.clientId == nil;
+    return self.useTokenAuth == false &&
+        self.key != nil &&
+        self.clientId == nil &&
+        self.token == nil &&
+        self.tokenDetails == nil &&
+        self.authUrl == nil &&
+        self.authCallback == nil;
 }
 
 - (BOOL)isMethodPOST {

--- a/ably-ios/ARTAuthTokenDetails.h
+++ b/ably-ios/ARTAuthTokenDetails.h
@@ -43,7 +43,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 - (instancetype)initWithToken:(NSString *)token;
-- (instancetype)initWithToken:(NSString *)token expires:(NSDate *)expires issued:(NSDate *)issued capability:(NSString *)capability clientId:(NSString *)clientId;
+- (instancetype)initWithToken:(NSString *)token expires:(art_nullable NSDate *)expires issued:(art_nullable  NSDate *)issued capability:(art_nullable  NSString *)capability clientId:(art_nullable NSString *)clientId;
 
 @end
 

--- a/ably-ios/ARTStatus.h
+++ b/ably-ios/ARTStatus.h
@@ -25,6 +25,16 @@ typedef NS_ENUM(NSUInteger, ARTState) {
     ARTStateError = 99999
 };
 
+/**
+ ARTCodeErrors
+
+ The list of all public error codes returned under the error domain ARTAblyErrorDomain
+ */
+typedef CF_ENUM(NSUInteger, ARTCodeError) {
+    // FIXME: check hard coded errors
+    ARTCodeErrorAPIKeyMissing = 80001
+};
+
 ART_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString *const ARTAblyErrorDomain;

--- a/ably-ios/ARTStatus.m
+++ b/ably-ios/ARTStatus.m
@@ -10,7 +10,8 @@
 
 #import "ARTStatus.h"
 
-NSString *const ARTAblyErrorDomain = @"ARTAblyErrorDomain";
+// Reverse-DNS style domain
+NSString *const ARTAblyErrorDomain = @"io.ably.cocoa";
 
 @implementation ARTErrorInfo
 

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -22,7 +22,8 @@
 typedef NS_ENUM(NSUInteger, ARTAuthentication) {
     ARTAuthenticationOff,
     ARTAuthenticationOn,
-    ARTAuthenticationUseBasic
+    ARTAuthenticationUseBasic,
+    ARTAuthenticationNewToken
 };
 
 typedef NS_ENUM(NSUInteger, ARTAuthMethod) {

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -49,8 +49,7 @@ class AblyTests {
 
     class var jsonRestOptions: ARTClientOptions {
         get {
-            let options = ARTClientOptions()
-            options.environment = "sandbox"
+            let options = AblyTests.clientOptions()
             options.binary = false
             return options
         }
@@ -89,7 +88,6 @@ class AblyTests {
             
             if debug {
                 print(response)
-                options.logLevel = .Verbose
             }
             
             let key = response["keys"][0]
@@ -104,6 +102,15 @@ class AblyTests {
     
     class func commonAppSetup(debug debug: Bool = false) -> ARTClientOptions {
         return AblyTests.setupOptions(AblyTests.jsonRestOptions, debug: debug)
+    }
+
+    class func clientOptions(debug debug: Bool = false) -> ARTClientOptions {
+        let options = ARTClientOptions()
+        options.environment = "sandbox"
+        if debug {
+            options.logLevel = .Verbose
+        }
+        return options
     }
     
 }
@@ -130,21 +137,33 @@ func querySyslog(forLogsAfter startingTime: NSDate? = nil) -> AnyGenerator<Strin
 
 /// Publish message class
 class PublishTestMessage {
-    var error: NSError?
-    
-    init(client: ARTRest, failOnError: Bool) {
-        self.error = NSError(domain: "", code: -1, userInfo: nil)
-        
+
+    var completion: Optional<(NSError?)->()>
+    var error: NSError? = NSError(domain: "", code: -1, userInfo: nil)
+
+    convenience init(client: ARTRest, failOnError: Bool) {
+        self.init(client: client, completion: nil)
+    }
+
+    init(client: ARTRest, completion: Optional<(NSError?)->()>) {
         client.channels.get("test").publish("message") { error in
             self.error = error
-            if failOnError {
-                XCTFail("Got error '\(error)'")
+            if let callback = completion {
+                callback(error)
+            }
+            else if let e = error {
+                XCTFail("Got error '\(e)'")
             }
         }
     }
+
 }
 
 /// Publish message
+func publishTestMessage(client: ARTRest, completion: Optional<(NSError?)->()>) -> PublishTestMessage {
+    return PublishTestMessage(client: client, completion: completion)
+}
+
 func publishTestMessage(client: ARTRest, failOnError: Bool = true) -> PublishTestMessage {
     return PublishTestMessage(client: client, failOnError: failOnError)
 }
@@ -230,7 +249,7 @@ func extractBodyAsJSON(request: NSMutableURLRequest?) -> Result<NSDictionary> {
 }
 
 /*
- Records each request for test purpose.
+ Records each request and response for test purpose.
  */
 @objc
 class MockHTTPExecutor: NSObject, ARTHTTPExecutor {
@@ -240,10 +259,16 @@ class MockHTTPExecutor: NSObject, ARTHTTPExecutor {
     var logger: ARTLog?
     
     var requests: [NSMutableURLRequest] = []
+    var responses: [NSHTTPURLResponse] = []
 
     func executeRequest(request: NSMutableURLRequest, completion callback: ARTHttpRequestCallback?) {
         self.requests.append(request)
-        self.executor.executeRequest(request, completion: callback)
+        self.executor.executeRequest(request, completion: { response, data, error in
+            if let httpResponse = response {
+                self.responses.append(httpResponse)
+            }
+            callback?(response, data, error)
+        })
     }
 }
 


### PR DESCRIPTION
 - Implemented 40140, renew token (forced)
 - Implemented ARTCodeErrors for NSError
 - Changed ARTAblyErrorDomain to use Reverse-DNS style domain
 - RSC14c with invalid authUrl