### PR TITLE
Don't use if-let to unwrap when it is sure that it will succeed.

### DIFF
--- a/ablySpec/RestClient.swift
+++ b/ablySpec/RestClient.swift
@@ -227,11 +227,11 @@ class RestClient: QuickSpec {
                     }
                 }
 
-                if let requestUrlA = mockExecutor.requests.first?.URL,
-                    let requestUrlB = mockExecutor.requests.last?.URL {
-                        expect(requestUrlA.scheme).to(equal("https"))
-                        expect(requestUrlB.scheme).to(equal("http"))
-                }
+                let requestUrlA = mockExecutor.requests.first!.URL!
+                expect(requestUrlA.scheme).to(equal("https"))
+
+                let requestUrlB = mockExecutor.requests.last!.URL!
+                expect(requestUrlB.scheme).to(equal("http"))
             }
 
             // RSC9


### PR DESCRIPTION
Force-unwrap with `!` instead. Otherwise, if the if-let fails to
unwrap the optional, it will be silently ignored. `!` crashes the
program at least, so that we know that we have something wrong
in the test code.