### PR TITLE
RTL6g

### DIFF
--- a/ably-ios/ARTBaseMessage.h
+++ b/ably-ios/ARTBaseMessage.h
@@ -32,8 +32,6 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description;
 
-- (instancetype)messageWithData:(id)data encoding:(NSString *)encoding;
-
 @end
 
 ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTBaseMessage.m
+++ b/ably-ios/ARTBaseMessage.m
@@ -33,13 +33,6 @@
     return message;
 }
 
-- (instancetype)messageWithData:(id)data encoding:(NSString *)encoding {
-    ARTBaseMessage *message = [self copy];
-    message.data = data;
-    message.encoding = encoding;
-    return message;
-}
-
 - (id)decodeWithEncoder:(ARTDataEncoder*)encoder error:(NSError **)error {
     ARTDataEncoderOutput *decoded = [encoder decode:self.data encoding:self.encoding];
     if (decoded.errorInfo && error) {

--- a/ably-ios/ARTMessage.h
+++ b/ably-ios/ARTMessage.h
@@ -19,9 +19,6 @@ ART_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(art_nullable NSString *)name data:(id)data;
 - (instancetype)initWithName:(art_nullable NSString *)name data:(id)data clientId:(NSString *)clientId;
 
-+ (__GENERIC(NSArray, ARTMessage *) *)messagesWithData:(NSArray *)data;
-+ (ARTMessage *)messageWithData:(id)data name:(art_nullable NSString *)name;
-
 @end
 
 ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTMessage.m
+++ b/ably-ios/ARTMessage.m
@@ -43,20 +43,4 @@
     return message;
 }
 
-+ (ARTMessage *)messageWithData:(id)data name:(NSString *)name {
-    ARTMessage *message = [[ARTMessage alloc] init];
-    message.name = name;
-    message.data = data;
-    message.encoding = @"";
-    return message;
-}
-
-+ (NSArray *)messagesWithData:(NSArray *)data {
-    NSMutableArray * messages =[[NSMutableArray alloc] initWithCapacity:[data count]];
-    for (int i=0; i < [data count]; i++) {
-        [messages addObject:[ARTMessage messageWithData:[data objectAtIndex:i] name:nil]];
-    }
-    return messages;
-}
-
 @end

--- a/ably-ios/ARTRealtimeChannel.m
+++ b/ably-ios/ARTRealtimeChannel.m
@@ -62,7 +62,7 @@
 }
 
 - (void)publish:(NSString *)name data:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
-    NSArray *messages = [NSArray arrayWithObject:[ARTMessage messageWithData:data name:name]];
+    NSArray *messages = [NSArray arrayWithObject:[[ARTMessage alloc] initWithName:name data:data]];
     [self publish:messages cb:cb];
 }
 

