### PR TITLE
Test suite websocket

### DIFF
--- a/ably-ios/ARTRealtime+Private.h
+++ b/ably-ios/ARTRealtime+Private.h
@@ -26,13 +26,13 @@ ART_ASSUME_NONNULL_BEGIN
 
 // Transport Events
 - (void)onHeartbeat;
-- (void)onConnected:(ARTProtocolMessage *)message withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
+- (void)onConnected:(ARTProtocolMessage *)message;
 - (void)onDisconnected;
 - (void)onSuspended;
-- (void)onError:(ARTProtocolMessage *)message withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
+- (void)onError:(ARTProtocolMessage *)message;
 - (void)onAck:(ARTProtocolMessage *)message;
 - (void)onNack:(ARTProtocolMessage *)message;
-- (void)onChannelMessage:(ARTProtocolMessage *)message withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
+- (void)onChannelMessage:(ARTProtocolMessage *)message;
 
 - (int64_t)connectionSerial;
 

--- a/ably-ios/ARTRealtime+Private.h
+++ b/ably-ios/ARTRealtime+Private.h
@@ -25,15 +25,14 @@ ART_ASSUME_NONNULL_BEGIN
 @property (readonly, strong, nonatomic) NSMutableArray *stateSubscriptions;
 
 // Transport Events
-- (void)onHeartbeat:(ARTProtocolMessage *)message;
+- (void)onHeartbeat;
 - (void)onConnected:(ARTProtocolMessage *)message withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
-- (void)onDisconnected:(ARTProtocolMessage *)message;
+- (void)onDisconnected;
+- (void)onSuspended;
 - (void)onError:(ARTProtocolMessage *)message withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
 - (void)onAck:(ARTProtocolMessage *)message;
 - (void)onNack:(ARTProtocolMessage *)message;
 - (void)onChannelMessage:(ARTProtocolMessage *)message withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
-
-- (void)onSuspended;
 
 - (int64_t)connectionSerial;
 

--- a/ably-ios/ARTRealtime+Private.h
+++ b/ably-ios/ARTRealtime+Private.h
@@ -36,9 +36,6 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (int64_t)connectionSerial;
 
-- (void)transition:(ARTRealtimeConnectionState)state;
-- (void)transition:(ARTRealtimeConnectionState)state withErrorInfo:(art_nullable ARTErrorInfo *)errorInfo;
-
 // FIXME: Connection should manage the transport
 - (void)setTransportClass:(Class)transportClass;
 - (ARTConnection *)connection;

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -461,15 +461,15 @@
     }
 }
 
-- (void)onConnected:(ARTProtocolMessage *)message withErrorInfo:(ARTErrorInfo *)errorInfo {
+- (void)onConnected:(ARTProtocolMessage *)message {
     // Resuming
     if ([self isFromResume]) {
-        if (errorInfo && ![message.connectionId isEqualToString:self.connectionId]) {
+        if (message.error && ![message.connectionId isEqualToString:self.connectionId]) {
             [self.logger warn:@"ARTRealtime: connection has reconnected, but resume failed. Detaching all channels"];
             // Fatal error, detach all channels
             for (NSString *channelName in self.allChannels) {
                 ARTRealtimeChannel *channel = [self.allChannels objectForKey:channelName];
-                [channel detachChannel:[ARTStatus state:ARTStateConnectionDisconnected info:errorInfo]];
+                [channel detachChannel:[ARTStatus state:ARTStateConnectionDisconnected info:message.error]];
             }
 
             self.options.resumeKey = nil;
@@ -481,8 +481,8 @@
                 }
             }
         }
-        else if (errorInfo) {
-            [self.logger warn:@"ARTRealtime: connection has resumed with non-fatal error %@", errorInfo.message];
+        else if (message.error) {
+            [self.logger warn:@"ARTRealtime: connection has resumed with non-fatal error %@", message.error.message];
             // The error will be emitted on `transition`
         }
     }
@@ -496,7 +496,7 @@
                 self.msgSerial = 0;
                 self.pendingMessageStartSerial = 0;
             }
-            [self transition:ARTRealtimeConnected withErrorInfo:errorInfo];
+            [self transition:ARTRealtimeConnected withErrorInfo:message.error];
             break;
         default:
             NSAssert(false, @"Invalid Realtime state: expected Connecting has current state");
@@ -525,13 +525,13 @@
     }
 }
 
