### PR TITLE
Test that getting the same channel name gives the same instance.

### DIFF
--- a/ablySpec/RestClient.channels.swift
+++ b/ablySpec/RestClient.channels.swift
@@ -50,6 +50,9 @@ class RestClientChannels: QuickSpec {
                     it("should return a channel") {
                         let channel = client.channels.get(channelName)
                         expect(channel).to(beAChannel(named: channelName))
+
+                        let sameChannel = client.channels.get(channelName)
+                        expect(sameChannel).to(beIdenticalTo(channel))
                     }
 
                     // RSN3b


### PR DESCRIPTION
As specified by [RSN3a](http://docs.ably.io/client-lib-development-guide/features/#RSN3a).