### PR TITLE
TG4: PaginatedResult.next calls back with nil if there's no next.

### DIFF
--- a/ably-ios/ARTPaginatedResult.m
+++ b/ably-ios/ARTPaginatedResult.m
@@ -55,6 +55,13 @@
 }
 
 - (void)next:(ARTPaginatedResultCallback)callback {
+    if (!_relNext) {
+        // If there is no next page, we can't make a request, so we answer the callback
+        // with a nil PaginatedResult. That's why the callback has the result as nullable
+        // anyway. (That, and that it can fail.)
+        callback(nil, nil);
+        return;
+    }
     [self.class executePaginated:_rest withRequest:_relNext andResponseProcessor:_responseProcessor callback:callback];
 }
 


### PR DESCRIPTION
This behavior is consistent with [the spec](http://docs.ably.io/client-lib-development-guide/features/#TG4).