### PR TITLE
RSC10, RSC14c: Adapt to new spec, 40140 -> [40140, 40150).

### DIFF
--- a/ably-ios/ARTRest.m
+++ b/ably-ios/ARTRest.m
@@ -142,7 +142,7 @@
     [self.httpExecutor executeRequest:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode >= 400) {
             NSError *dataError = [self->_encoders[response.MIMEType] decodeError:data];
-            if (dataError.code == 40140) {
+            if (dataError.code >= 40140 && dataError.code < 40150) {
                 // Send it again, requesting a new token (forward callback)
                 [self.logger debug:__FILE__ line:__LINE__ message:@"requesting new token"];
                 [self executeRequest:request withAuthOption:ARTAuthenticationNewToken completion:callback];

--- a/ablySpec/RestClient.swift
+++ b/ablySpec/RestClient.swift
@@ -352,9 +352,14 @@ class RestClient: QuickSpec {
 
                         // Delay for token expiration
                         delay(tokenParams.ttl) {
-                            // 40140 - token expired and will not recover because authUrl is invalid
+                            // [40140, 40150) - token expired and will not recover because authUrl is invalid
                             publishTestMessage(rest) { error in
-                                expect(mockExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String).to(equal("40140"))
+                                guard let errorCode = mockExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
+                                    fail("expected X-Ably-ErrorCode header in request")
+                                    return
+                                }
+                                expect(Int(errorCode)).to(beGreaterThanOrEqualTo(40140))
+                                expect(Int(errorCode)).to(beLessThan(40150))
                                 expect(error).toNot(beNil())
                                 done()
                             }
@@ -396,9 +401,14 @@ class RestClient: QuickSpec {
 
                         // Delay for token expiration
                         delay(tokenParams.ttl) {
-                            // 40140 - token expired and will resend the request
+                            // [40140, 40150) - token expired and will not recover because authUrl is invalid
                             publishTestMessage(rest) { error in
-                                expect(mockExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String).to(equal("40140"))
+                                guard let errorCode = mockExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
+                                    fail("expected X-Ably-ErrorCode header in request")
+                                    return
+                                }
+                                expect(Int(errorCode)).to(beGreaterThanOrEqualTo(40140))
+                                expect(Int(errorCode)).to(beLessThan(40150))
                                 expect(error).to(beNil())
                                 expect(rest.auth.tokenDetails!.token).toNot(equal(currentTokenDetails.token))
                                 done()


### PR DESCRIPTION
https://github.com/ably/docs/commit/b628023b83aca480464d55e4260e21ee20690d7a

Because the CI is currently pretty much useless, I'll leave this here:

<img width="216" alt="captura de pantalla 2016-01-22 a les 18 24 29" src="https://cloud.githubusercontent.com/assets/727422/12517879/751e8bbc-c135-11e5-910a-d79019351b7d.png">
