### PR TITLE
Rewrite ARTEventEmitter per the spec and adjust Connection.

### DIFF
--- a/ably-ios/ARTConnection.h
+++ b/ably-ios/ARTConnection.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "CompatibilityMacros.h"
 #import "ARTTypes.h"
+#import "ARTEventEmitter.h"
 
 @class ARTRealtime;
 @class ARTEventEmitter;
@@ -21,13 +22,14 @@ ART_ASSUME_NONNULL_BEGIN
 @property (art_nullable, readonly, getter=getKey) NSString *key;
 @property (readonly, getter=getSerial) int64_t serial;
 @property (readonly, getter=getState) ARTRealtimeConnectionState state;
-@property (readonly, getter=getEventEmitter) ARTEventEmitter *eventEmitter;
 
 - (instancetype)initWithRealtime:(ARTRealtime *)realtime;
 
 - (void)connect;
 - (void)close;
 - (void)ping:(ARTRealtimePingCb)cb;
+
+ART_EMBED_INTERFACE_EVENT_EMITTER(NSNumber *, ARTConnectionStateChange *)
 
 @end
 

--- a/ably-ios/ARTConnection.m
+++ b/ably-ios/ARTConnection.m
@@ -14,6 +14,7 @@
 @interface ARTConnection () {
     // FIXME: temporary
     __weak ARTRealtime* _realtime;
+    __weak ARTEventEmitter* _eventEmitter;
 }
 
 @end
@@ -23,6 +24,7 @@
 - (instancetype)initWithRealtime:(ARTRealtime *)realtime {
     if (self == [super init]) {
         _realtime = realtime;
+        _eventEmitter = realtime.eventEmitter;
     }
     return self;
 }
@@ -43,10 +45,6 @@
     return _realtime.state;
 }
 
-- (ARTEventEmitter *)getEventEmitter {
-    return _realtime.eventEmitter;
-}
-
 - (void)connect {
     [_realtime connect];
 }
@@ -58,5 +56,7 @@
 - (void)ping:(ARTRealtimePingCb)cb {
     [_realtime ping:cb];
 }
+
+ART_EMBED_IMPLEMENTATION_EVENT_EMITTER(NSNumber *, ARTConnectionStateChange *)
 
 @end

--- a/ably-ios/ARTEventEmitter+Private.h
+++ b/ably-ios/ARTEventEmitter+Private.h
@@ -1,0 +1,36 @@
+//
+//  ARTEventEmitter+Private.h
+//  ably
+//
+//  Created by Toni Cárdenas on 29/1/16.
+//  Copyright © 2016 Ably. All rights reserved.
+//
+
+#include "ARTEventEmitter.h"
+#include "CompatibilityMacros.h"
+
+ART_ASSUME_NONNULL_BEGIN
+
+@interface __GENERIC(ARTEventEmitterEntry, ItemType) : NSObject
+
+@property (readwrite, strong, nonatomic) __GENERIC(ARTEventListener, ItemType) *listener;
+@property (readwrite, nonatomic) BOOL once;
+
+- (instancetype)initWithListener:(__GENERIC(ARTEventListener, ItemType) *)listener once:(BOOL)once;
+// ARTEventEmitterEntry are compared only using their listener.
+- (BOOL)isEqual:(id)object;
+
+@end
+
+@interface __GENERIC(ARTEventEmitter, EventType, ItemType) ()
+
+// The reason we use arrays as sets is that blocks are not hashable.
+
+@property (readwrite, nonatomic) __GENERIC(NSMutableDictionary, EventType, __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *) *listeners;
+// totalListeners listen to all events, except those in exceptions.
+@property (readwrite, nonatomic) __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *totalListeners;
+@property (readwrite, nonatomic) __GENERIC(NSMutableDictionary, EventType, __GENERIC(NSMutableArray, __GENERIC(ARTEventListener, ItemType) *) *) *ignoring;
+
+@end
+
+ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTEventEmitter+Private.h
+++ b/ably-ios/ARTEventEmitter+Private.h
@@ -17,19 +17,13 @@ ART_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic) BOOL once;
 
 - (instancetype)initWithListener:(__GENERIC(ARTEventListener, ItemType) *)listener once:(BOOL)once;
-// ARTEventEmitterEntry are compared only using their listener.
-- (BOOL)isEqual:(id)object;
 
 @end
 
 @interface __GENERIC(ARTEventEmitter, EventType, ItemType) ()
 
-// The reason we use arrays as sets is that blocks are not hashable.
-
 @property (readwrite, nonatomic) __GENERIC(NSMutableDictionary, EventType, __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *) *listeners;
-// totalListeners listen to all events, except those in exceptions.
 @property (readwrite, nonatomic) __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *totalListeners;
-@property (readwrite, nonatomic) __GENERIC(NSMutableDictionary, EventType, __GENERIC(NSMutableArray, __GENERIC(ARTEventListener, ItemType) *) *) *ignoring;
 
 @end
 

--- a/ably-ios/ARTEventEmitter+Private.h
+++ b/ably-ios/ARTEventEmitter+Private.h
@@ -23,7 +23,7 @@ ART_ASSUME_NONNULL_BEGIN
 @interface __GENERIC(ARTEventEmitter, EventType, ItemType) ()
 
 @property (readwrite, nonatomic) __GENERIC(NSMutableDictionary, EventType, __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *) *listeners;
-@property (readwrite, nonatomic) __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *totalListeners;
+@property (readwrite, nonatomic) __GENERIC(NSMutableArray, __GENERIC(ARTEventEmitterEntry, ItemType) *) *anyListeners;
 
 @end
 

--- a/ably-ios/ARTEventEmitter.h
+++ b/ably-ios/ARTEventEmitter.h
@@ -24,17 +24,17 @@ ART_ASSUME_NONNULL_BEGIN
 - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb;
 - (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
-- (__GENERIC(ARTEventListener, ItemType) *)onAll:(void (^)(ItemType))cb;
-- (void)onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType))cb;
+- (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 - (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb;
 - (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
-- (__GENERIC(ARTEventListener, ItemType) *)onceAll:(void (^)(ItemType))cb;
-- (void)onceAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType))cb;
+- (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;
-- (void)offAll:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 - (void)emit:(EventType)event with:(ItemType)data;
 
@@ -47,17 +47,17 @@ ART_ASSUME_NONNULL_BEGIN
 #define ART_EMBED_INTERFACE_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb;\
 - (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)onAll:(void (^)(ItemType))cb;\
-- (void)onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType))cb;\
+- (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
 - (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb;\
 - (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)onceAll:(void (^)(ItemType))cb;\
-- (void)onceAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType))cb;\
+- (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
-- (void)offAll:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 // This macro adds methods to a class implementation that just bridge calls to an internal
 // instance variable, which must be called _eventEmitter, of type ARTEventEmitter *.
@@ -71,12 +71,12 @@ return [_eventEmitter on:event call:cb];\
 [_eventEmitter on:event callListener:listener];\
 }\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)onAll:(void (^)(ItemType))cb {\
-return [_eventEmitter onAll:cb];\
+- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType))cb {\
+return [_eventEmitter on:cb];\
 }\
 \
-- (void)onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener];\
+- (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener];\
 }\
 \
 - (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb {\
@@ -87,20 +87,20 @@ return [_eventEmitter once:event call:cb];\
 [_eventEmitter once:event callListener:listener];\
 }\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)onceAll:(void (^)(ItemType))cb {\
-return [_eventEmitter onceAll:cb];\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType))cb {\
+return [_eventEmitter once:cb];\
 }\
 \
-- (void)onceAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter onceAllCallListener:listener];\
+- (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter onceCallListener:listener];\
 }\
 \
 - (void)off:(EventType)event listener:listener {\
 [_eventEmitter off:event listener:listener];\
 }\
 \
-- (void)offAll:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter offAll:listener];\
+- (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter off:listener];\
 }\
 \
 - (void)emit:(EventType)event with:(ItemType)data {\

--- a/ably-ios/ARTEventEmitter.h
+++ b/ably-ios/ARTEventEmitter.h
@@ -21,16 +21,16 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface __GENERIC(ARTEventEmitter, EventType, ItemType) : NSObject
 
-- (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb;
+- (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType __art_nullable))cb;
 - (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
-- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType))cb;
+- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb;
 - (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
-- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb;
+- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType __art_nullable))cb;
 - (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
-- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType))cb;
+- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb;
 - (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;
@@ -44,16 +44,16 @@ ART_ASSUME_NONNULL_BEGIN
 // This way you can automatically "implement the EventEmitter pattern" for a class
 // as the spec say. It's supposed to be used together with ART_EMBED_IMPLEMENTATION_EVENT_EMITTER
 // in the implementation of the class.
-#define ART_EMBED_INTERFACE_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb;\
+#define ART_EMBED_INTERFACE_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType __art_nullable))cb;\
 - (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType))cb;\
+- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb;\
 - (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb;\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType __art_nullable))cb;\
 - (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType))cb;\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb;\
 - (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
@@ -63,7 +63,7 @@ ART_ASSUME_NONNULL_BEGIN
 // instance variable, which must be called _eventEmitter, of type ARTEventEmitter *.
 // It's supposed to be used together with ART_EMBED_IMPLEMENTATION_EVENT_EMITTER in the
 // header file of the class.
-#define ART_EMBED_IMPLEMENTATION_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb {\
+#define ART_EMBED_IMPLEMENTATION_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter on:event call:cb];\
 }\
 \
@@ -71,7 +71,7 @@ return [_eventEmitter on:event call:cb];\
 [_eventEmitter on:event callListener:listener];\
 }\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType))cb {\
+- (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter on:cb];\
 }\
 \
@@ -79,7 +79,7 @@ return [_eventEmitter on:cb];\
 [_eventEmitter onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener];\
 }\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb {\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter once:event call:cb];\
 }\
 \
@@ -87,7 +87,7 @@ return [_eventEmitter once:event call:cb];\
 [_eventEmitter once:event callListener:listener];\
 }\
 \
-- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType))cb {\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter once:cb];\
 }\
 \

--- a/ably-ios/ARTEventEmitter.h
+++ b/ably-ios/ARTEventEmitter.h
@@ -9,14 +9,102 @@
 #import <Foundation/Foundation.h>
 #import "ARTTypes.h"
 
-@protocol ARTSubscription;
-
 @class ARTRealtime;
 
-@interface ARTEventEmitter : NSObject
+ART_ASSUME_NONNULL_BEGIN
 
-- (instancetype)initWithRealtime:(ARTRealtime *)realtime;
-- (id<ARTSubscription>)on:(ARTRealtimeConnectionStateCb)cb;
-- (void)removeEvents;
+@interface __GENERIC(ARTEventListener, ItemType) : NSObject
+
+- (void)call:(ItemType)argument;
 
 @end
+
+@interface __GENERIC(ARTEventEmitter, EventType, ItemType) : NSObject
+
+- (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb;
+- (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+
+- (__GENERIC(ARTEventListener, ItemType) *)onAll:(void (^)(ItemType))cb;
+- (void)onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+
+- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb;
+- (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+
+- (__GENERIC(ARTEventListener, ItemType) *)onceAll:(void (^)(ItemType))cb;
+- (void)onceAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+
+- (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (void)offAll:(__GENERIC(ARTEventListener, ItemType) *)listener;
+
+- (void)emit:(EventType)event with:(ItemType)data;
+
+@end
+
+// This macro adds methods to a class header file that mimic the API of an event emitter.
+// This way you can automatically "implement the EventEmitter pattern" for a class
+// as the spec say. It's supposed to be used together with ART_EMBED_IMPLEMENTATION_EVENT_EMITTER
+// in the implementation of the class.
+#define ART_EMBED_INTERFACE_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb;\
+- (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+\
+- (__GENERIC(ARTEventListener, ItemType) *)onAll:(void (^)(ItemType))cb;\
+- (void)onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb;\
+- (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+\
+- (__GENERIC(ARTEventListener, ItemType) *)onceAll:(void (^)(ItemType))cb;\
+- (void)onceAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+\
+- (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+- (void)offAll:(__GENERIC(ARTEventListener, ItemType) *)listener;
+
+// This macro adds methods to a class implementation that just bridge calls to an internal
+// instance variable, which must be called _eventEmitter, of type ARTEventEmitter *.
+// It's supposed to be used together with ART_EMBED_IMPLEMENTATION_EVENT_EMITTER in the
+// header file of the class.
+#define ART_EMBED_IMPLEMENTATION_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType))cb {\
+return [_eventEmitter on:event call:cb];\
+}\
+\
+- (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter on:event callListener:listener];\
+}\
+\
+- (__GENERIC(ARTEventListener, ItemType) *)onAll:(void (^)(ItemType))cb {\
+return [_eventEmitter onAll:cb];\
+}\
+\
+- (void)onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter onAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener];\
+}\
+\
+- (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType))cb {\
+return [_eventEmitter once:event call:cb];\
+}\
+\
+- (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter once:event callListener:listener];\
+}\
+\
+- (__GENERIC(ARTEventListener, ItemType) *)onceAll:(void (^)(ItemType))cb {\
+return [_eventEmitter onceAll:cb];\
+}\
+\
+- (void)onceAllCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter onceAllCallListener:listener];\
+}\
+\
+- (void)off:(EventType)event listener:listener {\
+[_eventEmitter off:event listener:listener];\
+}\
+\
+- (void)offAll:(__GENERIC(ARTEventListener, ItemType) *)listener {\
+[_eventEmitter offAll:listener];\
+}\
+\
+- (void)emit:(EventType)event with:(ItemType)data {\
+[_eventEmitter emit:event with:data];\
+}
+
+ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTEventEmitter.h
+++ b/ably-ios/ARTEventEmitter.h
@@ -22,16 +22,10 @@ ART_ASSUME_NONNULL_BEGIN
 @interface __GENERIC(ARTEventEmitter, EventType, ItemType) : NSObject
 
 - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType __art_nullable))cb;
