### PR TITLE
RTL4: Fix test that was doing nothing.

### DIFF
--- a/ably-iosTests/ARTRealtimeAttachTest.m
+++ b/ably-iosTests/ARTRealtimeAttachTest.m
@@ -51,19 +51,24 @@
 
                 __block bool hasAttached = false;
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
-                    XCTAssertEqual(ARTStateOk, reason.state);
                     if(state == ARTRealtimeChannelAttaching) {
+                        XCTAssertEqual(ARTStateOk, reason.state);
                         [channel attach];
                     }
                     if (state == ARTRealtimeChannelAttached) {
+                        XCTAssertEqual(ARTStateOk, reason.state);
                         [channel attach];
                         
                         if(!hasAttached) {
-                            [expectation fulfill];
+                            hasAttached = true;
+                            [channel detach];
                         }
                         else {
                             XCTFail(@"duplicate call to attach shouldnt happen");
                         }
+                    }
+                    if (state == ARTRealtimeChannelDetached) {
+                        [expectation fulfill];
                     }
                 }];
                 [channel attach];


### PR DESCRIPTION
hasAttached was never being written. Also, now expectation is
fullfilled when the channel is closed so that the no-op
`[channel attach]` calls can have an observable effect if they're
wrong, ie. if they transition again to ATTACHED.