### PR TITLE
ObjC tests: TimeForwards and TimeBackwards

### DIFF
--- a/ably-iosTests/ARTRealtimeChannelHistoryTest.m
+++ b/ably-iosTests/ARTRealtimeChannelHistoryTest.m
@@ -310,8 +310,8 @@
             long long serverNow= [time timeIntervalSince1970]*1000;
             long long appNow =[ARTTestUtil nowMilli];
             timeOffset = serverNow - appNow;
+            [e fulfill];
         }];
-        [e fulfill];
     }];
     
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
@@ -389,10 +389,9 @@
             XCTAssert(!error);
             long long serverNow= [time timeIntervalSince1970]*1000;
             long long appNow =[ARTTestUtil nowMilli];
-            timeOffset = serverNow - appNow;
-            
+            timeOffset = serverNow - appNow;            
+            [e fulfill];
         }];
-        [e fulfill];
     }];
 
     

--- a/ably-iosTests/ARTRestChannelHistoryTest.m
+++ b/ably-iosTests/ARTRestChannelHistoryTest.m
@@ -48,8 +48,8 @@
             long long serverNow = [time timeIntervalSince1970]*1000;
             long long appNow =[ARTTestUtil nowMilli];
             timeOffset = serverNow - appNow;
+            [e fulfill];
         }];
-        [e fulfill];
     }];
     
     
@@ -127,12 +127,12 @@
    [ARTTestUtil testRest:^(ARTRest *rest) {
        _rest = rest;
        [rest time:^(NSDate *time, NSError *error) {
-            XCTAssert(!error);
-            long long serverNow = [time timeIntervalSince1970]*1000;
-            long long appNow =[ARTTestUtil nowMilli];
-            timeOffset = serverNow - appNow;
+           XCTAssert(!error);
+           long long serverNow = [time timeIntervalSince1970]*1000;
+           long long appNow =[ARTTestUtil nowMilli];
+           timeOffset = serverNow - appNow;
+           [e fulfill];
        }];
-       [e fulfill];
     }];
 
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];


### PR DESCRIPTION
Sometimes it was working, sometimes not.
The `XCTestExpectation.fulfill` was misplaced.