-- (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
-
 - (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb;
-- (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 - (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType __art_nullable))cb;
-- (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
-
 - (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb;
-- (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 - (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;
@@ -45,16 +39,10 @@ ART_ASSUME_NONNULL_BEGIN
 // as the spec say. It's supposed to be used together with ART_EMBED_IMPLEMENTATION_EVENT_EMITTER
 // in the implementation of the class.
 #define ART_EMBED_INTERFACE_EVENT_EMITTER(EventType, ItemType) - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event call:(void (^)(ItemType __art_nullable))cb;\
-- (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
-\
 - (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb;\
-- (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
 - (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType __art_nullable))cb;\
-- (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
-\
 - (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb;\
-- (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 \
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
 - (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;
@@ -67,32 +55,16 @@ ART_ASSUME_NONNULL_BEGIN
 return [_eventEmitter on:event call:cb];\
 }\
 \
-- (void)on:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter on:event callListener:listener];\
-}\
-\
 - (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter on:cb];\
-}\
-\
-- (void)onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter onCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener];\
 }\
 \
 - (__GENERIC(ARTEventListener, ItemType) *)once:(EventType)event call:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter once:event call:cb];\
 }\
 \
-- (void)once:(EventType)event callListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter once:event callListener:listener];\
-}\
-\
 - (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb {\
 return [_eventEmitter once:cb];\
-}\
-\
-- (void)onceCallListener:(__GENERIC(ARTEventListener, ItemType) *)listener {\
-[_eventEmitter onceCallListener:listener];\
 }\
 \
 - (void)off:(EventType)event listener:listener {\

--- a/ably-ios/ARTEventEmitter.h
+++ b/ably-ios/ARTEventEmitter.h
@@ -29,6 +29,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;
 - (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (void)off;
 
 - (void)emit:(EventType)event with:(ItemType)data;
 
@@ -45,7 +46,8 @@ ART_ASSUME_NONNULL_BEGIN
 - (__GENERIC(ARTEventListener, ItemType) *)once:(void (^)(ItemType __art_nullable))cb;\
 \
 - (void)off:(EventType)event listener:(__GENERIC(ARTEventListener, ItemType) *)listener;\
-- (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;
+- (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener;\
+- (void)off;
 
 // This macro adds methods to a class implementation that just bridge calls to an internal
 // instance variable, which must be called _eventEmitter, of type ARTEventEmitter *.
@@ -73,6 +75,9 @@ return [_eventEmitter once:cb];\
 \
 - (void)off:(__GENERIC(ARTEventListener, ItemType) *)listener {\
 [_eventEmitter off:listener];\
+}\
+- (void)off {\
+[_eventEmitter off];\
 }\
 \
 - (void)emit:(EventType)event with:(ItemType)data {\

--- a/ably-ios/ARTEventEmitter.m
+++ b/ably-ios/ARTEventEmitter.m
@@ -132,7 +132,7 @@
     if ([self.totalListeners member:entry.listener] != nil) {
         // Already listening to everything! No need to add. Just check if it
         // is ignoring it, and un-ignore it if so.
-        [self removeFromArray:[self.ignoring objectForKey:event] item:entry.listener];
+        [self removeObject:entry.listener fromArrayWithKey:event inDictionary:self.ignoring];
         if (!entry.once) {
             // But 'once' listeners still need to be added. emit will check
             // listeners before totalListeners. If a listener has once=true
@@ -182,17 +182,16 @@
         [self addObject:listener toArrayWithKey:event inDictionary:self.ignoring];
         return;
     }
-
-    [self removeFromArray:[self.listeners objectForKey:event] item:listener];
+    [self removeObject:listener fromArrayWithKey:event inDictionary:self.listeners];
 }
 
 - (void)offAll:(ARTEventListener *)listener {
     [self.totalListeners artRemoveObject:listener];
-    for (NSMutableArray *listeners in [self.ignoring allValues]) {
-        [listeners artRemoveObject:listener];
+    for (id event in [self.ignoring keyEnumerator]) {
+        [self removeObject:listener fromArrayWithKey:event inDictionary:self.ignoring];
     }
-    for (NSMutableArray *listenersToEvent in [self.listeners allValues]) {
-        [listenersToEvent artRemoveObject:listener];
+    for (id event in [self.listeners keyEnumerator]) {
+        [self removeObject:listener fromArrayWithKey:event inDictionary:self.listeners];
     }
 }
 
@@ -253,12 +252,6 @@
     }
 }
 
-- (void)removeFromArray:(NSMutableArray *)array item:(id)item {
-    if (array) {
-        [array artRemoveObject:item];
-    }
-}
-
 - (void)addObject:(id)obj toArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict {
     NSMutableArray *array = [dict objectForKey:key];
     if (array == nil) {
@@ -266,6 +259,17 @@
         [dict setObject:array forKey:key];
     }
     [array addObjectReplacing:obj];
+}
+
+- (void)removeObject:(id)obj fromArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict {
+    NSMutableArray *array = [dict objectForKey:key];
+    if (array == nil) {
+        return;
+    }
+    [array artRemoveObject:obj];
+    if ([array count] == 0) {
+        [dict removeObjectForKey:key];
+    }
 }
 
 @end

--- a/ably-ios/ARTEventEmitter.m
+++ b/ably-ios/ARTEventEmitter.m
@@ -139,14 +139,13 @@
 }
 
 - (void)emit:(id)event with:(id)data {
-    NSMutableArray *listenersForEvent = [self.listeners objectForKey:event];
     NSMutableArray *toCall = [[NSMutableArray alloc] init];
-    NSMutableArray *toRemoveFromListenersForEvent = [[NSMutableArray alloc] init];
+    NSMutableArray *toRemoveFromListeners = [[NSMutableArray alloc] init];
     NSMutableArray *toRemoveFromTotalListeners = [[NSMutableArray alloc] init];
     @try {
-        for (ARTEventEmitterEntry *entry in listenersForEvent) {
+        for (ARTEventEmitterEntry *entry in [self.listeners objectForKey:event]) {
             if (entry.once) {
-                [toRemoveFromListenersForEvent addObject:entry];
+                [toRemoveFromListeners addObject:entry];
             }
             
             [toCall addObject:entry];
@@ -160,8 +159,8 @@
         }
     }
     @finally {
-        for (ARTEventEmitterEntry *entry in toRemoveFromListenersForEvent) {
-            [listenersForEvent removeObject:entry];
+        for (ARTEventEmitterEntry *entry in toRemoveFromListeners) {
+            [self removeObject:entry fromArrayWithKey:event inDictionary:self.listeners];
         }
         for (ARTEventEmitterEntry *entry in toRemoveFromTotalListeners) {
             [self.anyListeners removeObject:entry];

--- a/ably-ios/ARTEventEmitter.m
+++ b/ably-ios/ARTEventEmitter.m
@@ -6,39 +6,266 @@
 //  Copyright (c) 2015 Ably. All rights reserved.
 //
 
-#import "ARTEventEmitter.h"
+#import "ARTEventEmitter+Private.h"
 
 #import "ARTRealtime.h"
 #import "ARTRealtime+Private.h"
 #import "ARTRealtimeChannel.h"
 #import "ARTRealtimeChannelSubscription.h"
 
-@interface ARTEventEmitter ()
+@interface NSMutableArray (AsSet)
 
-@property (readonly, weak, nonatomic) ARTRealtime *realtime;
+- (id)member:(id)object;
+- (void)addObjectReplacing:(id)object;
 
 @end
 
-@implementation ARTEventEmitter
+@implementation NSMutableArray (AsSet)
 
-- (instancetype)initWithRealtime:(ARTRealtime *)realtime {
-    self = [super init];
-    if(self) {
-        _realtime = realtime;
+- (id)member:(id)object {
+    for (id item in self) {
+        if ([item isEqual:object]) {
+            return item;
+        }
+    }
+    return nil;
+}
+
+- (void)addObjectReplacing:(id)object {
+    for (int i = 0; i < [self count]; i++) {
+        id item = [self objectAtIndex:i];
+        if ([item isEqual:object] || [object isEqual:item]) {
+            [self replaceObjectAtIndex:i withObject:object];
+            return;
+        }
+    }
+    [self addObject:object];
+}
+
+- (void)artRemoveObject:(id)object {
+    for (id item in self) {
+        if ([item isEqual:object]) {
+            [self removeObject:item];
+            return;
+        }
+    }
+}
+
+@end
+
+@interface ARTEventListener ()
+
+- (instancetype)initWithBlock:(void (^)(id __art_nonnull))block;
+
+@end
+
+@implementation ARTEventListener {
+    void (^_block)(id __art_nonnull);
+}
+
+- (instancetype)initWithBlock:(void (^)(id __art_nonnull))block {
+    self = [self init];
+    if (self) {
+        _block = block;
     }
     return self;
 }
 
-- (id<ARTSubscription>)on:(ARTRealtimeConnectionStateCb)cb {
-    // TODO: more protection, callback can be nil!
-    ARTRealtimeConnectionStateSubscription *subscription = [[ARTRealtimeConnectionStateSubscription alloc] initWithRealtime:self.realtime cb:cb];
-    [self.realtime.stateSubscriptions addObject:subscription];
-    cb(self.realtime.state, nil);
-    return subscription;
+- (void)call:(id)argument {
+    _block(argument);
 }
 
-- (void)removeEvents {
-    [self.realtime.stateSubscriptions removeAllObjects];
+@end
+
+@implementation ARTEventEmitterEntry
+
+-(instancetype)initWithListener:(ARTEventListener *)listener once:(BOOL)once {
+    self = [self init];
+    if (self) {
+        _listener = listener;
+        _once = once;
+    }
+    return self;
+}
+
+- (BOOL)isEqual:(id)object {
+    if ([object isKindOfClass:[self class]]) {
+        return self == object || self.listener == ((ARTEventEmitterEntry *)object).listener;
+    }
+    return self.listener == object;
+}
+
+@end
+
+@implementation ARTEventEmitter
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _listeners = [[NSMutableDictionary alloc] init];
+        _totalListeners = [[NSMutableArray alloc] init];
+        _ignoring = [[NSMutableDictionary alloc] init];
+    }
+    return self;
+}
+
+- (ARTEventListener *)on:(id)event call:(void (^)(id __art_nonnull))cb {
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    [self on:event callListener:listener];
+    return listener;
+}
+
+- (void)on:(id)event callListener:(ARTEventListener *)listener {
+    [self addOnEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:false] event:event];
+}
+
+- (ARTEventListener *)once:(id)event call:(void (^)(id __art_nonnull))cb {
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    [self once:event callListener:listener];
+    return listener;
+}
+
+- (void)once:(id)event callListener:(ARTEventListener *)listener {
+    [self addOnEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:true] event:event];
+}
+
+- (void)addOnEntry:(ARTEventEmitterEntry *)entry event:(id)event {
+    if ([self.totalListeners member:entry.listener] != nil) {
+        // Already listening to everything! No need to add. Just check if it
+        // is ignoring it, and un-ignore it if so.
+        [self removeFromArray:[self.ignoring objectForKey:event] item:entry.listener];
+        if (!entry.once) {
+            // But 'once' listeners still need to be added. emit will check
+            // listeners before totalListeners. If a listener has once=true
+            // and also is in totalListeners, after dispatching the event to it,
+            // the event will be added to its ignored set.
+            return;
+        }
+    }
+    
+    [self addObject:entry toArrayWithKey:event inDictionary:self.listeners];
+}
+
+- (ARTEventListener *)onAll:(void (^)(id __art_nonnull))cb {
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    [self onAllCallListener:listener];
+    return listener;
+}
+
+- (void)onAllCallListener:(ARTEventListener *)listener {
+    [self addOnAllEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:false]];
+}
+
+- (ARTEventListener *)onceAll:(void (^)(id __art_nonnull))cb {
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    [self onceAllCallListener:listener];
+    return listener;
+}
+
+- (void)onceAllCallListener:(ARTEventListener *)listener {
+    [self addOnAllEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:true]];
+}
+
+- (void)addOnAllEntry:(ARTEventEmitterEntry *)entry {
+    [self.totalListeners addObjectReplacing:entry];
+    
+    // Maybe cb was already listening to some events; remove it from their
+    // entries in listeners if so.
+    for (NSMutableArray *listenersToEvent in [self.listeners allValues]) {
+        [listenersToEvent artRemoveObject:entry.listener];
+    }
+}
+
+- (void)off:(id)event listener:(ARTEventListener *)listener {
+    if ([self.totalListeners member:listener] != nil) {
+        // It is listening to everything but now wants to ignore a particular
+        // event. Just mark it in its ignoring entry; emit will check that.
+        [self addObject:listener toArrayWithKey:event inDictionary:self.ignoring];
+        return;
+    }
+
+    [self removeFromArray:[self.listeners objectForKey:event] item:listener];
+}
+
+- (void)offAll:(ARTEventListener *)listener {
+    [self.totalListeners artRemoveObject:listener];
+    for (NSMutableArray *listeners in [self.ignoring allValues]) {
+        [listeners artRemoveObject:listener];
+    }
+    for (NSMutableArray *listenersToEvent in [self.listeners allValues]) {
+        [listenersToEvent artRemoveObject:listener];
+    }
+}
+
+- (void)emit:(id)event with:(id)data {
+    NSMutableArray *listenersForEvent = [self.listeners objectForKey:event];
+    NSMutableArray *toCall = [[NSMutableArray alloc] init];
+    NSMutableArray *toRemoveFromListenersForEvent = [[NSMutableArray alloc] init];
+    NSMutableArray *toRemoveFromTotalListeners = [[NSMutableArray alloc] init];
+    @try {
+        for (ARTEventEmitterEntry *entry in listenersForEvent) {
+            if (entry.once) {
+                NSMutableArray *ign = [self.ignoring objectForKey:event];
+                if (ign && [ign member:entry.listener]) {
+                    // If you call 'onAll', then 'once(A)' and then 'off(A)',
+                    // 'onAll' will add to totalListeners, 'once(A)' will add
+                    // to listeners and 'off(A)' will add to ignoring. We've found
+                    // here one of those cases; just keep going. (If 'on' or 'once'
+                    // is called again, it will remove A from ignoring and replace this
+                    // entry, so it's fine to leave it here.)
+                    [toRemoveFromListenersForEvent addObjectReplacing:entry];
+                    continue;
+                }
+
+                [toRemoveFromListenersForEvent addObjectReplacing:entry];
+                if ([self.totalListeners member:entry]) {
+                    // If you call 'onAll' and then 'once(A)', you end up here, and you need
+                    // to ignore from now on A so that 'once' has effect.
+                    [self addObject:entry.listener toArrayWithKey:event inDictionary:self.ignoring];
+                }
+            }
+            
+            [toCall addObjectReplacing:entry];
+        }
+        
+        for (ARTEventEmitterEntry *entry in self.totalListeners) {
+            NSMutableArray *ign = [self.ignoring objectForKey:event];
+            if (ign && [ign member:entry.listener]) {
+                continue;
+            }
+            
+            if (entry.once) {
+                [toRemoveFromTotalListeners addObjectReplacing:entry];
+            }
+
+            [toCall addObjectReplacing:entry];
+        }
+    }
+    @finally {
+        for (ARTEventEmitterEntry *entry in toRemoveFromListenersForEvent) {
+            [listenersForEvent artRemoveObject:entry.listener];
+        }
+        for (ARTEventEmitterEntry *entry in toRemoveFromTotalListeners) {
+            [self.totalListeners artRemoveObject:entry.listener];
+        }
+        for (ARTEventEmitterEntry *entry in toCall) {
+            [entry.listener call:data];
+        }
+    }
+}
+
+- (void)removeFromArray:(NSMutableArray *)array item:(id)item {
+    if (array) {
+        [array artRemoveObject:item];
+    }
+}
+
+- (void)addObject:(id)obj toArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict {
+    NSMutableArray *array = [dict objectForKey:key];
+    if (array == nil) {
+        array = [[NSMutableArray alloc] init];
+        [dict setObject:array forKey:key];
+    }
+    [array addObjectReplacing:obj];
 }
 
 @end

--- a/ably-ios/ARTEventEmitter.m
+++ b/ably-ios/ARTEventEmitter.m
@@ -145,23 +145,23 @@
     [self addObject:entry toArrayWithKey:event inDictionary:self.listeners];
 }
 
-- (ARTEventListener *)onAll:(void (^)(id __art_nonnull))cb {
+- (ARTEventListener *)on:(void (^)(id __art_nonnull))cb {
     ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
-    [self onAllCallListener:listener];
+    [self onCallListener:listener];
     return listener;
 }
 
-- (void)onAllCallListener:(ARTEventListener *)listener {
+- (void)onCallListener:(ARTEventListener *)listener {
     [self addOnAllEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:false]];
 }
 
-- (ARTEventListener *)onceAll:(void (^)(id __art_nonnull))cb {
+- (ARTEventListener *)once:(void (^)(id __art_nonnull))cb {
     ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
-    [self onceAllCallListener:listener];
+    [self onceCallListener:listener];
     return listener;
 }
 
-- (void)onceAllCallListener:(ARTEventListener *)listener {
+- (void)onceCallListener:(ARTEventListener *)listener {
     [self addOnAllEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:true]];
 }
 
@@ -185,7 +185,7 @@
     [self removeObject:listener fromArrayWithKey:event inDictionary:self.listeners];
 }
 
-- (void)offAll:(ARTEventListener *)listener {
+- (void)off:(ARTEventListener *)listener {
     [self.totalListeners artRemoveObject:listener];
     for (id event in [self.ignoring keyEnumerator]) {
         [self removeObject:listener fromArrayWithKey:event inDictionary:self.ignoring];

--- a/ably-ios/ARTEventEmitter.m
+++ b/ably-ios/ARTEventEmitter.m
@@ -77,7 +77,7 @@
     self = [super init];
     if (self) {
         _listeners = [[NSMutableDictionary alloc] init];
-        _totalListeners = [[NSMutableArray alloc] init];
+        _anyListeners = [[NSMutableArray alloc] init];
     }
     return self;
 }
@@ -111,7 +111,7 @@
 }
 
 - (void)addOnAllEntry:(ARTEventEmitterEntry *)entry {
-    [self.totalListeners addObject:entry];
+    [self.anyListeners addObject:entry];
 }
 
 - (void)off:(id)event listener:(ARTEventListener *)listener {
@@ -124,7 +124,7 @@
     BOOL (^cond)(id) = ^BOOL(id entry) {
         return ((ARTEventEmitterEntry *)entry).listener == listener;
     };
-    [self.totalListeners artRemoveWhere:cond];
+    [self.anyListeners artRemoveWhere:cond];
     for (id event in [self.listeners allKeys]) {
         [self removeObject:listener fromArrayWithKey:event inDictionary:self.listeners where:cond];
     }
@@ -144,7 +144,7 @@
             [toCall addObject:entry];
         }
         
-        for (ARTEventEmitterEntry *entry in self.totalListeners) {
+        for (ARTEventEmitterEntry *entry in self.anyListeners) {
             if (entry.once) {
                 [toRemoveFromTotalListeners addObject:entry];
             }
@@ -156,7 +156,7 @@
             [listenersForEvent removeObject:entry];
         }
         for (ARTEventEmitterEntry *entry in toRemoveFromTotalListeners) {
-            [self.totalListeners removeObject:entry];
+            [self.anyListeners removeObject:entry];
         }
         for (ARTEventEmitterEntry *entry in toCall) {
             [entry.listener call:data];

--- a/ably-ios/ARTEventEmitter.m
+++ b/ably-ios/ARTEventEmitter.m
@@ -76,8 +76,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _listeners = [[NSMutableDictionary alloc] init];
-        _anyListeners = [[NSMutableArray alloc] init];
+        [self resetListeners];
     }
     return self;
 }
@@ -128,6 +127,15 @@
     for (id event in [self.listeners allKeys]) {
         [self removeObject:listener fromArrayWithKey:event inDictionary:self.listeners where:cond];
     }
+}
+
+- (void)off {
+    [self resetListeners];
+}
+
+- (void)resetListeners {
+    _listeners = [[NSMutableDictionary alloc] init];
+    _anyListeners = [[NSMutableArray alloc] init];
 }
 
 - (void)emit:(id)event with:(id)data {

--- a/ably-ios/ARTRealtime+Private.h
+++ b/ably-ios/ARTRealtime+Private.h
@@ -7,6 +7,8 @@
 //
 
 #import "ARTRealtime.h"
+#import "ARTEventEmitter.h"
+#import "ARTTypes.h"
 
 #import "ARTRealtimeTransport.h"
 
@@ -16,6 +18,12 @@
 @class ARTConnection;
 
 ART_ASSUME_NONNULL_BEGIN
+
+@interface ARTRealtime ()
+
+@property (readonly, strong, nonatomic) __GENERIC(ARTEventEmitter, NSNumber *, ARTConnectionStateChange *) *eventEmitter;
+
+@end
 
 /// ARTRealtime private methods that are used for whitebox testing.
 @interface ARTRealtime (Private)
@@ -39,6 +47,8 @@ ART_ASSUME_NONNULL_BEGIN
 // FIXME: Connection should manage the transport
 - (void)setTransportClass:(Class)transportClass;
 - (ARTConnection *)connection;
+
+- (void)resetEventEmitter;
 
 @end
 

--- a/ably-ios/ARTRealtime.h
+++ b/ably-ios/ARTRealtime.h
@@ -10,6 +10,7 @@
 #import "ARTTypes.h"
 #import "ARTLog.h"
 #import "ARTRealtimeChannels.h"
+#import "ARTEventEmitter.h"
 
 @class ARTStatus;
 @class ARTMessage;
@@ -22,7 +23,6 @@
 @class ARTPresence;
 @class ARTPresenceMap;
 @class ARTRealtimeChannelPresenceSubscription;
-@class ARTRealtimeConnectionStateSubscription;
 @class ARTEventEmitter;
 @class ARTRealtimeChannel;
 @class ARTAuth;
@@ -74,10 +74,9 @@ typedef void (^ARTRealtimePingCb)(ARTStatus *);
 // Message sending
 - (void)send:(ARTProtocolMessage *)msg cb:(art_nullable ARTStatusCallback)cb;
 
-- (void)unsubscribeState:(ARTRealtimeConnectionStateSubscription *)subscription;
-
-@property (readonly, strong, nonatomic) ARTEventEmitter *eventEmitter;
 @property (readonly, getter=getLogger) ARTLog *logger;
+
+ART_EMBED_INTERFACE_EVENT_EMITTER(NSNumber *, ARTConnectionStateChange *)
 
 @end
 

--- a/ably-ios/ARTRealtimeChannelSubscription.h
+++ b/ably-ios/ARTRealtimeChannelSubscription.h
@@ -52,15 +52,3 @@
 - (void)unsubscribe;
 
 @end
-
-
-@interface ARTRealtimeConnectionStateSubscription : NSObject <ARTSubscription>
-
-@property (readonly, weak, nonatomic) ARTRealtime *realtime;
-@property (readonly, strong, nonatomic) ARTRealtimeConnectionStateCb cb;
-
-- (instancetype)initWithRealtime:(ARTRealtime *)realtime cb:(ARTRealtimeConnectionStateCb)cb;
-
-- (void)unsubscribe;
-
-@end

--- a/ably-ios/ARTRealtimeChannelSubscription.m
+++ b/ably-ios/ARTRealtimeChannelSubscription.m
@@ -88,23 +88,3 @@
 }
 
 @end
-
-
-#pragma mark - ARTRealtimeConnectionStateSubscription
-
-@implementation ARTRealtimeConnectionStateSubscription
-
-- (instancetype)initWithRealtime:(ARTRealtime *)realtime cb:(ARTRealtimeConnectionStateCb)cb {
-    self = [super init];
-    if (self) {
-        _realtime = realtime;
-        _cb = cb;
-    }
-    return self;
-}
-
-- (void)unsubscribe {
-    [self.realtime unsubscribeState:self];
-}
-
-@end

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -76,8 +76,6 @@ typedef void (^ARTRealtimeChannelMessageCb)(ARTMessage * message, ARTErrorInfo *
 
 typedef void (^ARTRealtimeChannelStateCb)(ARTRealtimeChannelState, ARTStatus *);
 
-typedef void (^ARTRealtimeConnectionStateCb)(ARTRealtimeConnectionState state, ARTErrorInfo *__art_nullable errorInfo);
-
 typedef void (^ARTRealtimeChannelPresenceCb)(ARTPresenceMessage *);
 
 typedef void (^ARTRealtimePingCb)(ARTStatus *);
@@ -116,6 +114,18 @@ typedef void (^ARTTokenCallback)(ARTAuthTokenDetails *__art_nullable tokenDetail
 - (instancetype)init;
 - (instancetype)initWithCancellable:(id<ARTCancellable>)cancellable;
 - (void)cancel;
+
+@end
+
+@interface ARTConnectionStateChange : NSObject
+
+- (instancetype)initWithCurrent:(ARTRealtimeConnectionState)current
+                       previous:(ARTRealtimeConnectionState)previous
+                         reason:(ARTErrorInfo *__art_nullable)reason;
+
+@property (readonly, nonatomic) ARTRealtimeConnectionState current;
+@property (readonly, nonatomic) ARTRealtimeConnectionState previous;
+@property (readonly, nonatomic, art_nullable) ARTErrorInfo *reason;
 
 @end
 

--- a/ably-ios/ARTTypes.h
+++ b/ably-ios/ARTTypes.h
@@ -123,9 +123,15 @@ typedef void (^ARTTokenCallback)(ARTAuthTokenDetails *__art_nullable tokenDetail
                        previous:(ARTRealtimeConnectionState)previous
                          reason:(ARTErrorInfo *__art_nullable)reason;
 
+- (instancetype)initWithCurrent:(ARTRealtimeConnectionState)current
+                       previous:(ARTRealtimeConnectionState)previous
+                         reason:(ARTErrorInfo *__art_nullable)reason
+                        retryIn:(NSTimeInterval)retryIn;
+
 @property (readonly, nonatomic) ARTRealtimeConnectionState current;
 @property (readonly, nonatomic) ARTRealtimeConnectionState previous;
 @property (readonly, nonatomic, art_nullable) ARTErrorInfo *reason;
+@property (readonly, nonatomic) NSTimeInterval retryIn;
 
 @end
 

--- a/ably-ios/ARTTypes.m
+++ b/ably-ios/ARTTypes.m
@@ -72,3 +72,17 @@ NSString *generateNonce() {
 }
 
 @end
+
+@implementation ARTConnectionStateChange
+
+- (instancetype)initWithCurrent:(ARTRealtimeConnectionState)current previous:(ARTRealtimeConnectionState)previous reason:(ARTErrorInfo *)reason {
+    self = [self init];
+    if (self) {
+        _current = current;
+        _previous = previous;
+        _reason = reason;
+    }
+    return self;
+}
+
+@end

--- a/ably-ios/ARTTypes.m
+++ b/ably-ios/ARTTypes.m
@@ -76,11 +76,16 @@ NSString *generateNonce() {
 @implementation ARTConnectionStateChange
 
 - (instancetype)initWithCurrent:(ARTRealtimeConnectionState)current previous:(ARTRealtimeConnectionState)previous reason:(ARTErrorInfo *)reason {
+    return [self initWithCurrent:current previous:previous reason:reason retryIn:(NSTimeInterval)0];
+}
+
+- (instancetype)initWithCurrent:(ARTRealtimeConnectionState)current previous:(ARTRealtimeConnectionState)previous reason:(ARTErrorInfo *)reason retryIn:(NSTimeInterval)retryIn {
     self = [self init];
     if (self) {
         _current = current;
         _previous = previous;
         _reason = reason;
+        _retryIn = retryIn;
     }
     return self;
 }

--- a/ably-iosTests/ARTRealtimeAttachTest.m
+++ b/ably-iosTests/ARTRealtimeAttachTest.m
@@ -45,7 +45,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"attachOnce"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
@@ -143,7 +143,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
@@ -168,7 +168,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block BOOL detachingHit = NO;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
@@ -225,7 +225,7 @@
     XCTestExpectation *  expectation = [self expectationWithDescription:@"testDetachingIgnoresDetach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             
             if (state == ARTRealtimeConnected) {
@@ -253,7 +253,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testAttachFailsOnFailedConnection"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
@@ -272,7 +272,7 @@
                     }
                 }];
                 [channel attach];
-                [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+                [realtime on:^(ARTConnectionStateChange *stateChange) {
                     ARTRealtimeConnectionState state = stateChange.current;
                     if(state == ARTRealtimeFailed) {
                         hasFailed = true;
@@ -380,7 +380,7 @@
             [realtime connect];
         }];
 
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {

--- a/ably-iosTests/ARTRealtimeAttachTest.m
+++ b/ably-iosTests/ARTRealtimeAttachTest.m
@@ -34,7 +34,7 @@
 - (void)tearDown {
     if (_realtime) {
         [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.eventEmitter removeEvents];
+        [_realtime resetEventEmitter];
         [_realtime close];
     }
     _realtime = nil;
@@ -45,7 +45,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"attachOnce"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
 
@@ -142,7 +143,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
@@ -166,7 +168,8 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block BOOL detachingHit = NO;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
@@ -222,7 +225,8 @@
     XCTestExpectation *  expectation = [self expectationWithDescription:@"testDetachingIgnoresDetach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"testDetachingIgnoresDetach"];
@@ -249,7 +253,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testAttachFailsOnFailedConnection"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
                 __block bool hasFailed = false;
@@ -267,7 +272,8 @@
                     }
                 }];
                 [channel attach];
-                [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+                [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+                    ARTRealtimeConnectionState state = stateChange.current;
                     if(state == ARTRealtimeFailed) {
                         hasFailed = true;
                         [channel attach];
@@ -374,7 +380,9 @@
             [realtime connect];
         }];
 
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
                 [channel.presence enter:@"not_allowed_here" cb:^(ARTStatus *status) {

--- a/ably-iosTests/ARTRealtimeChannelTest.m
+++ b/ably-iosTests/ARTRealtimeChannelTest.m
@@ -58,7 +58,6 @@
         _realtime = realtime;
         [realtime onAll:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
@@ -303,7 +302,6 @@
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
         [realtime onAll:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
                     if (state == ARTRealtimeChannelAttached) {
@@ -331,7 +329,6 @@
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
         [realtime onAll:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
                     if (state == ARTRealtimeChannelAttached) {

--- a/ably-iosTests/ARTRealtimeChannelTest.m
+++ b/ably-iosTests/ARTRealtimeChannelTest.m
@@ -56,7 +56,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"attach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
@@ -300,7 +300,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
@@ -327,7 +327,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {

--- a/ably-iosTests/ARTRealtimeChannelTest.m
+++ b/ably-iosTests/ARTRealtimeChannelTest.m
@@ -39,13 +39,13 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     if (_realtime) {
         [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.eventEmitter removeEvents];
+        [_realtime resetEventEmitter];
         [_realtime close];
     }
     _realtime = nil;
     if (_realtime2) {
         [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2.eventEmitter removeEvents];
+        [_realtime2 resetEventEmitter];
         [_realtime2 close];
     }
     _realtime2 = nil;
@@ -56,7 +56,9 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"attach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
@@ -299,7 +301,9 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
                     if (state == ARTRealtimeChannelAttached) {
@@ -325,7 +329,9 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 [channel subscribeToStateChanges:^(ARTRealtimeChannelState state, ARTStatus *reason) {
                     if (state == ARTRealtimeChannelAttached) {

--- a/ably-iosTests/ARTRealtimeConnectTest.m
+++ b/ably-iosTests/ARTRealtimeConnectTest.m
@@ -42,7 +42,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectText"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [expectation fulfill];
@@ -56,7 +56,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectPing"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [realtime ping:^(ARTStatus *status) {
@@ -76,7 +76,7 @@
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool connectingHappened = false;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnecting) {
                 XCTAssertTrue([realtime connectionId] == nil);
@@ -105,7 +105,7 @@
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool closingHappened = false;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime close];
@@ -130,7 +130,7 @@
     options.autoConnect = false;
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
         
             if(state == ARTRealtimeConnected) {
@@ -159,7 +159,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block int connectionCount=0;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
         
             if (state == ARTRealtimeConnected) {
@@ -184,7 +184,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool connectHappened = false;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
         
             if(state == ARTRealtimeConnected) {
@@ -223,7 +223,7 @@
         __block bool gotClosed =false;
         __block bool gotFailed= false;
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
 
             if(state == ARTRealtimeConnecting) {
@@ -284,7 +284,7 @@
         _realtime = realtime;
         __block bool hasClosed = false;
         __block id listener = nil;
-        listener = [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        listener = [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
         
             if(state == ARTRealtimeConnected) {
@@ -299,7 +299,7 @@
                 XCTAssertTrue(hasClosed);
                 XCTAssertThrows([realtime ping:^(ARTStatus *s) {}]);
                 [exp fulfill];
-                [realtime offAll:listener];
+                [realtime off:listener];
             }
         }];
         [realtime connect];

--- a/ably-iosTests/ARTRealtimeConnectTest.m
+++ b/ably-iosTests/ARTRealtimeConnectTest.m
@@ -33,7 +33,7 @@
     [super tearDown];
     if (_realtime) {
         [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.eventEmitter removeEvents];
+        [_realtime resetEventEmitter];
         [_realtime close];
     }
     _realtime = nil;
@@ -42,7 +42,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectText"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [expectation fulfill];
             }
@@ -55,7 +56,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectPing"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [realtime ping:^(ARTStatus *status) {
                     XCTAssertEqual(ARTStateOk, status.state);
@@ -69,10 +71,13 @@
 
 - (void)testConnectStateChange {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
+    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    options.autoConnect = false;
+    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool connectingHappened = false;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnecting) {
                 XCTAssertTrue([realtime connectionId] == nil);
                 XCTAssertTrue([realtime connectionKey] == nil);
@@ -87,6 +92,7 @@
                 [expectation fulfill];
             }
         }];
+        [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
     
@@ -94,10 +100,13 @@
 
 - (void)testConnectStateChangeClose {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
+    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    options.autoConnect = false;
+    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool closingHappened = false;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime close];
             }
@@ -110,15 +119,20 @@
                 [expectation fulfill];
             }
         }];
+        [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectionSerial {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
+    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    options.autoConnect = false;
+    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+        
             if(state == ARTRealtimeConnected) {
                 XCTAssertEqual([realtime connectionSerial], -1);
                 ARTRealtimeChannel * c =[realtime.channels get:@"chan"];
@@ -133,6 +147,7 @@
                 [c attach];
             }
         }];
+        [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
     
@@ -144,7 +159,9 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block int connectionCount=0;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+        
             if (state == ARTRealtimeConnected) {
                 connectionCount++;
                 if(connectionCount ==1) {
@@ -167,7 +184,9 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool connectHappened = false;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+        
             if(state == ARTRealtimeConnected) {
                 if(connectHappened) {
                     [expectation fulfill];
@@ -204,14 +223,14 @@
         __block bool gotClosed =false;
         __block bool gotFailed= false;
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
-            if(state == ARTRealtimeChannelInitialised) {
-                gotInitialized = true;
-                [realtime connect];
-            }
-            else if(state == ARTRealtimeConnecting) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+
+            if(state == ARTRealtimeConnecting) {
                 gotConnecting = true;
-                
+                if (stateChange.previous == ARTRealtimeInitialized) {
+                    gotInitialized = true;
+                }
             }
             else if(state == ARTRealtimeConnected) {
                 if(!gotConnected) {
@@ -252,16 +271,22 @@
                 [exp fulfill];
             }
         }];
+        [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectPingError {
     XCTestExpectation *exp = [self expectationWithDescription:@"testConnectPingError"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
+    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    options.autoConnect = false;
+    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool hasClosed = false;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        __block id listener = nil;
+        listener = [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+        
             if(state == ARTRealtimeConnected) {
                 [realtime close];
             }
@@ -274,8 +299,10 @@
                 XCTAssertTrue(hasClosed);
                 XCTAssertThrows([realtime ping:^(ARTStatus *s) {}]);
                 [exp fulfill];
+                [realtime offAll:listener];
             }
         }];
+        [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }

--- a/ably-iosTests/ARTRealtimeInitTest.m
+++ b/ably-iosTests/ARTRealtimeInitTest.m
@@ -49,7 +49,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"initWithOptions"];
     [ARTTestUtil testRealtime:^(ARTRealtime * realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [expectation fulfill];
@@ -68,7 +68,7 @@
         options.environment = @"test";
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeFailed) {
                 [expectation fulfill];
@@ -88,7 +88,7 @@
         options.restPort = 9998;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeFailed) {
                 [expectation fulfill];
@@ -117,7 +117,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [expectation fulfill];
@@ -133,7 +133,7 @@
         options.autoConnect = false;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [expectation fulfill];

--- a/ably-iosTests/ARTRealtimeMessageTest.m
+++ b/ably-iosTests/ARTRealtimeMessageTest.m
@@ -329,7 +329,6 @@
         ARTRealtimeChannel *channel = [_realtime.channels get:@"testSingleSendText"];
         [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             if(state == ARTRealtimeConnected) {
                 [channel attach];
             }

--- a/ably-iosTests/ARTRealtimeMessageTest.m
+++ b/ably-iosTests/ARTRealtimeMessageTest.m
@@ -262,7 +262,7 @@
             messagesReceived++;
         }];
         __block bool connectingHappened = false;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state ==ARTRealtimeConnecting) {
                 if(connectingHappened) {
@@ -327,7 +327,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [_realtime.channels get:@"testSingleSendText"];
-        [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [_realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [channel attach];

--- a/ably-iosTests/ARTRealtimePresenceHistoryTest.m
+++ b/ably-iosTests/ARTRealtimePresenceHistoryTest.m
@@ -102,7 +102,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -141,7 +141,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testSimpleText"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -174,7 +174,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testSimpleText"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -283,7 +283,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testWaitTextBackward"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -420,7 +420,7 @@
 
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testWaitText"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -545,7 +545,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];

--- a/ably-iosTests/ARTRealtimePresenceHistoryTest.m
+++ b/ably-iosTests/ARTRealtimePresenceHistoryTest.m
@@ -20,6 +20,7 @@
 #import "ARTEventEmitter.h"
 #import "ARTPaginatedResult.h"
 #import "ARTDataQuery.h"
+#import "ARTRealtime+Private.h"
 
 @interface ARTRealtimePresenceHistoryTest : XCTestCase
 {
@@ -38,19 +39,19 @@
 - (void)tearDown {
     if (_realtime) {
         [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.eventEmitter removeEvents];
+        [_realtime resetEventEmitter];
         [_realtime close];
     }
     _realtime = nil;
     if (_realtime2) {
         [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2.eventEmitter removeEvents];
+        [_realtime2 resetEventEmitter];
         [_realtime2 close];
     }
     _realtime2 = nil;
     if (_realtime3) {
         [ARTTestUtil removeAllChannels:_realtime3];
-        [_realtime3.eventEmitter removeEvents];
+        [_realtime3 resetEventEmitter];
         [_realtime3 close];
     }
     _realtime3 = nil;
@@ -101,7 +102,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -139,7 +141,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testSimpleText"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -171,7 +174,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testSimpleText"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -279,7 +283,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testWaitTextBackward"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -415,7 +420,8 @@
 
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testWaitText"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -539,7 +545,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -43,13 +43,13 @@
 - (void)tearDown {
     if (_realtime) {
         [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.eventEmitter removeEvents];
+        [_realtime resetEventEmitter];
         [_realtime close];
     }
     _realtime = nil;
     if (_realtime2) {
         [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2.eventEmitter removeEvents];
+        [_realtime2 resetEventEmitter];
         [_realtime2 close];
     }
     _realtime2 = nil;
@@ -143,7 +143,8 @@
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         XCTestExpectation *expectConnected = [self expectationWithDescription:@"expectConnected"];
 
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [expectConnected fulfill];
             }
@@ -235,7 +236,8 @@
             [expectation fulfill];
         }];
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -273,7 +275,8 @@
             }
         }];
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -308,7 +311,8 @@
                 [expectation fulfill];
             }
         }];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -344,7 +348,8 @@
                 [expectation fulfill];
             }
         }];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -379,7 +384,8 @@
                 [expectation fulfill];
             }
         }];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -416,7 +422,8 @@
             
         }];
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -444,7 +451,8 @@
             }
         }];
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -604,7 +612,8 @@
             }
         }];
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -641,7 +650,8 @@
             }
         }];
         
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
             }
@@ -753,7 +763,8 @@
     NSString * presenceEnter = @"client_has_entered";
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                 [channel.presence enter:presenceEnter cb:^(ARTStatus *status) {
@@ -772,7 +783,8 @@
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"channel"];
         __block bool hasDisconnected = false;
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onDisconnected];
             }
@@ -823,7 +835,8 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClientIdFailsOnError"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                 [channel.presence  enterClient:@"clientId" data:@"" cb:^(ARTStatus *status) {
@@ -1124,7 +1137,9 @@
                         }
                     }];
 
-                    [realtime2.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+                    [realtime2 onAll:^(ARTConnectionStateChange *stateChange) {
+                        ARTRealtimeConnectionState state = stateChange.current;
+                        ARTErrorInfo *errorInfo = stateChange.reason;
                         if(state == ARTRealtimeFailed) {
                             hasFailed = true;
                             [realtime2 connect];

--- a/ably-iosTests/ARTRealtimePresenceTest.m
+++ b/ably-iosTests/ARTRealtimePresenceTest.m
@@ -143,7 +143,7 @@
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         XCTestExpectation *expectConnected = [self expectationWithDescription:@"expectConnected"];
 
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [expectConnected fulfill];
@@ -236,7 +236,7 @@
             [expectation fulfill];
         }];
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -275,7 +275,7 @@
             }
         }];
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -311,7 +311,7 @@
                 [expectation fulfill];
             }
         }];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -348,7 +348,7 @@
                 [expectation fulfill];
             }
         }];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -384,7 +384,7 @@
                 [expectation fulfill];
             }
         }];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -422,7 +422,7 @@
             
         }];
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -451,7 +451,7 @@
             }
         }];
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -612,7 +612,7 @@
             }
         }];
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -650,7 +650,7 @@
             }
         }];
         
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 [channel attach];
@@ -763,7 +763,7 @@
     NSString * presenceEnter = @"client_has_entered";
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
@@ -783,7 +783,7 @@
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"channel"];
         __block bool hasDisconnected = false;
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onDisconnected];
@@ -835,7 +835,7 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClientIdFailsOnError"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
@@ -1137,7 +1137,7 @@
                         }
                     }];
 
