### PR TITLE
Temporarily disable RestClientStats tests.

### DIFF
--- a/ablySpec/RestClient.stats.swift
+++ b/ablySpec/RestClient.stats.swift
@@ -87,10 +87,9 @@ class RestClientStats: QuickSpec {
     override func spec() {
         describe("RestClient") {
             // RSC6
-            context("stats") {
+            pending("stats") {
                 // Temporarily disabled until #https://github.com/ably/ably-ios/issues/142
                 // is figured out.
-                return
 
                 // RSC6a
                 context("result") {

--- a/ablySpec/RestClient.stats.swift
+++ b/ablySpec/RestClient.stats.swift
@@ -88,6 +88,10 @@ class RestClientStats: QuickSpec {
         describe("RestClient") {
             // RSC6
             context("stats") {
+                // Temporarily disabled until #https://github.com/ably/ably-ios/issues/142
+                // is figured out.
+                return
+
                 // RSC6a
                 context("result") {
                     let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)!


### PR DESCRIPTION
Until #142 is addressed, to avoid blocking the test suite.