### PR TITLE
Replace ?-chains with force-unwraps.

### DIFF
--- a/ablySpec/Auth.swift
+++ b/ablySpec/Auth.swift
@@ -53,10 +53,10 @@ class Auth : QuickSpec {
                 }
 
                 let key64 = NSString(string: "\(client.options.key!)")
-                    .dataUsingEncoding(NSUTF8StringEncoding)?
+                    .dataUsingEncoding(NSUTF8StringEncoding)!
                     .base64EncodedStringWithOptions(NSDataBase64EncodingOptions(rawValue: 0))
                                 
-                let expectedAuthorization = "Basic \(key64!)"
+                let expectedAuthorization = "Basic \(key64)"
                 
                 expect(mockExecutor.requests.first).toNot(beNil(), description: "No request found")
                 


### PR DESCRIPTION
There is some abuse of ?-chaining in the test code. If we expect a
thing to be there and if not being that the case would mean that
test code (e. g. a helper) is wrong, force-unwrap should be used
instead of silently ignoring this condition with a ?-chain so that
the error is caught from the test framework. The test framework
should only tell us about the code being tested, not about the
code that tests the code being tested.