-- (void)onError:(ARTProtocolMessage *)message withErrorInfo:(ARTErrorInfo *)errorInfo {
+- (void)onError:(ARTProtocolMessage *)message {
     // TODO work out which states this can be received in
     if (message.channel) {
-        [self onChannelMessage:message withErrorInfo:errorInfo];
+        [self onChannelMessage:message];
     } else {
         self.connectionId = nil;
-        [self transition:ARTRealtimeFailed withErrorInfo:errorInfo];
+        [self transition:ARTRealtimeFailed withErrorInfo:message.error];
     }
 }
 
@@ -543,7 +543,7 @@
     [self nack:message];
 }
 
-- (void)onChannelMessage:(ARTProtocolMessage *)message withErrorInfo:(ARTErrorInfo *)errorInfo {
+- (void)onChannelMessage:(ARTProtocolMessage *)message {
     // TODO work out which states this can be received in / error info?
     ARTRealtimeChannel *channel = [self.allChannels objectForKey:message.channel];
     [channel onChannelMessage:message];
@@ -807,13 +807,13 @@
             [self onHeartbeat];
             break;
         case ARTProtocolMessageError:
-            [self onError:message withErrorInfo:message.error];
+            [self onError:message];
             break;
         case ARTProtocolMessageConnected:
             // Set Auth#clientId
             [[self auth] setProtocolClientId:message.clientId];
             // Event
-            [self onConnected:message withErrorInfo:message.error];
+            [self onConnected:message];
             break;
         case ARTProtocolMessageDisconnected:
             [self onDisconnected];
@@ -828,7 +828,7 @@
             [self transition:ARTRealtimeClosed];
             break;
         default:
-            [self onChannelMessage:message withErrorInfo:message.error];
+            [self onChannelMessage:message];
             break;
     }
 }

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -517,7 +517,6 @@
     switch (self.state) {
         case ARTRealtimeConnected:
             self.connectionId = nil;
-            self.msgSerial = 0;
             [self transition:ARTRealtimeDisconnected];
             break;
         default:

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -446,7 +446,7 @@
     self.pingTimeout = nil;
 }
 
