### PR TITLE
Make ARTPaginatedResult generic.

### DIFF
--- a/ably-ios/ARTChannel.h
+++ b/ably-ios/ARTChannel.h
@@ -13,7 +13,7 @@
 
 @class ARTChannelOptions;
 @class ARTMessage;
-@class ARTPaginatedResult;
+@class __GENERIC(ARTPaginatedResult, ItemType);
 @class ARTDataQuery;
 
 ART_ASSUME_NONNULL_BEGIN
@@ -32,7 +32,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)publishMessage:(ARTMessage *)message callback:(art_nullable ARTErrorCallback)callback;
 - (void)publishMessages:(__GENERIC(NSArray, ARTMessage *) *)messages callback:(art_nullable ARTErrorCallback)callback;
 
-- (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void(^)(ARTPaginatedResult /* <ARTMessage *> */ *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
+- (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *)  *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @end
 

--- a/ably-ios/ARTChannel.m
+++ b/ably-ios/ARTChannel.m
@@ -54,7 +54,7 @@
     [self internalPostMessages:[message encode:self.payloadEncoder] callback:callback];
 }
 
-- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult *, NSError *))callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback error:(NSError **)errorPtr {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
     return NO;
 }

--- a/ably-ios/ARTPaginatedResult+Private.h
+++ b/ably-ios/ARTPaginatedResult+Private.h
@@ -12,9 +12,9 @@
 
 ART_ASSUME_NONNULL_BEGIN
 
-@interface ARTPaginatedResult ()
+@interface __GENERIC(ARTPaginatedResult, ItemType) ()
 
-typedef NSArray *__art_nullable(^ARTPaginatedResultResponseProcessor)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable);
+typedef __GENERIC(NSArray, ItemType) *__art_nullable(^ARTPaginatedResultResponseProcessor)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable);
 
 + (void)executePaginated:(ARTRest *)rest withRequest:(NSMutableURLRequest *)request
               andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor

--- a/ably-ios/ARTPaginatedResult.h
+++ b/ably-ios/ARTPaginatedResult.h
@@ -12,12 +12,12 @@
 
 ART_ASSUME_NONNULL_BEGIN
 
-@interface ARTPaginatedResult : NSObject
+@interface __GENERIC(ARTPaginatedResult, ItemType) : NSObject
 
 // FIXME: review with Stats callback
-typedef void(^ARTPaginatedResultCallback)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error);
+typedef void(^ARTPaginatedResultCallback)(__GENERIC(ARTPaginatedResult, ItemType) *__art_nullable result, NSError *__art_nullable error);
 
-@property (nonatomic, strong, readonly) NSArray *items;
+@property (nonatomic, strong, readonly) __GENERIC(NSArray, ItemType) *items;
 
 @property (nonatomic, readonly) BOOL hasFirst;
 @property (nonatomic, readonly) BOOL hasCurrent;

--- a/ably-ios/ARTPresence.h
+++ b/ably-ios/ARTPresence.h
@@ -13,7 +13,7 @@
 @protocol ARTSubscription;
 
 @class ARTChannel;
-@class ARTPaginatedResult;
+@class __GENERIC(ARTPaginatedResult, ItemType);
 @class ARTDataQuery;
 
 ART_ASSUME_NONNULL_BEGIN
@@ -30,12 +30,12 @@ ART_ASSUME_NONNULL_BEGIN
 /**
  Get the presence state for one channel
  */
-- (void)get:(void (^)(ARTPaginatedResult /* <ARTPresenceMessage *> */ *__art_nullable result, NSError *__art_nullable error))callback;
+- (void)get:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
 
 /**
  Obtain recent presence history for one channel
  */
-- (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult /* <ARTPresenceMessage *> */ *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
+- (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @end
 

--- a/ably-ios/ARTPresence.m
+++ b/ably-ios/ARTPresence.m
@@ -29,11 +29,11 @@
     return _channel;
 }
 
-- (void)get:(void (^)(ARTPaginatedResult /* <ARTPresenceMessage *> */ *result, NSError *error))callback {
+- (void)get:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
 }
 
-- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult /* <ARTPresenceMessage *> */ *result, NSError *error))callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback error:(NSError **)errorPtr {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
     return NO;
 }

--- a/ably-ios/ARTRealtime.h
+++ b/ably-ios/ARTRealtime.h
@@ -16,7 +16,6 @@
 @class ARTStatsQuery;
 @class ARTRealtimeChannel;
 @class ARTPresenceMessage;