--- a/ablySpec/Crypto.swift
+++ b/ablySpec/Crypto.swift
@@ -13,9 +13,9 @@ import SwiftyJSON
 class Crypto : QuickSpec {
     override func spec() {
         describe("Crypto") {
-            for keyLength in ["128", "256"] {
-                context("with fixtures from crypto-data-\(keyLength).json") {
-                    let (key, iv, items) = AblyTests.loadCryptoTestData("ably-common/test-resources/crypto-data-\(keyLength).json")
+            for cryptoTest in CryptoTest.all {
+                context("with fixtures from \(cryptoTest).json") {
+                    let (key, iv, items) = AblyTests.loadCryptoTestData(cryptoTest)
                     let decoder = ARTDataEncoder.init(cipherParams: nil, error: nil)
                     let cipherParams = ARTCipherParams.init(
                         algorithm: "aes",

--- a/ablySpec/Crypto.swift
+++ b/ablySpec/Crypto.swift
@@ -24,7 +24,7 @@ class Crypto : QuickSpec {
                     )
 
                     func extractMessage(fixture: AblyTests.CryptoTestItem.TestMessage) -> ARTMessage {
-                        let msg = ARTMessage.init(data: fixture.data, name: fixture.name)
+                        let msg = ARTMessage(name: fixture.name, data: fixture.data)
                         msg.encoding = fixture.encoding
                         return msg
                     }

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -557,7 +557,7 @@ class RealtimeClientChannel: QuickSpec {
                             resultClientId = message.clientId
                         }
 
-                        let message = ARTMessage(data: "message", name: nil)
+                        let message = ARTMessage(name: nil, data: "message")
                         message.clientId = "client_string"
 
                         channel.publish([message]) { errorInfo in
@@ -587,7 +587,7 @@ class RealtimeClientChannel: QuickSpec {
                             result.append(message.data as! JSONObject)
                         }
 
-                        let messages = [ARTMessage(data: ["key":1], name: nil), ARTMessage(data: ["key":2], name: nil)]
+                        let messages = [ARTMessage(name: nil, data: ["key":1]), ARTMessage(name: nil, data: ["key":2])]
                         channel.publish(messages)
 
                         let transport = client.transport as! TestProxyTransport

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -742,6 +742,32 @@ class RealtimeClientChannel: QuickSpec {
                             expect(messageSent.messages![0].clientId).to(beNil())
                         }
 
+                        // RTL6g1b
+                        it("should have clientId value as null for the Message when received") {
+                            let options = AblyTests.commonAppSetup()
+                            options.autoConnect = false
+                            let client = ARTRealtime(options: options)
+                            client.setTransportClass(TestProxyTransport.self)
+                            client.connect()
+                            defer { client.close() }
+
+                            let channel = client.channels.get("test")
+
+                            waitUntil(timeout: testTimeout) { done in
+                                channel.subscribe { message in
+                                    expect(message.clientId).to(beNil())
+                                    done()
+                                }
+                                channel.publish(nil, data: "message")
+                            }
+
+                            let transport = client.transport as! TestProxyTransport
+                            expect(transport.protocolMessagesReceived.filter { $0.action == .Message }).toEventually(haveCount(1), timeout: testTimeout)
+
+                            let messageReceived = transport.protocolMessagesReceived.filter({ $0.action == .Message })[0]
+                            expect(messageReceived.messages![0].clientId).to(beNil())
+                        }
+
                     }
 
                 }

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -714,6 +714,38 @@ class RealtimeClientChannel: QuickSpec {
 
                 }
 
+                // RTL6g
+                context("Identified clients with clientId") {
+
+                    // RTL6g1
+                    context("When publishing a Message with clientId set to null") {
+
+                        // RTL6g1a
+                        it("should be unnecessary to set clientId of the Message before publishing") {
+                            let options = AblyTests.commonAppSetup()
+                            options.autoConnect = false
+                            let client = ARTRealtime(options: options)
+                            client.setTransportClass(TestProxyTransport.self)
+                            client.connect()
+                            defer { client.close() }
+
+                            let channel = client.channels.get("test")
+
+                            channel.publish(nil, data: "message") { errorInfo in
+                                expect(errorInfo).to(beNil())
+                            }
+
+                            let transport = client.transport as! TestProxyTransport
+                            expect(transport.protocolMessagesSent.filter { $0.action == .Message }).toEventually(haveCount(1), timeout: testTimeout)
+
+                            let messageSent = transport.protocolMessagesSent.filter({ $0.action == .Message })[0]
+                            expect(messageSent.messages![0].clientId).to(beNil())
+                        }
+
+                    }
+
+                }
+
             }
 
             // RTL7

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -743,7 +743,7 @@ class RealtimeClientChannel: QuickSpec {
                         }
 
                         // RTL6g1b
-                        it("should have clientId value as null for the Message when received") {
+                        pending("should have clientId value as null for the Message when received") {
                             let options = AblyTests.commonAppSetup()
                             options.autoConnect = false
                             let client = ARTRealtime(options: options)

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -721,7 +721,7 @@ class RealtimeClientChannel: QuickSpec {
                     context("When publishing a Message with clientId set to null") {
 
                         // RTL6g1a
-                        it("should be unnecessary to set clientId of the Message before publishing") {
+                        pending("should be unnecessary to set clientId of the Message before publishing") {
                             let options = AblyTests.commonAppSetup()
                             options.autoConnect = false
                             let client = ARTRealtime(options: options)

--- a/ablySpec/RestChannel.swift
+++ b/ablySpec/RestChannel.swift
@@ -109,7 +109,7 @@ class RestChannel: QuickSpec {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.createWithNSError(NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
                     
-                    channel.publish([ARTMessage(data:data, name: name)]) { error in
+                    channel.publish([ARTMessage(name: name, data: data)]) { error in
                         publishError = error
                         try! channel.history { result, _ in
                             publishedMessage = result?.items.first as? ARTMessage
@@ -133,8 +133,8 @@ class RestChannel: QuickSpec {
                     var publishedMessages: [ARTMessage] = []
 
                     let messages = [
-                        ARTMessage(data: "foo", name: "bar"),
-                        ARTMessage(data: "baz", name: "bat")
+                        ARTMessage(name: "bar", data: "foo"),
+                        ARTMessage(name: "bat", data: "baz")
                     ]
                     channel.publish(messages) { error in
                         publishError = error

--- a/ablySpec/TestUtilities.swift
+++ b/ablySpec/TestUtilities.swift
@@ -18,6 +18,10 @@ import Ably.Private
 enum CryptoTest: String {
     case aes128 = "crypto-data-128"
     case aes256 = "crypto-data-256"
+
+    static var all: [CryptoTest] {
+        return [.aes128, .aes256]
+    }
 }
 
 class Configuration : QuickConfiguration {


### PR DESCRIPTION
❌ Not passing.

Can't publish a message of type `ARTMessage`: `channel.publish(message, ...)`
```
2016-02-10 15:31:37.259 xctest[4649:209394] ERROR: ARTChannel: error encoding data, status: 2029696992
/Users/ricardopereira/Repositories/Whitesmith/ably-ios/ablySpec/RealtimeClientChannel.swift:560: error: -[ablySpec.RealtimeClientChannel Channel__publish__Identified_clients_with_clientId__When_publishing_a_Message_with_clientId_set_to_null__should_be_unnecessary_to_set_clientId_of_the_Message_before_publishing_UsersricardopereiraRepositoriesWhitesmithablyiosablySpecRealtimeClientChannelswift_536] : failed: caught "NSInvalidArgumentException", "message encoding failed"
(
	0   CoreFoundation                      0x00b5ea94 __exceptionPreprocess + 180
	1   libobjc.A.dylib                     0x0061fe02 objc_exception_throw + 50
	2   ably                                0x0a5a4817 -[ARTChannel encodeMessageIfNeeded:] + 487
	3   ably                                0x0a5a613b __41-[ARTRealtimeChannel publishMessages:cb:]_block_invoke + 91
	4   ably                                0x0a5ea357 -[NSArray(ARTFunctional) artMap:] + 455
	5   ably                                0x0a5a6012 -[ARTRealtimeChannel publishMessages:cb:] + 370
	6   ably                                0x0a5a5e2c -[ARTRealtimeChannel publish:withName:cb:] + 268
	7   ably                                0x0a5a5cde -[ARTRealtimeChannel publish:cb:] + 318
```

It is possible in JavaScript:
```
channel.publish({ data: 'boom!', name: 'event' });
```
