### PR TITLE
Properly annotate ARTConnection.id, ARTConnection.key as optional.

### DIFF
--- a/ably-ios/ARTConnection.h
+++ b/ably-ios/ARTConnection.h
@@ -17,8 +17,8 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTConnection: NSObject
 
-@property (readonly, getter=getId) NSString *id;
-@property (readonly, getter=getKey) NSString *key;
+@property (art_nullable, readonly, getter=getId) NSString *id;
+@property (art_nullable, readonly, getter=getKey) NSString *key;
 @property (readonly, getter=getSerial) int64_t serial;
 @property (readonly, getter=getState) ARTRealtimeConnectionState state;
 @property (readonly, getter=getEventEmitter) ARTEventEmitter *eventEmitter;

--- a/ably-ios/ARTRealtime.h
+++ b/ably-ios/ARTRealtime.h
@@ -57,8 +57,8 @@ Instance the Ably library with the given options.
 - (BOOL)isActive;
 
 - (ARTRealtimeConnectionState)state;
-- (NSString *)connectionId;
-- (NSString *)connectionKey;
+- (art_nullable NSString *)connectionId;
+- (art_nullable NSString *)connectionKey;
 - (NSString *)recoveryKey;
 - (ARTAuth *)auth;
 - (__GENERIC(NSDictionary, NSString *, ARTRealtimeChannel *) *)channels;

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -47,8 +47,8 @@
 @property (readwrite, assign, nonatomic) CFRunLoopTimerRef closeTimeout;
 @property (readwrite, assign, nonatomic) CFRunLoopTimerRef pingTimeout;
 
-@property (readwrite, strong, nonatomic) NSString *connectionId;
-@property (readwrite, strong, nonatomic) NSString *connectionKey; //for recovery
+@property (readwrite, strong, nonatomic, art_nullable) NSString *connectionId;
+@property (readwrite, strong, nonatomic, art_nullable) NSString *connectionKey; //for recovery
 @property (readwrite, assign, nonatomic) int64_t connectionSerial;
 
 /// Current protocol `msgSerial`. Starts at zero.

--- a/ablySpec/RealtimeClient.connection.swift
+++ b/ablySpec/RealtimeClient.connection.swift
@@ -603,16 +603,17 @@ class RealtimeClientConnection: QuickSpec {
                     let client = ARTRealtime(options: options)
                     let connection = client.connection()
 
-                    expect(connection.id).to(beEmpty())
+                    expect(connection.id).to(beNil())
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.eventEmitter.on { state, errorInfo in
-                            if state == .Connected && errorInfo == nil {
-                                expect(connection.id).toNot(beEmpty())
+                            expect(errorInfo).to(beNil())
+                            if state == .Connected {
+                                expect(connection.id).toNot(beNil())
                                 done()
                             }
                             else if state == .Connecting {
-                                expect(connection.id).to(beEmpty())
+                                expect(connection.id).to(beNil())
                             }
                         }
                     }
@@ -630,13 +631,18 @@ class RealtimeClientConnection: QuickSpec {
                     waitUntil(timeout: testTimeout) { done in
                         for _ in 1...max {
                             disposable.append(ARTRealtime(options: options))
-                            let currentConnection = disposable.last?.connection()
-                            currentConnection?.eventEmitter.on { state, errorInfo in
+                            let currentConnection = disposable.last!.connection()
+                            currentConnection.eventEmitter.on { state, errorInfo in
                                 if state == .Connected {
-                                    expect(ids).toNot(contain(currentConnection?.id))
-                                    ids.append(currentConnection?.id ?? "")
+                                    guard let connectionId = currentConnection.id else {
+                                        fail("connectionId is nil on CONNECTED")
+                                        done()
+                                        return
+                                    }
+                                    expect(ids).toNot(contain(connectionId))
+                                    ids.append(connectionId)
 
-                                    currentConnection?.close()
+                                    currentConnection.close()
                                     
                                     if ids.count == max {
                                         done()
@@ -659,16 +665,17 @@ class RealtimeClientConnection: QuickSpec {
                     let client = ARTRealtime(options: options)
                     let connection = client.connection()
 
-                    expect(connection.key).to(beEmpty())
+                    expect(connection.key).to(beNil())
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.eventEmitter.on { state, errorInfo in
-                            if state == .Connected && errorInfo == nil {
-                                expect(connection.key).toNot(beEmpty())
+                            expect(errorInfo).to(beNil())
+                            if state == .Connected {
+                                expect(connection.id).toNot(beNil())
                                 done()
                             }
                             else if state == .Connecting {
-                                expect(connection.key).to(beEmpty())
+                                expect(connection.key).to(beNil())
                             }
                         }
                     }
@@ -684,13 +691,18 @@ class RealtimeClientConnection: QuickSpec {
                     waitUntil(timeout: testTimeout) { done in
                         for _ in 1...max {
                             disposable.append(ARTRealtime(options: options))
-                            let currentConnection = disposable.last?.connection()
-                            currentConnection?.eventEmitter.on { state, errorInfo in
+                            let currentConnection = disposable.last!.connection()
+                            currentConnection.eventEmitter.on { state, errorInfo in
                                 if state == .Connected {
-                                    expect(keys).toNot(contain(currentConnection?.key))
-                                    keys.append(currentConnection?.key ?? "")
+                                    guard let connectionKey = currentConnection.key else {
+                                        fail("connectionKey is nil on CONNECTED")
+                                        done()
+                                        return
+                                    }
+                                    expect(keys).toNot(contain(connectionKey))
+                                    keys.append(connectionKey)
 
-                                    currentConnection?.close()
+                                    currentConnection.close()
 
                                     if keys.count == max {
                                         done()

--- a/ablySpec/RealtimeClient.swift
+++ b/ablySpec/RealtimeClient.swift
@@ -83,7 +83,7 @@ class RealtimeClient: QuickSpec {
                                 done()
                             case .Connected:
                                 self.checkError(errorInfo)
-                                expect(client.recoveryKey()).to(equal("\(client.connectionKey()):\(client.connectionSerial())"), description: "recoveryKey wrong formed")
+                                expect(client.recoveryKey()).to(equal("\(client.connectionKey() ?? ""):\(client.connectionSerial())"), description: "recoveryKey wrong formed")
                                 options.recover = client.recoveryKey()
                                 done()
                             default:


### PR DESCRIPTION
RTN8a and RTN9a require them to be nullable.