-@class ARTPaginatedResult;
 @class ARTErrorInfo;
 @class ARTCipherParams;
 @class ARTPresence;

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -243,7 +243,7 @@
     [self.transport sendPing];
 }
 
-- (BOOL)stats:(ARTStatsQuery *)query callback:(void (^)(ARTPaginatedResult *result, NSError *error))completion error:(NSError **)errorPtr {
+- (BOOL)stats:(ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *result, NSError *error))completion error:(NSError **)errorPtr {
     return [self.rest stats:query callback:completion error:errorPtr];
 }
 

--- a/ably-ios/ARTRealtimeChannel.h
+++ b/ably-ios/ARTRealtimeChannel.h
@@ -19,7 +19,6 @@
 @class ARTRealtimePresence;
 @class ARTPresenceMap;
 @class ARTMessage;
-@class ARTPaginatedResult;
 @class ARTProtocolMessage;
 @class ARTRealtimeChannelSubscription;
 @class ARTRealtimeChannelStateSubscription;

--- a/ably-ios/ARTRealtimePresence.m
+++ b/ably-ios/ARTRealtimePresence.m
@@ -24,12 +24,12 @@
     return (ARTRealtimeChannel *)super.channel;
 }
 
-- (void)get:(void (^)(ARTPaginatedResult *result, NSError *error))callback {
+- (void)get:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback {
     [[self channel] throwOnDisconnectedOrFailed];
     [super get:callback];
 }
 
-- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult *result, NSError *error))callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback error:(NSError **)errorPtr {
     [[self channel] throwOnDisconnectedOrFailed];
     return [super history:query callback:callback error:errorPtr];
 }

--- a/ably-ios/ARTRest.h
+++ b/ably-ios/ARTRest.h
@@ -16,7 +16,6 @@
 @class ARTClientOptions;
 @class ARTAuth;
 @class ARTCancellable;
-@class ARTPaginatedResult;
 @class ARTStatsQuery;
 
 ART_ASSUME_NONNULL_BEGIN

--- a/ably-ios/ARTRest.m
+++ b/ably-ios/ARTRest.m
@@ -212,7 +212,7 @@
     return nil;
 }
 
-- (BOOL)stats:(ARTStatsQuery *)query callback:(void (^)(ARTPaginatedResult *, NSError *))callback error:(NSError **)errorPtr {
+- (BOOL)stats:(ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *, NSError *))callback error:(NSError **)errorPtr {
     if (query.limit > 1000) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain

--- a/ably-ios/ARTRestPresence.m
+++ b/ably-ios/ARTRestPresence.m
@@ -26,7 +26,7 @@
     return (ARTRestChannel *)super.channel;
 }
 
-- (void)get:(void (^)(ARTPaginatedResult /* <ARTPresenceMessage *> */ *result, NSError *error))callback {
+- (void)get:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback {
     NSURL *requestUrl = [NSURL URLWithString:[[self channel].basePath stringByAppendingPathComponent:@"presence"]];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl];
 
@@ -41,7 +41,7 @@
     [ARTPaginatedResult executePaginated:[self channel].rest withRequest:request andResponseProcessor:responseProcessor callback:callback];
 }
 
-- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult /* <ARTPresenceMessage *> */ *result, NSError *error))callback error:(NSError **)errorPtr {
+- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback error:(NSError **)errorPtr {
     if (query.limit > 1000) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -17,7 +17,8 @@
 @class ARTAuthTokenParams;
 @class ARTAuthTokenRequest;
 @class ARTAuthTokenDetails;
-@class ARTPaginatedResult;
+@class __GENERIC(ARTPaginatedResult, ItemType);
+@class ARTStats;
 
 typedef NS_ENUM(NSUInteger, ARTAuthentication) {
     ARTAuthenticationOff,
@@ -90,7 +91,7 @@ typedef void (^ARTErrorCallback)(NSError *__art_nullable error);
 
 typedef void (^ARTHttpRequestCallback)(NSHTTPURLResponse *__art_nullable response, NSData *__art_nullable data, NSError *__art_nullable error);
 
-typedef void (^ARTStatsCallback)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error);
+typedef void (^ARTStatsCallback)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable result, NSError *__art_nullable error);
 
 typedef void (^ARTTimeCallback)(NSDate *__art_nullable time, NSError *__art_nullable error);
 


### PR DESCRIPTION
At first I thought this would help to write test code, as Xcode would help with autocomplete. Turns out that Swift ignores generics, except for Foundation collections. Anyway, it's done, and Objective-C clients can benefit from them.