-- (void)onHeartbeat:(ARTProtocolMessage *)message {
+- (void)onHeartbeat {
     [self.logger verbose:@"ARTRealtime heartbeat received"];
     if(self.pingCb) {
         [self cancelPingTimer];
@@ -512,7 +512,7 @@
     return _connectionId;
 }
 
-- (void)onDisconnected:(ARTProtocolMessage *)message {
+- (void)onDisconnected {
     [self.logger info:@"ARTRealtime disconnected"];
     switch (self.state) {
         case ARTRealtimeConnected:
@@ -805,7 +805,7 @@
 
     switch (message.action) {
         case ARTProtocolMessageHeartbeat:
-            [self onHeartbeat:message];
+            [self onHeartbeat];
             break;
         case ARTProtocolMessageError:
             [self onError:message withErrorInfo:message.error];
@@ -817,7 +817,7 @@
             [self onConnected:message withErrorInfo:message.error];
             break;
         case ARTProtocolMessageDisconnected:
-            [self onDisconnected:message];
+            [self onDisconnected];
             break;
         case ARTProtocolMessageAck:
             [self onAck:message];

--- a/ably-iosTests/ARTRealtimeAttachTest.m
+++ b/ably-iosTests/ARTRealtimeAttachTest.m
@@ -257,7 +257,7 @@
                     if (state == ARTRealtimeChannelAttached) {
                         if(!hasFailed) {
                             XCTAssertEqual(ARTStateOk, reason.state);
-                            [realtime onError:nil withErrorInfo:nil];
+                            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                         }
                     }
                     else if(state == ARTRealtimeChannelFailed) {
@@ -306,7 +306,7 @@
         ARTRealtimeChannel *channel1 = [realtime channel:@"channel"];
         [channel1 subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
             if (state == ARTRealtimeChannelAttaching) {
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             else {
                 XCTAssertEqual(ARTRealtimeChannelFailed, state);
@@ -325,7 +325,7 @@
         ARTRealtimeChannel *channel1 = [realtime channel:@"channel"];
         [channel1 subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
             if (state == ARTRealtimeChannelAttached) {
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             else if(state != ARTRealtimeChannelAttaching) {
                 XCTAssertEqual(ARTRealtimeChannelFailed, state);

--- a/ably-iosTests/ARTRealtimeChannelTest.m
+++ b/ably-iosTests/ARTRealtimeChannelTest.m
@@ -211,7 +211,7 @@
         ARTRealtimeChannel *channel = [realtime channel:@"channel"];
         [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
             if(state == ARTRealtimeChannelAttached) {
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             else if(state == ARTRealtimeChannelFailed) {
                 [channel publish:@"will_fail" cb:^(ARTStatus *status) {
@@ -297,8 +297,7 @@
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
                     if (state == ARTRealtimeChannelAttached) {
-                        // FIXME: create proper methods to transition each state.
-                        [realtime onError:nil withErrorInfo:nil];
+                        [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                     }
                 }];
                 [channel attach];
@@ -324,7 +323,7 @@
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
                     if (state == ARTRealtimeChannelAttached) {
-                        [realtime onError:nil withErrorInfo:nil];
+                        [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                     }
                 }];
                 [channel attach];

--- a/ably-iosTests/ARTRealtimeConnectTest.m
+++ b/ably-iosTests/ARTRealtimeConnectTest.m
@@ -219,7 +219,7 @@
                     [realtime close];
                 }
                 else {
-                    [realtime onDisconnected:nil];
+                    [realtime onDisconnected];
                 }
             }
             else if(state == ARTRealtimeDisconnected) {
@@ -228,7 +228,7 @@
             }
             else if(state == ARTRealtimeSuspended) {
                 gotSuspended = true;
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             else if(state == ARTRealtimeClosing) {
                 gotClosing = true;
@@ -268,7 +268,7 @@
             if(state == ARTRealtimeClosed) {
                 hasClosed = true;
                 XCTAssertThrows([realtime ping:^(ARTStatus *s) {}]);
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             if(state == ARTRealtimeFailed) {
                 XCTAssertTrue(hasClosed);

--- a/ably-iosTests/ARTRealtimeMessageTest.m
+++ b/ably-iosTests/ARTRealtimeMessageTest.m
@@ -271,7 +271,7 @@
                     connectingHappened = true;
                     [channel publish:connectingMessage cb:^(ARTStatus *status) {
                         XCTAssertEqual(ARTStateOk, status.state);
-                        [realtime onDisconnected:nil];
+                        [realtime onDisconnected];
                     }];
                 }
             }

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -755,7 +755,7 @@
         ARTRealtimeChannel *channel = [realtime channel:channelName];
         [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
             if(state == ARTRealtimeConnected) {
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                 [channel.presence enter:presenceEnter cb:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateError, status.state);
                     [exp fulfill];
@@ -774,12 +774,12 @@
         __block bool hasDisconnected = false;
         [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
             if(state == ARTRealtimeConnected) {
-                [realtime onDisconnected:nil];
+                [realtime onDisconnected];
             }
             else if(state == ARTRealtimeDisconnected) {
                 hasDisconnected = true;
                 XCTAssertThrows([channel.presence get:^(ARTPaginatedResult *result, NSError *error) {}]);
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             else if(state == ARTRealtimeFailed) {
                 XCTAssertTrue(hasDisconnected);
@@ -825,7 +825,7 @@
         ARTRealtimeChannel *channel = [realtime channel:@"channelName"];
         [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
             if(state == ARTRealtimeConnected) {
-                [realtime onError:nil withErrorInfo:nil];
+                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                 [channel.presence  enterClient:@"clientId" data:@"" cb:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateError, status.state);
                     [exp fulfill];
@@ -1115,7 +1115,7 @@
                         if(!firstSyncMessageReceived) {
                             XCTAssertFalse([channel2.presenceMap isSyncComplete]); //confirm we still have more syncing to do.
                             firstSyncMessageReceived = true;
-                            [realtime2 onError:nil withErrorInfo:nil];
+                            [realtime2 onError:[ARTTestUtil newErrorProtocolMessage]];
                         }
                         else if([channel2.presenceMap isSyncComplete] && !syncComplete) {
                             XCTAssertTrue(hasFailed);

--- a/ably-iosTests/ARTRealtimeRecoverTest.m
+++ b/ably-iosTests/ARTRealtimeRecoverTest.m
@@ -80,7 +80,7 @@
                 // Sending a message
                 [channel publish:c1Message cb:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateOk, status.state);
-                    [_realtime onDisconnected:nil];
+                    [_realtime onDisconnected];
                 }];
             }
             else if (state == ARTRealtimeDisconnected) {

--- a/ably-iosTests/ARTRealtimeRecoverTest.m
+++ b/ably-iosTests/ARTRealtimeRecoverTest.m
@@ -71,7 +71,6 @@
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
 
         __block NSString *firstConnectionId = nil;
-        __block bool gotFirstMessage = false;
         [_realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
             if (state == ARTRealtimeConnected) {
                 firstConnectionId = [_realtime connectionId];

--- a/ably-iosTests/ARTRealtimeResumeTest.m
+++ b/ably-iosTests/ARTRealtimeResumeTest.m
@@ -81,7 +81,7 @@
                 [channelB publish:message1 cb:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateOk, status.state);
                     // Forcibly disconnect
-                    [_realtime onError:nil withErrorInfo:nil];
+                    [_realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                 }];
             }
         }];
@@ -142,7 +142,7 @@
             NSString * msg = [message content];
             if([msg isEqualToString:message2]) {
                 //disconnect connection1
-                [_realtime onError:nil withErrorInfo:nil];
+                [_realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                 [channel2 publish:message3 cb:^(ARTStatus *status) {
                     [channel2 publish:message4 cb:^(ARTStatus *status) {
                         [_realtime connect];

--- a/ably-iosTests/ARTTestUtil.h
+++ b/ably-iosTests/ARTTestUtil.h
@@ -76,4 +76,6 @@ typedef void (^ARTRealtimeTestCallback)(ARTRealtime *realtime, ARTRealtimeConnec
 + (NSString *)getCrypto256Json;
 + (NSString *)getErrorsJson;
 
++ (ARTProtocolMessage *)newErrorProtocolMessage;
+
 @end

--- a/ably-iosTests/ARTTestUtil.m
+++ b/ably-iosTests/ARTTestUtil.m
@@ -14,6 +14,7 @@
 #import "ARTRealtimeChannel.h"
 #import "ARTRealtimePresence.h"
 #import "ARTPayload.h"
+#import "ARTProtocolMessage.h"
 #import "ARTEventEmitter.h"
 #import "ARTURLSessionServerTrust.h"
 
@@ -278,6 +279,13 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
         }];
     }];
     [testCase waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+}
+
++ (ARTProtocolMessage *)newErrorProtocolMessage {
+    ARTProtocolMessage* protocolMessage = [[ARTProtocolMessage alloc] init];
+    protocolMessage.action = ARTProtocolMessageError;
+    protocolMessage.error = [ARTErrorInfo createWithCode:0 message:@"Fail test"];
+    return protocolMessage;
 }
 
 @end

--- a/ablySpec/RealtimeClient.connection.swift
+++ b/ablySpec/RealtimeClient.connection.swift
@@ -196,13 +196,13 @@ class RealtimeClientConnection: QuickSpec {
                             case .Suspended:
                                 events += [state]
                                 // Forced
-                                client.transition(.Disconnected)
+                                client.onDisconnected()
                             case .Closing:
                                 events += [state]
                             case .Closed:
                                 events += [state]
                                 // Forced
-                                client.transition(.Suspended)
+                                client.onSuspended()
                             case .Failed:
                                 events += [state]
                                 expect(errorInfo).toNot(beNil(), description: "Error is nil")

--- a/ablySpec/RealtimeClient.connection.swift
+++ b/ablySpec/RealtimeClient.connection.swift
@@ -191,17 +191,14 @@ class RealtimeClientConnection: QuickSpec {
                                 client.close()
                             case .Disconnected:
                                 events += [state]
-                                // Forced
-                                client.fail()
+                                client.onError(AblyTests.newErrorProtocolMessage())
                             case .Suspended:
                                 events += [state]
-                                // Forced
                                 client.onDisconnected()
                             case .Closing:
                                 events += [state]
                             case .Closed:
                                 events += [state]
-                                // Forced
                                 client.onSuspended()
                             case .Failed:
                                 events += [state]
@@ -332,7 +329,7 @@ class RealtimeClientConnection: QuickSpec {
                         connection.eventEmitter.on { state, reason in
                             switch state {
                             case .Connected:
-                                client.fail()
+                                client.onError(AblyTests.newErrorProtocolMessage())
                             case .Failed:
                                 errorInfo = reason
                                 done()

--- a/ablySpec/RealtimeClient.connection.swift
+++ b/ablySpec/RealtimeClient.connection.swift
@@ -192,7 +192,7 @@ class RealtimeClientConnection: QuickSpec {
                             case .Disconnected:
                                 events += [state]
                                 // Forced
-                                client.transition(.Failed, withErrorInfo: ARTErrorInfo())
+                                client.fail()
                             case .Suspended:
                                 events += [state]
                                 // Forced
@@ -332,8 +332,7 @@ class RealtimeClientConnection: QuickSpec {
                         connection.eventEmitter.on { state, reason in
                             switch state {
                             case .Connected:
-                                // Forced
-                                client.transition(.Failed, withErrorInfo: ARTErrorInfo())
+                                client.fail()
                             case .Failed:
                                 errorInfo = reason
                                 done()

--- a/ablySpec/RealtimeClient.connection.swift
+++ b/ablySpec/RealtimeClient.connection.swift
@@ -188,13 +188,13 @@ class RealtimeClientConnection: QuickSpec {
                                 events += [state]
                             case .Connected:
                                 events += [state]
-                                client.close()
+                                client.onDisconnected()
                             case .Disconnected:
                                 events += [state]
-                                client.onError(AblyTests.newErrorProtocolMessage())
+                                client.close()
                             case .Suspended:
                                 events += [state]
-                                client.onDisconnected()
+                                client.onError(AblyTests.newErrorProtocolMessage())
                             case .Closing:
                                 events += [state]
                             case .Closed:
@@ -208,19 +208,18 @@ class RealtimeClientConnection: QuickSpec {
                         }
                     }
 
-                    expect(events).to(haveCount(8), description: "Missing some states")
-
                     if events.count != 8 {
+                        fail("Missing some states")
                         return
                     }
 
                     expect(events[0].rawValue).to(equal(ARTRealtimeConnectionState.Initialized.rawValue), description: "Should be INITIALIZED state")
                     expect(events[1].rawValue).to(equal(ARTRealtimeConnectionState.Connecting.rawValue), description: "Should be CONNECTING state")
                     expect(events[2].rawValue).to(equal(ARTRealtimeConnectionState.Connected.rawValue), description: "Should be CONNECTED state")
-                    expect(events[3].rawValue).to(equal(ARTRealtimeConnectionState.Closing.rawValue), description: "Should be CLOSING state")
-                    expect(events[4].rawValue).to(equal(ARTRealtimeConnectionState.Closed.rawValue), description: "Should be CLOSED state")
-                    expect(events[5].rawValue).to(equal(ARTRealtimeConnectionState.Suspended.rawValue), description: "Should be SUSPENDED state")
-                    expect(events[6].rawValue).to(equal(ARTRealtimeConnectionState.Disconnected.rawValue), description: "Should be DISCONNECTED state")
+                    expect(events[3].rawValue).to(equal(ARTRealtimeConnectionState.Disconnected.rawValue), description: "Should be DISCONNECTED state")
+                    expect(events[4].rawValue).to(equal(ARTRealtimeConnectionState.Closing.rawValue), description: "Should be CLOSING state")
+                    expect(events[5].rawValue).to(equal(ARTRealtimeConnectionState.Closed.rawValue), description: "Should be CLOSED state")
+                    expect(events[6].rawValue).to(equal(ARTRealtimeConnectionState.Suspended.rawValue), description: "Should be SUSPENDED state")
                     expect(events[7].rawValue).to(equal(ARTRealtimeConnectionState.Failed.rawValue), description: "Should be FAILED state")
 
                     client.close()

--- a/ablySpec/RealtimeClient.swift
+++ b/ablySpec/RealtimeClient.swift
@@ -271,7 +271,7 @@ class RealtimeClient: QuickSpec {
                 var start: NSDate?
                 var endInterval: UInt?
 
-                waitUntil(timeout: 120.0) { done in
+                waitUntil(timeout: testTimeout + options.suspendedRetryTimeout) { done in
                     client.eventEmitter.on { state, errorInfo in
                         switch state {
                         case .Failed:
@@ -287,7 +287,7 @@ class RealtimeClient: QuickSpec {
 
                             if start == nil {
                                 // Force
-                                client.transition(.Suspended)
+                                client.onSuspended()
                             }
                         case .Suspended:
                             start = NSDate()

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -115,6 +115,13 @@ class AblyTests {
         }
         return options
     }
+
+    class func newErrorProtocolMessage() -> ARTProtocolMessage {
+        let protocolMessage = ARTProtocolMessage()
+        protocolMessage.action = .Error
+        protocolMessage.error = ARTErrorInfo.createWithCode(0, message: "Fail test")
+        return protocolMessage
+    }
     
 }
 

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -10,6 +10,7 @@ import Foundation
 import XCTest
 import Quick
 import SwiftyJSON
+import SwiftWebSocket
 
 import ably.Private
 
@@ -416,18 +417,64 @@ class TestProxyTransport: ARTWebSocketTransport {
 
 }
 
+class ARTRealtimeExtended: ARTRealtime {
+
+    private var lostStateActive: Bool = false
+
+    override func connectionId() -> String? {
+        if lostStateActive {
+            return "lost"
+        }
+        return super.connectionId()
+    }
+
+    override func connectionKey() -> String? {
+        if lostStateActive {
+            return "lost"
+        }
+        return super.connectionKey()
+    }
+
+    func simulateLostConnection() {
+        //1. Abruptly disconnect
+        //2. Change the `Connection#id` and `Connection#key` before the client 
+        //   library attempts to reconnect and resume the connection
+        onDisconnected()
+        lostStateActive = true
+    }
+    
+}
+
 
 // MARK: - Extensions
 
 extension ARTRealtime {
 
-    func fail() {
-        transition(.Failed, withErrorInfo: ARTErrorInfo())
-    }
-
     func dispose() {
         removeAllChannels()
         eventEmitter.removeEvents()
     }
-    
+
+}
+
+extension ARTWebSocketTransport {
+
+    func simulateIncomingNormalClose() {
+        let CLOSE_NORMAL = 1000
+        let webSocketDelegate = self as! WebSocketDelegate
+        webSocketDelegate.webSocketClose(CLOSE_NORMAL, reason: "", wasClean: true)
+    }
+
+    func simulateIncomingAbruptlyClose() {
+        let CLOSE_ABNORMAL = 1006
+        let webSocketDelegate = self as! WebSocketDelegate
+        webSocketDelegate.webSocketClose(CLOSE_ABNORMAL, reason: "connection was closed abnormally", wasClean: false)
+    }
+
+    func simulateIncomingError() {
+        let error = NSError(domain: ARTAblyErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey:"Fail test"])
+        let webSocketDelegate = self as! WebSocketDelegate
+        webSocketDelegate.webSocketError(error)
+    }
+
 }

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -421,6 +421,10 @@ class TestProxyTransport: ARTWebSocketTransport {
 
 extension ARTRealtime {
 
+    func fail() {
+        transition(.Failed, withErrorInfo: ARTErrorInfo())
+    }
+
     func dispose() {
         removeAllChannels()
         eventEmitter.removeEvents()


### PR DESCRIPTION
I was using `client.transition` to simulate _incomings of errors & connection state change_ and it is wrong because some of the logic is missed.

To change the connection states:
 - `client.onConnected(message: ARTProtocolMessage)`
 - `client.onDisconnected()`
 - `client.onSuspended()`
 - `client.onError(AblyTests.simulateError())`

With this PR we have:
 - `simulateIncomingNormalClose`
 - `simulateIncomingAbruptlyClose`
 - `simulateIncomingError`
 - `simulateLostConnection`