-                    [realtime2 onAll:^(ARTConnectionStateChange *stateChange) {
+                    [realtime2 on:^(ARTConnectionStateChange *stateChange) {
                         ARTRealtimeConnectionState state = stateChange.current;
                         ARTErrorInfo *errorInfo = stateChange.reason;
                         if(state == ARTRealtimeFailed) {

--- a/ably-iosTests/ARTRealtimeRecoverTest.m
+++ b/ably-iosTests/ARTRealtimeRecoverTest.m
@@ -71,7 +71,7 @@
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
 
         __block NSString *firstConnectionId = nil;
-        [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [_realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeConnected) {
                 firstConnectionId = [_realtime connectionId];
@@ -88,7 +88,7 @@
                 _realtimeNonRecovered = [[ARTRealtime alloc] initWithOptions:options];
 
                 ARTRealtimeChannel *c2 = [_realtimeNonRecovered.channels get:channelName];
-                [_realtimeNonRecovered onAll:^(ARTConnectionStateChange *stateChange) {
+                [_realtimeNonRecovered on:^(ARTConnectionStateChange *stateChange) {
                     ARTRealtimeConnectionState state2 = stateChange.current;
                     if (state2 == ARTRealtimeConnected) {
                         // Sending other message to the same channel to check if the recovered connection receives it
@@ -100,7 +100,7 @@
                             ARTRealtime *realtimeRecovered = [[ARTRealtime alloc] initWithOptions:options];
                             ARTRealtimeChannel *c3 = [realtimeRecovered.channels get:channelName];
 
-                            [realtimeRecovered onAll:^(ARTConnectionStateChange *stateChange) {
+                            [realtimeRecovered on:^(ARTConnectionStateChange *stateChange) {
                                 ARTRealtimeConnectionState cState = stateChange.current;
                                 if (cState == ARTRealtimeConnected) {
                                     XCTAssertEqualObjects([realtimeRecovered connectionId], firstConnectionId);
@@ -124,7 +124,7 @@
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
         options.recover = @"bad_recovery_key:1234";
         _realtimeRecover = [[ARTRealtime alloc] initWithOptions:options];
-        [_realtimeRecover onAll:^(ARTConnectionStateChange *stateChange) {
+        [_realtimeRecover on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState cState = stateChange.current;
             ARTErrorInfo *errorInfo = stateChange.reason;
             if (cState == ARTRealtimeFailed) {

--- a/ably-iosTests/ARTRealtimeRecoverTest.m
+++ b/ably-iosTests/ARTRealtimeRecoverTest.m
@@ -73,7 +73,6 @@
         __block NSString *firstConnectionId = nil;
         [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 firstConnectionId = [_realtime connectionId];
 
@@ -91,7 +90,6 @@
                 ARTRealtimeChannel *c2 = [_realtimeNonRecovered.channels get:channelName];
                 [_realtimeNonRecovered onAll:^(ARTConnectionStateChange *stateChange) {
                     ARTRealtimeConnectionState state2 = stateChange.current;
-                    ARTErrorInfo *errorInfo = stateChange.reason;
                     if (state2 == ARTRealtimeConnected) {
                         // Sending other message to the same channel to check if the recovered connection receives it
                         [c2 publish:c2Message cb:^(ARTStatus *status) {
@@ -104,7 +102,6 @@
 
                             [realtimeRecovered onAll:^(ARTConnectionStateChange *stateChange) {
                                 ARTRealtimeConnectionState cState = stateChange.current;
-                                ARTErrorInfo *errorInfo = stateChange.reason;
                                 if (cState == ARTRealtimeConnected) {
                                     XCTAssertEqualObjects([realtimeRecovered connectionId], firstConnectionId);
                                     [c3 subscribe:^(ARTMessage *message, ARTErrorInfo *errorInfo) {

--- a/ably-iosTests/ARTRealtimeResumeTest.m
+++ b/ably-iosTests/ARTRealtimeResumeTest.m
@@ -88,7 +88,6 @@
 
         [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeFailed) {
                 // 4. Client A is disconnected and B sends message
                 [channelB publish:message2 cb:^(ARTStatus *status) {
@@ -157,8 +156,6 @@
         }];
         
         [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
             [channel attach];
         }];
     }];

--- a/ably-iosTests/ARTRealtimeResumeTest.m
+++ b/ably-iosTests/ARTRealtimeResumeTest.m
@@ -35,13 +35,13 @@
 - (void)tearDown {
     if (_realtime) {
         [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.eventEmitter removeEvents];
+        [_realtime resetEventEmitter];
         [_realtime close];
     }
     _realtime = nil;
     if (_realtime2) {
         [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2.eventEmitter removeEvents];
+        [_realtime2 resetEventEmitter];
         [_realtime2 close];
     }
     _realtime2 = nil;
@@ -86,7 +86,9 @@
             }
         }];
 
-        [_realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeFailed) {
                 // 4. Client A is disconnected and B sends message
                 [channelB publish:message2 cb:^(ARTStatus *status) {
@@ -154,7 +156,9 @@
             }
         }];
         
-        [_realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             [channel attach];
         }];
     }];

--- a/ably-iosTests/ARTRealtimeResumeTest.m
+++ b/ably-iosTests/ARTRealtimeResumeTest.m
@@ -86,7 +86,7 @@
             }
         }];
 
-        [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [_realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             if (state == ARTRealtimeFailed) {
                 // 4. Client A is disconnected and B sends message
@@ -155,7 +155,7 @@
             }
         }];
         
-        [_realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [_realtime on:^(ARTConnectionStateChange *stateChange) {
             [channel attach];
         }];
     }];

--- a/ably-iosTests/ARTTestUtil.m
+++ b/ably-iosTests/ARTTestUtil.m
@@ -261,7 +261,9 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
     XCTestExpectation *expectation = [testCase expectationWithDescription:@"testRealtime"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug cb:^(ARTClientOptions *options) {
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        [realtime.eventEmitter on:^(ARTRealtimeConnectionState state, ARTErrorInfo *errorInfo) {
+        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+            ARTRealtimeConnectionState state = stateChange.current;
+            ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeFailed) {
                 // FIXME: XCTFail not working outside a XCTestCase method!
                 if (errorInfo) {

--- a/ably-iosTests/ARTTestUtil.m
+++ b/ably-iosTests/ARTTestUtil.m
@@ -261,7 +261,7 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
     XCTestExpectation *expectation = [testCase expectationWithDescription:@"testRealtime"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug cb:^(ARTClientOptions *options) {
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        [realtime onAll:^(ARTConnectionStateChange *stateChange) {
+        [realtime on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
             ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeFailed) {

--- a/ably.xcodeproj/project.pbxproj
+++ b/ably.xcodeproj/project.pbxproj
@@ -145,6 +145,9 @@
 		D7F1D3771BF4DE72001A4B5E /* ARTRealtimePresence.h in Headers */ = {isa = PBXBuildFile; fileRef = D7F1D3751BF4DE72001A4B5E /* ARTRealtimePresence.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D7F1D3781BF4DE72001A4B5E /* ARTRealtimePresence.m in Sources */ = {isa = PBXBuildFile; fileRef = D7F1D3761BF4DE72001A4B5E /* ARTRealtimePresence.m */; };
 		D7F1D37A1BF4E33A001A4B5E /* ARTRestChannel+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D7F1D3791BF4E33A001A4B5E /* ARTRestChannel+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EB0505FC1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB0505FB1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h */; };
+		EB1AE0CC1C5C1EB200D62250 /* ARTEventEmitter+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB1AE0CB1C5C1EB200D62250 /* ARTEventEmitter+Private.h */; };
+		EB1AE0CE1C5C3A4900D62250 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1AE0CD1C5C3A4900D62250 /* Utilities.swift */; };
 		EB3239441C59AB0400892664 /* ARTDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = EB3239421C59AB0400892664 /* ARTDataEncoder.m */; };
 		EB3239451C59AB0400892664 /* ARTDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = EB3239421C59AB0400892664 /* ARTDataEncoder.m */; };
 		EB82F8511C59D29B00661917 /* ARTDataEncoder.h in Headers */ = {isa = PBXBuildFile; fileRef = EB3239461C59AB2C00892664 /* ARTDataEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -355,12 +358,15 @@
 		D7F1D3761BF4DE72001A4B5E /* ARTRealtimePresence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimePresence.m; sourceTree = "<group>"; };
 		D7F1D3791BF4E33A001A4B5E /* ARTRestChannel+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTRestChannel+Private.h"; sourceTree = "<group>"; };
 		DF8DF755839D59574B7B795F /* Pods-ablySpec.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ablySpec.release.xcconfig"; path = "Pods/Target Support Files/Pods-ablySpec/Pods-ablySpec.release.xcconfig"; sourceTree = "<group>"; };
-		EB3239421C59AB0400892664 /* ARTDataEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDataEncoder.m; sourceTree = "<group>"; };
-		EB3239461C59AB2C00892664 /* ARTDataEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTDataEncoder.h; path = "ably-ios/ARTDataEncoder.h"; sourceTree = SOURCE_ROOT; };
 		EB89D4021C61C1A4007FA5B7 /* ARTRestChannels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTRestChannels.h; sourceTree = "<group>"; };
 		EB89D4031C61C1A4007FA5B7 /* ARTRestChannels.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTRestChannels.m; sourceTree = "<group>"; };
 		EB89D4081C61C5ED007FA5B7 /* ARTRealtimeChannels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTRealtimeChannels.h; sourceTree = "<group>"; };
 		EB89D40A1C61C6EA007FA5B7 /* ARTRealtimeChannels.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTRealtimeChannels.m; sourceTree = "<group>"; };
+		EB0505FB1C5BD7C4006BA7E2 /* ARTBaseMessage+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTBaseMessage+Private.h"; sourceTree = "<group>"; };
+		EB1AE0CB1C5C1EB200D62250 /* ARTEventEmitter+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTEventEmitter+Private.h"; sourceTree = "<group>"; };
+		EB1AE0CD1C5C3A4900D62250 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		EB3239421C59AB0400892664 /* ARTDataEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDataEncoder.m; sourceTree = "<group>"; };
+		EB3239461C59AB2C00892664 /* ARTDataEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARTDataEncoder.h; path = "ably-ios/ARTDataEncoder.h"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -442,6 +448,7 @@
 				D74EFAEA1C4D09B500CFF98E /* RealtimeClientChannel.swift */,
 				D71D30031C5F7B2F002115B0 /* RealtimeClientChannels.swift */,
 				851674EE1B7BA5CD00D35169 /* Stats.swift */,
+				EB1AE0CD1C5C3A4900D62250 /* Utilities.swift */,
 			);
 			path = ablySpec;
 			sourceTree = "<group>";
@@ -566,8 +573,6 @@
 				D7F1D3751BF4DE72001A4B5E /* ARTRealtimePresence.h */,
 				D7F1D3761BF4DE72001A4B5E /* ARTRealtimePresence.m */,
 				D746AE321BBC29EB003ECEF8 /* Transport */,
-				D746AE3E1BBC5B14003ECEF8 /* ARTEventEmitter.h */,
-				D746AE3F1BBC5B14003ECEF8 /* ARTEventEmitter.m */,
 				D746AE451BBD6FE9003ECEF8 /* ARTQueuedMessage.h */,
 				D746AE461BBD6FE9003ECEF8 /* ARTQueuedMessage.m */,
 				D746AE491BBD70F0003ECEF8 /* ARTRealtimeChannelSubscription.h */,
@@ -636,6 +641,9 @@
 		D746AE341BBC2B60003ECEF8 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				EB1AE0CB1C5C1EB200D62250 /* ARTEventEmitter+Private.h */,
+				D746AE3E1BBC5B14003ECEF8 /* ARTEventEmitter.h */,
+				D746AE3F1BBC5B14003ECEF8 /* ARTEventEmitter.m */,
 				960D07911A45F1D800ED8C8C /* ARTCrypto.h */,
 				960D07921A45F1D800ED8C8C /* ARTCrypto.m */,
 				96A507A71A37806A0077CDF8 /* ARTEncoder.h */,
@@ -741,6 +749,7 @@
 				D7F1D37A1BF4E33A001A4B5E /* ARTRestChannel+Private.h in Headers */,
 				85B2C2191B6FE8DE00EA5254 /* CompatibilityMacros.h in Headers */,
 				96A507A91A37806A0077CDF8 /* ARTEncoder.h in Headers */,
+				EB1AE0CC1C5C1EB200D62250 /* ARTEventEmitter+Private.h in Headers */,
 				1C6C18A31ADFDAB100AB79E4 /* ARTLog.h in Headers */,
 				D7EBE5A41BE9F6900086E675 /* ARTConnection.h in Headers */,
 				96A507AD1A3780F60077CDF8 /* ARTJsonEncoder.h in Headers */,
@@ -1024,6 +1033,7 @@
 				EB89D4071C61C1B9007FA5B7 /* ARTRestChannels.m in Sources */,
 				D74EFAEB1C4D09B500CFF98E /* RealtimeClientChannel.swift in Sources */,
 				851674EF1B7BA5CD00D35169 /* Stats.swift in Sources */,
+				EB1AE0CE1C5C3A4900D62250 /* Utilities.swift in Sources */,
 				D72304701BB72CED00F1ABDA /* RealtimeClient.swift in Sources */,
 				D746AE2D1BBB625E003ECEF8 /* RestClientChannels.swift in Sources */,
 				EB3239451C59AB0400892664 /* ARTDataEncoder.m in Sources */,

--- a/ablySpec/Auth.swift
+++ b/ablySpec/Auth.swift
@@ -248,7 +248,7 @@ class Auth : QuickSpec {
                         client.connect()
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.onAll { stateChange in
+                            client.on { stateChange in
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected && error == nil {

--- a/ablySpec/Auth.swift
+++ b/ablySpec/Auth.swift
@@ -248,7 +248,9 @@ class Auth : QuickSpec {
                         client.connect()
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.eventEmitter.on({ state, error in
+                            client.onAll { stateChange in
+                                let state = stateChange.current
+                                let error = stateChange.reason
                                 if state == .Connected && error == nil {
                                     let currentChannel = client.channels.get("test")
                                     currentChannel.subscribe({ message, errorInfo in
@@ -256,7 +258,7 @@ class Auth : QuickSpec {
                                     })
                                     currentChannel.publish("ping", cb:nil)
                                 }
-                            })
+                            }
                         }
 
                         let transport = client.transport as! TestProxyTransport

--- a/ablySpec/Auth.swift
+++ b/ablySpec/Auth.swift
@@ -249,6 +249,7 @@ class Auth : QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             client.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected && error == nil {

--- a/ablySpec/RealtimeClient.swift
+++ b/ablySpec/RealtimeClient.swift
@@ -36,6 +36,7 @@ class RealtimeClient: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -76,6 +77,7 @@ class RealtimeClient: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -98,6 +100,7 @@ class RealtimeClient: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         newClient.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -180,6 +183,7 @@ class RealtimeClient: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -281,6 +285,7 @@ class RealtimeClient: QuickSpec {
 
                 waitUntil(timeout: testTimeout + options.suspendedRetryTimeout) { done in
                     client.on { stateChange in
+                        let stateChange = stateChange!
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {

--- a/ablySpec/RealtimeClient.swift
+++ b/ablySpec/RealtimeClient.swift
@@ -35,7 +35,9 @@ class RealtimeClient: QuickSpec {
                     let client = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.eventEmitter.on { state, errorInfo in
+                        client.onAll { stateChange in
+                            let state = stateChange.current
+                            let errorInfo = stateChange.reason
                             switch state {
                             case .Connecting, .Closing, .Closed:
                                 break
@@ -73,7 +75,9 @@ class RealtimeClient: QuickSpec {
                     let client = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.eventEmitter.on { state, errorInfo in
+                        client.onAll { stateChange in
+                            let state = stateChange.current
+                            let errorInfo = stateChange.reason
                             switch state {
                             case .Failed:
                                 self.checkError(errorInfo, withAlternative: "Failed state")
@@ -93,7 +97,9 @@ class RealtimeClient: QuickSpec {
                     let newClient = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        newClient.eventEmitter.on { state, errorInfo in
+                        newClient.onAll { stateChange in
+                            let state = stateChange.current
+                            let errorInfo = stateChange.reason
                             switch state {
                             case .Failed:
                                 self.checkError(errorInfo, withAlternative: "Failed state")
@@ -173,7 +179,9 @@ class RealtimeClient: QuickSpec {
                     let client = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.eventEmitter.on { state, errorInfo in
+                        client.onAll { stateChange in
+                            let state = stateChange.current
+                            let errorInfo = stateChange.reason
                             switch state {
                             case .Failed:
                                 self.checkError(errorInfo, withAlternative: "Failed state")
@@ -272,7 +280,9 @@ class RealtimeClient: QuickSpec {
                 var endInterval: UInt?
 
                 waitUntil(timeout: testTimeout + options.suspendedRetryTimeout) { done in
-                    client.eventEmitter.on { state, errorInfo in
+                    client.onAll { stateChange in
+                        let state = stateChange.current
+                        let errorInfo = stateChange.reason
                         switch state {
                         case .Failed:
                             self.checkError(errorInfo, withAlternative: "Failed state")

--- a/ablySpec/RealtimeClient.swift
+++ b/ablySpec/RealtimeClient.swift
@@ -35,7 +35,7 @@ class RealtimeClient: QuickSpec {
                     let client = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -75,7 +75,7 @@ class RealtimeClient: QuickSpec {
                     let client = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -97,7 +97,7 @@ class RealtimeClient: QuickSpec {
                     let newClient = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        newClient.onAll { stateChange in
+                        newClient.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -179,7 +179,7 @@ class RealtimeClient: QuickSpec {
                     let client = ARTRealtime(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -280,7 +280,7 @@ class RealtimeClient: QuickSpec {
                 var endInterval: UInt?
 
                 waitUntil(timeout: testTimeout + options.suspendedRetryTimeout) { done in
-                    client.onAll { stateChange in
+                    client.on { stateChange in
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -328,6 +328,7 @@ class RealtimeClientChannel: QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             client.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {
@@ -354,6 +355,7 @@ class RealtimeClientChannel: QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             client.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -327,7 +327,7 @@ class RealtimeClientChannel: QuickSpec {
                         defer { client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.onAll { stateChange in
+                            client.on { stateChange in
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {
@@ -353,7 +353,7 @@ class RealtimeClientChannel: QuickSpec {
                         defer { client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.onAll { stateChange in
+                            client.on { stateChange in
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -327,7 +327,9 @@ class RealtimeClientChannel: QuickSpec {
                         defer { client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.eventEmitter.on { state, error in
+                            client.onAll { stateChange in
+                                let state = stateChange.current
+                                let error = stateChange.reason
                                 if state == .Connected {
                                     let channel = client.channels.get("test")
                                     channel.subscribeToStateChanges { state, status in
@@ -351,7 +353,9 @@ class RealtimeClientChannel: QuickSpec {
                         defer { client.close() }
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.eventEmitter.on { state, error in
+                            client.onAll { stateChange in
+                                let state = stateChange.current
+                                let error = stateChange.reason
                                 if state == .Connected {
                                     let channel = client.channels.get("test")
                                     channel.subscribeToStateChanges { channelState, channelStatus in

--- a/ablySpec/RealtimeClientConnection.swift
+++ b/ablySpec/RealtimeClientConnection.swift
@@ -49,7 +49,7 @@ class RealtimeClientConnection: QuickSpec {
                     client.connect()
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -86,7 +86,7 @@ class RealtimeClientConnection: QuickSpec {
                     client.connect()
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -123,7 +123,7 @@ class RealtimeClientConnection: QuickSpec {
                 expect(options.autoConnect).to(beTrue(), description: "autoConnect should be true by default")
 
                 // The only way to control this functionality is with the options flag
-                ARTRealtime(options: options).onAll { stateChange in
+                ARTRealtime(options: options).on { stateChange in
                     let state = stateChange.current
                     let errorInfo = stateChange.reason
                     switch state {
@@ -144,7 +144,7 @@ class RealtimeClientConnection: QuickSpec {
                 var waiting = true
 
                 waitUntil(timeout: testTimeout) { done in
-                    client.onAll { stateChange in
+                    client.on { stateChange in
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {
@@ -177,7 +177,7 @@ class RealtimeClientConnection: QuickSpec {
                     var events: [ARTRealtimeConnectionState] = []
 
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -236,7 +236,7 @@ class RealtimeClientConnection: QuickSpec {
                     var events: [ARTRealtimeConnectionState] = []
 
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -270,7 +270,7 @@ class RealtimeClientConnection: QuickSpec {
                     var events: [ARTRealtimeConnectionState] = []
 
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -308,7 +308,7 @@ class RealtimeClientConnection: QuickSpec {
                     expect(connection.state.rawValue).to(equal(ARTRealtimeConnectionState.Initialized.rawValue), description: "Missing INITIALIZED state")
 
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -337,7 +337,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     var errorInfo: ARTErrorInfo?
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let reason = stateChange.reason
                             switch state {
@@ -423,7 +423,7 @@ class RealtimeClientConnection: QuickSpec {
                 client.connect()
 
                 waitUntil(timeout: testTimeout) { done in
-                    client.onAll { stateChange in
+                    client.on { stateChange in
                         let state = stateChange.current
                         let error = stateChange.reason
                         expect(error).to(beNil())
@@ -496,7 +496,7 @@ class RealtimeClientConnection: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.onAll { stateChange in
+                            client.on { stateChange in
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {
@@ -564,7 +564,7 @@ class RealtimeClientConnection: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            client.onAll { stateChange in
+                            client.on { stateChange in
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {
@@ -772,7 +772,7 @@ class RealtimeClientConnection: QuickSpec {
                     expect(connection.id).to(beNil())
 
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             expect(errorInfo).to(beNil())
@@ -800,7 +800,7 @@ class RealtimeClientConnection: QuickSpec {
                         for _ in 1...max {
                             disposable.append(ARTRealtime(options: options))
                             let currentConnection = disposable.last!.connection()
-                            currentConnection.onAll { stateChange in
+                            currentConnection.on { stateChange in
                                 let state = stateChange.current
                                 let errorInfo = stateChange.reason
                                 if state == .Connected {
@@ -838,7 +838,7 @@ class RealtimeClientConnection: QuickSpec {
                     expect(connection.key).to(beNil())
 
                     waitUntil(timeout: testTimeout) { done in
-                        connection.onAll { stateChange in
+                        connection.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             expect(errorInfo).to(beNil())
@@ -864,7 +864,7 @@ class RealtimeClientConnection: QuickSpec {
                         for _ in 1...max {
                             disposable.append(ARTRealtime(options: options))
                             let currentConnection = disposable.last!.connection()
-                            currentConnection.onAll { stateChange in
+                            currentConnection.on { stateChange in
                                 let state = stateChange.current
                                 let errorInfo = stateChange.reason
                                 if state == .Connected {
@@ -899,7 +899,7 @@ class RealtimeClientConnection: QuickSpec {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer { client.close() }
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             if state == .Connected {
@@ -979,7 +979,7 @@ class RealtimeClientConnection: QuickSpec {
                     var states: [ARTRealtimeConnectionState] = []
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -1021,7 +1021,7 @@ class RealtimeClientConnection: QuickSpec {
                     var start: NSDate?
                     var end: NSDate?
 
-                    client.onAll { stateChange in
+                    client.on { stateChange in
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {
@@ -1064,7 +1064,7 @@ class RealtimeClientConnection: QuickSpec {
                     var states: [ARTRealtimeConnectionState] = []
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -1105,7 +1105,7 @@ class RealtimeClientConnection: QuickSpec {
                 defer { client.close() }
 
                 waitUntil(timeout: testTimeout) { done in
-                    client.onAll { stateChange in
+                    client.on { stateChange in
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {
@@ -1142,7 +1142,7 @@ class RealtimeClientConnection: QuickSpec {
                     }
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -1190,7 +1190,7 @@ class RealtimeClientConnection: QuickSpec {
                     defer { client.close() }
 
                     waitUntil(timeout: testTimeout) { done in
-                        client.onAll { stateChange in
+                        client.on { stateChange in
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {

--- a/ablySpec/RealtimeClientConnection.swift
+++ b/ablySpec/RealtimeClientConnection.swift
@@ -50,6 +50,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -87,6 +88,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -124,6 +126,7 @@ class RealtimeClientConnection: QuickSpec {
 
                 // The only way to control this functionality is with the options flag
                 ARTRealtime(options: options).on { stateChange in
+                    let stateChange = stateChange!
                     let state = stateChange.current
                     let errorInfo = stateChange.reason
                     switch state {
@@ -145,6 +148,7 @@ class RealtimeClientConnection: QuickSpec {
 
                 waitUntil(timeout: testTimeout) { done in
                     client.on { stateChange in
+                        let stateChange = stateChange!
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {
@@ -178,6 +182,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -237,6 +242,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -271,6 +277,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -309,6 +316,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -338,6 +346,7 @@ class RealtimeClientConnection: QuickSpec {
                     var errorInfo: ARTErrorInfo?
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let reason = stateChange.reason
                             switch state {
@@ -424,6 +433,7 @@ class RealtimeClientConnection: QuickSpec {
 
                 waitUntil(timeout: testTimeout) { done in
                     client.on { stateChange in
+                        let stateChange = stateChange!
                         let state = stateChange.current
                         let error = stateChange.reason
                         expect(error).to(beNil())
@@ -497,6 +507,7 @@ class RealtimeClientConnection: QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             client.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {
@@ -565,6 +576,7 @@ class RealtimeClientConnection: QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             client.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let error = stateChange.reason
                                 if state == .Connected {
@@ -773,6 +785,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             expect(errorInfo).to(beNil())
@@ -801,6 +814,7 @@ class RealtimeClientConnection: QuickSpec {
                             disposable.append(ARTRealtime(options: options))
                             let currentConnection = disposable.last!.connection()
                             currentConnection.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let errorInfo = stateChange.reason
                                 if state == .Connected {
@@ -839,6 +853,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         connection.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             expect(errorInfo).to(beNil())
@@ -865,6 +880,7 @@ class RealtimeClientConnection: QuickSpec {
                             disposable.append(ARTRealtime(options: options))
                             let currentConnection = disposable.last!.connection()
                             currentConnection.on { stateChange in
+                                let stateChange = stateChange!
                                 let state = stateChange.current
                                 let errorInfo = stateChange.reason
                                 if state == .Connected {
@@ -900,6 +916,7 @@ class RealtimeClientConnection: QuickSpec {
                     defer { client.close() }
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             if state == .Connected {
@@ -980,6 +997,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -1022,6 +1040,7 @@ class RealtimeClientConnection: QuickSpec {
                     var end: NSDate?
 
                     client.on { stateChange in
+                        let stateChange = stateChange!
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {
@@ -1065,6 +1084,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -1106,6 +1126,7 @@ class RealtimeClientConnection: QuickSpec {
 
                 waitUntil(timeout: testTimeout) { done in
                     client.on { stateChange in
+                        let stateChange = stateChange!
                         let state = stateChange.current
                         let errorInfo = stateChange.reason
                         switch state {
@@ -1143,6 +1164,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {
@@ -1191,6 +1213,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         client.on { stateChange in
+                            let stateChange = stateChange!
                             let state = stateChange.current
                             let errorInfo = stateChange.reason
                             switch state {

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -237,7 +237,8 @@ class PublishTestMessage {
             }
         }
 
-        client.eventEmitter.on { state, error in
+        client.onAll { stateChange in
+            let state = stateChange.current
             if state == .Connected {
                 let channel = client.channels.get("test")
                 channel.subscribeToStateChanges { state, status in
@@ -475,10 +476,11 @@ class ARTRealtimeExtended: ARTRealtime {
 extension ARTRealtime {
 
     func dispose() {
-        for channel in self.channels {
-            self.channels.release(channel.name)
+        let names = self.channels.map({ $0.name })
+        for name in names {
+            self.channels.release(name)
         }
-        eventEmitter.removeEvents()
+        self.resetEventEmitter()
     }
 
 }

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -237,7 +237,7 @@ class PublishTestMessage {
             }
         }
 
-        client.onAll { stateChange in
+        client.on { stateChange in
             let state = stateChange.current
             if state == .Connected {
                 let channel = client.channels.get("test")

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -238,6 +238,7 @@ class PublishTestMessage {
         }
 
         client.on { stateChange in
+            let stateChange = stateChange!
             let state = stateChange.current
             if state == .Connected {
                 let channel = client.channels.get("test")

--- a/ablySpec/Utilities.swift
+++ b/ablySpec/Utilities.swift
@@ -76,30 +76,67 @@ class Utilities: QuickSpec {
                     expect(receivedAllOnce).to(equal(123))
                 }
                 
-                it("should stop receiving events when calling off") {
-                    eventEmitter.off(listenerFoo1!)
-                    eventEmitter.emit("foo", with: 123)
-                    
-                    expect(receivedFoo1).to(beNil())
-                    expect(receivedFoo2).to(equal(123))
-                    expect(receivedAll).to(equal(123))
-                    
-                    eventEmitter.emit("bar", with: 222)
-                    
-                    expect(receivedFoo2).to(equal(123))
-                    expect(receivedAll).to(equal(222))
-                    
-                    eventEmitter.off(listenerAll!)
-                    eventEmitter.emit("bar", with: 333)
-                    
-                    expect(receivedAll).to(equal(222))
+                context("calling off with a single listener argument") {
+                    it("should stop receiving events when calling off with a single listener argument") {
+                        eventEmitter.off(listenerFoo1!)
+                        eventEmitter.emit("foo", with: 123)
+                        
+                        expect(receivedFoo1).to(beNil())
+                        expect(receivedFoo2).to(equal(123))
+                        expect(receivedAll).to(equal(123))
+                        
+                        eventEmitter.emit("bar", with: 222)
+                        
+                        expect(receivedFoo2).to(equal(123))
+                        expect(receivedAll).to(equal(222))
+                        
+                        eventEmitter.off(listenerAll!)
+                        eventEmitter.emit("bar", with: 333)
+                        
+                        expect(receivedAll).to(equal(222))
+                    }
                 }
+                
+                context("calling off with listener and event arguments") {
+                    it("should still receive events if off doesn't match the listener's criteria") {
+                        eventEmitter.off("foo", listener: listenerAll!)
+                        eventEmitter.emit("foo", with: 111)
 
-                it("should receive events if off doesn't match the listener's criteria") {
-                    eventEmitter.off("foo", listener: listenerAll!)
-                    eventEmitter.emit("foo", with: 111)
+                        expect(receivedFoo1).to(equal(111))
+                        expect(receivedAll).to(equal(111))
+                    }
+                
+                    it("should stop receive events if off matches the listener's criteria") {
+                        eventEmitter.off("foo", listener: listenerFoo1!)
+                        eventEmitter.emit("foo", with: 111)
 
-                    expect(receivedAll).to(equal(111))
+                        expect(receivedFoo1).to(beNil())
+                        expect(receivedAll).to(equal(111))
+                    }
+                }
+                
+                context("calling off with no arguments") {
+                    it("should remove all listeners") {
+                        eventEmitter.off()
+                        eventEmitter.emit("foo", with: 111)
+                        
+                        expect(receivedFoo1).to(beNil())
+                        expect(receivedFoo2).to(beNil())
+                        expect(receivedAll).to(beNil())
+                        
+                        eventEmitter.emit("bar", with: 111)
+                        
+                        expect(receivedBar).to(beNil())
+                        expect(receivedBarOnce).to(beNil())
+                        expect(receivedAll).to(beNil())
+                    }
+                    
+                    it("should allow listening again") {
+                        eventEmitter.off()
+                        eventEmitter.on("foo", call: { receivedFoo1 = $0 as? Int })
+                        eventEmitter.emit("foo", with: 111)
+                        expect(receivedFoo1).to(equal(111))
+                    }
                 }
             }
         }

--- a/ablySpec/Utilities.swift
+++ b/ablySpec/Utilities.swift
@@ -18,34 +18,25 @@ class Utilities: QuickSpec {
                 var receivedFoo1: Int?
                 var receivedFoo2: Int?
                 var receivedBar: Int?
-                var receivedFooOrBar: Int?
                 var receivedBarOnce: Int?
                 var receivedAll: Int?
                 var receivedAllOnce: Int?
                 var listenerFoo1: ARTEventListener?
-                var listenerFoo2: ARTEventListener?
-                var listenerBar: ARTEventListener?
-                var listenerFooOrBar: ARTEventListener?
-                var listenerBarOnce: ARTEventListener?
                 var listenerAll: ARTEventListener?
-                var listenerAllOnce: ARTEventListener?
                 
                 beforeEach {
                     eventEmitter = ARTEventEmitter()
                     receivedFoo1 = nil
                     receivedFoo2 = nil
                     receivedBar = nil
-                    receivedFooOrBar = nil
                     receivedBarOnce = nil
                     receivedAll = nil
                     listenerFoo1 = eventEmitter.on("foo", call: { receivedFoo1 = $0 as? Int })
-                    listenerFoo2 = eventEmitter.on("foo", call: { receivedFoo2 = $0 as? Int })
-                    listenerBar = eventEmitter.on("bar", call: { receivedBar = $0 as? Int })
-                    listenerFooOrBar = eventEmitter.on("foo", call: { receivedFooOrBar = $0 as? Int })
-                    eventEmitter.on("bar", callListener: listenerFooOrBar!)
-                    listenerBarOnce = eventEmitter.once("bar", call: { receivedBarOnce = $0 as? Int })
+                    eventEmitter.on("foo", call: { receivedFoo2 = $0 as? Int })
+                    eventEmitter.on("bar", call: { receivedBar = $0 as? Int })
+                    eventEmitter.once("bar", call: { receivedBarOnce = $0 as? Int })
                     listenerAll = eventEmitter.on { receivedAll = $0 as? Int }
-                    listenerAllOnce = eventEmitter.once { receivedAllOnce = $0 as? Int }
+                    eventEmitter.once { receivedAllOnce = $0 as? Int }
                 }
 
                 it("should emit events to all relevant listeners") {
@@ -54,7 +45,6 @@ class Utilities: QuickSpec {
                     expect(receivedFoo1).to(equal(123))
                     expect(receivedFoo2).to(equal(123))
                     expect(receivedBar).to(beNil())
-                    expect(receivedFooOrBar).to(equal(123))
                     expect(receivedAll).to(equal(123))
                     
                     eventEmitter.emit("bar", with:456)
@@ -62,12 +52,10 @@ class Utilities: QuickSpec {
                     expect(receivedFoo1).to(equal(123))
                     expect(receivedFoo2).to(equal(123))
                     expect(receivedBar).to(equal(456))
-                    expect(receivedFooOrBar).to(equal(456))
                     expect(receivedAll).to(equal(456))
                     
                     eventEmitter.emit("qux", with:789)
                     
-                    expect(receivedFooOrBar).to(equal(456))
                     expect(receivedAll).to(equal(789))
                 }
                 
@@ -94,41 +82,24 @@ class Utilities: QuickSpec {
                     
                     expect(receivedFoo1).to(beNil())
                     expect(receivedFoo2).to(equal(123))
-                    expect(receivedFooOrBar).to(equal(123))
                     expect(receivedAll).to(equal(123))
                     
-                    eventEmitter.off("foo", listener: listenerFooOrBar!)
-                    eventEmitter.emit("foo", with: 456)
-                    
-                    expect(receivedFoo2).to(equal(456))
-                    expect(receivedFooOrBar).to(equal(123))
-                    
-                    eventEmitter.emit("bar", with: 789)
-                    
-                    expect(receivedFooOrBar).to(equal(789))
-                    
-                    eventEmitter.off("foo", listener: listenerAll!)
-                    eventEmitter.emit("foo", with: 111)
-                    
-                    expect(receivedAll).to(equal(789))
-                    
                     eventEmitter.emit("bar", with: 222)
+                    
+                    expect(receivedFoo2).to(equal(123))
+                    expect(receivedAll).to(equal(222))
+                    
+                    eventEmitter.off(listenerAll!)
+                    eventEmitter.emit("bar", with: 333)
                     
                     expect(receivedAll).to(equal(222))
                 }
 
-                it("should receive only once after calling on and then once") {
-                    eventEmitter.once("foo", callListener: listenerAll!)
-
-                    eventEmitter.emit("foo", with: 123)
-                    expect(receivedAll).to(equal(123))
-                    eventEmitter.emit("bar", with: 456)
-                    expect(receivedAll).to(equal(456))
-
+                it("should receive events if off doesn't match the listener's criteria") {
+                    eventEmitter.off("foo", listener: listenerAll!)
                     eventEmitter.emit("foo", with: 111)
-                    expect(receivedAll).to(equal(456))
-                    eventEmitter.emit("bar", with: 222)
-                    expect(receivedAll).to(equal(222))
+
+                    expect(receivedAll).to(equal(111))
                 }
             }
         }

--- a/ablySpec/Utilities.swift
+++ b/ablySpec/Utilities.swift
@@ -44,8 +44,8 @@ class Utilities: QuickSpec {
                     listenerFooOrBar = eventEmitter.on("foo", call: { receivedFooOrBar = $0 as? Int })
                     eventEmitter.on("bar", callListener: listenerFooOrBar!)
                     listenerBarOnce = eventEmitter.once("bar", call: { receivedBarOnce = $0 as? Int })
-                    listenerAll = eventEmitter.onAll { receivedAll = $0 as? Int }
-                    listenerAllOnce = eventEmitter.onceAll { receivedAllOnce = $0 as? Int }
+                    listenerAll = eventEmitter.on { receivedAll = $0 as? Int }
+                    listenerAllOnce = eventEmitter.once { receivedAllOnce = $0 as? Int }
                 }
 
                 it("should emit events to all relevant listeners") {
@@ -89,7 +89,7 @@ class Utilities: QuickSpec {
                 }
                 
                 it("should stop receiving events when calling off") {
-                    eventEmitter.offAll(listenerFoo1!)
+                    eventEmitter.off(listenerFoo1!)
                     eventEmitter.emit("foo", with: 123)
                     
                     expect(receivedFoo1).to(beNil())
@@ -117,7 +117,7 @@ class Utilities: QuickSpec {
                     expect(receivedAll).to(equal(222))
                 }
 
-                it("should receive only once after calling onAll and then once") {
+                it("should receive only once after calling on and then once") {
                     eventEmitter.once("foo", callListener: listenerAll!)
 
                     eventEmitter.emit("foo", with: 123)

--- a/ablySpec/Utilities.swift
+++ b/ablySpec/Utilities.swift
@@ -1,0 +1,137 @@
+//
+//  Utilities.swift
+//  ably
+//
+//  Created by Toni Cárdenas on 30/1/16.
+//  Copyright © 2016 Ably. All rights reserved.
+//
+
+import Nimble
+import Quick
+import Foundation
+
+class Utilities: QuickSpec {
+    override func spec() {
+        describe("Utilities") {
+            context("EventEmitter") {
+                var eventEmitter = ARTEventEmitter()
+                var receivedFoo1: Int?
+                var receivedFoo2: Int?
+                var receivedBar: Int?
+                var receivedFooOrBar: Int?
+                var receivedBarOnce: Int?
+                var receivedAll: Int?
+                var receivedAllOnce: Int?
+                var listenerFoo1: ARTEventListener?
+                var listenerFoo2: ARTEventListener?
+                var listenerBar: ARTEventListener?
+                var listenerFooOrBar: ARTEventListener?
+                var listenerBarOnce: ARTEventListener?
+                var listenerAll: ARTEventListener?
+                var listenerAllOnce: ARTEventListener?
+                
+                beforeEach {
+                    eventEmitter = ARTEventEmitter()
+                    receivedFoo1 = nil
+                    receivedFoo2 = nil
+                    receivedBar = nil
+                    receivedFooOrBar = nil
+                    receivedBarOnce = nil
+                    receivedAll = nil
+                    listenerFoo1 = eventEmitter.on("foo", call: { receivedFoo1 = $0 as? Int })
+                    listenerFoo2 = eventEmitter.on("foo", call: { receivedFoo2 = $0 as? Int })
+                    listenerBar = eventEmitter.on("bar", call: { receivedBar = $0 as? Int })
+                    listenerFooOrBar = eventEmitter.on("foo", call: { receivedFooOrBar = $0 as? Int })
+                    eventEmitter.on("bar", callListener: listenerFooOrBar!)
+                    listenerBarOnce = eventEmitter.once("bar", call: { receivedBarOnce = $0 as? Int })
+                    listenerAll = eventEmitter.onAll { receivedAll = $0 as? Int }
+                    listenerAllOnce = eventEmitter.onceAll { receivedAllOnce = $0 as? Int }
+                }
+
+                it("should emit events to all relevant listeners") {
+                    eventEmitter.emit("foo", with: 123)
+
+                    expect(receivedFoo1).to(equal(123))
+                    expect(receivedFoo2).to(equal(123))
+                    expect(receivedBar).to(beNil())
+                    expect(receivedFooOrBar).to(equal(123))
+                    expect(receivedAll).to(equal(123))
+                    
+                    eventEmitter.emit("bar", with:456)
+                    
+                    expect(receivedFoo1).to(equal(123))
+                    expect(receivedFoo2).to(equal(123))
+                    expect(receivedBar).to(equal(456))
+                    expect(receivedFooOrBar).to(equal(456))
+                    expect(receivedAll).to(equal(456))
+                    
+                    eventEmitter.emit("qux", with:789)
+                    
+                    expect(receivedFooOrBar).to(equal(456))
+                    expect(receivedAll).to(equal(789))
+                }
+                
+                it("should only call once listeners once for its event") {
+                    eventEmitter.emit("foo", with: 123)
+
+                    expect(receivedBarOnce).to(beNil())
+                    expect(receivedAllOnce).to(equal(123))
+                    
+                    eventEmitter.emit("bar", with: 456)
+                    
+                    expect(receivedBarOnce).to(equal(456))
+                    expect(receivedAllOnce).to(equal(123))
+
+                    eventEmitter.emit("bar", with: 789)
+                    
+                    expect(receivedBarOnce).to(equal(456))
+                    expect(receivedAllOnce).to(equal(123))
+                }
+                
+                it("should stop receiving events when calling off") {
+                    eventEmitter.offAll(listenerFoo1!)
+                    eventEmitter.emit("foo", with: 123)
+                    
+                    expect(receivedFoo1).to(beNil())
+                    expect(receivedFoo2).to(equal(123))
+                    expect(receivedFooOrBar).to(equal(123))
+                    expect(receivedAll).to(equal(123))
+                    
+                    eventEmitter.off("foo", listener: listenerFooOrBar!)
+                    eventEmitter.emit("foo", with: 456)
+                    
+                    expect(receivedFoo2).to(equal(456))
+                    expect(receivedFooOrBar).to(equal(123))
+                    
+                    eventEmitter.emit("bar", with: 789)
+                    
+                    expect(receivedFooOrBar).to(equal(789))
+                    
+                    eventEmitter.off("foo", listener: listenerAll!)
+                    eventEmitter.emit("foo", with: 111)
+                    
+                    expect(receivedAll).to(equal(789))
+                    
+                    eventEmitter.emit("bar", with: 222)
+                    
+                    expect(receivedAll).to(equal(222))
+                }
+
+                it("should receive only once after calling onAll and then once") {
+                    eventEmitter.once("foo", callListener: listenerAll!)
+
+                    eventEmitter.emit("foo", with: 123)
+                    expect(receivedAll).to(equal(123))
+                    eventEmitter.emit("bar", with: 456)
+                    expect(receivedAll).to(equal(456))
+
+                    eventEmitter.emit("foo", with: 111)
+                    expect(receivedAll).to(equal(456))
+                    eventEmitter.emit("bar", with: 222)
+                    expect(receivedAll).to(equal(222))
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Previously, ARTConnection managed state subscriptions and
ARTEventEmitter was just a shell. Now the heavy-lifting of
passing events around is done by ARTEventEmitter, which is
generic and can be reused by others, and ARTConnection just uses
it to emit events and expose its listening interface.

This also introduces ARTConnectionStateChange, used in connection
state events' callbacks, as the spec says.

Something that went away is that starting listening to events
dispatched the current event to the callback. Now it doesn't. It
starts listening to _changes_ from that point on. I think this
makes more sense and is consistent with what you expect from an
event emitter.

Fixes #133.