### PR TITLE
RTN12b

### DIFF
--- a/ablySpec/RealtimeClient.connection.swift
+++ b/ablySpec/RealtimeClient.connection.swift
@@ -888,7 +888,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 // RTN12b
-                it("should transition to CLOSED action when the close process timeouts") {
+                pending("should transition to CLOSED action when the close process timeouts") {
                     let options = AblyTests.commonAppSetup()
                     options.autoConnect = false
                     let client = ARTRealtime(options: options)

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -398,6 +398,8 @@ class TestProxyTransport: ARTWebSocketTransport {
     private(set) var protocolMessagesSent = [ARTProtocolMessage]()
     private(set) var protocolMessagesReceived = [ARTProtocolMessage]()
 
+    var actionsIgnored = [ARTProtocolMessageAction]()
+
     override func setupWebSocket(params: [NSURLQueryItem], withOptions options: ARTClientOptions) -> NSURL {
         let url = super.setupWebSocket(params, withOptions: options)
         lastUrl = url
@@ -411,6 +413,9 @@ class TestProxyTransport: ARTWebSocketTransport {
 
     override func receive(msg: ARTProtocolMessage) {
         protocolMessagesReceived.append(msg)
+        if actionsIgnored.contains(msg.action) {
+            return
+        }
         super.receive(msg)
     }
 


### PR DESCRIPTION
Not passing. The `realtimeRequestTimeout` is not used, so... feature not implemented.