### PR TITLE
Fix RTN10b.

### DIFF
--- a/ably-ios/ARTConnection.m
+++ b/ably-ios/ARTConnection.m
@@ -26,6 +26,7 @@
     if (self == [super init]) {
         _realtime = realtime;
         _eventEmitter = realtime.eventEmitter;
+        _serial = -1;
     }
     return self;
 }

--- a/ablySpec/RealtimeClientConnection.swift
+++ b/ablySpec/RealtimeClientConnection.swift
@@ -952,7 +952,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 // RTN10b
-                pending("should not update when a message is sent but increments by one when ACK is received") {
+                it("should not update when a message is sent but increments by one when ACK is received") {
                     let client = ARTRealtime(options: AblyTests.commonAppSetup())
                     defer {
                         client.dispose()
@@ -960,7 +960,11 @@ class RealtimeClientConnection: QuickSpec {
                     }
                     let channel = client.channels.get("test")
 
-                    for index in 0...5 {
+                    expect(client.connection.serial).to(equal(-1))
+                    expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.Connected), timeout: testTimeout)
+                    expect(client.connection.serial).to(equal(-1))
+
+                    for index in 0...3 {
                         waitUntil(timeout: testTimeout) { done in
                             channel.publish(nil, data: "message", cb: { errorInfo in
                                 expect(errorInfo).to(beNil())


### PR DESCRIPTION
The test was checking the connection serial before the connection
was established. The code behave correctly, but before CONNECTED
serial was 0 just because it's the default int value, then set to
-1 at CONNECTED. I've changed serial's initial value to -1, to
make it not important whether you check it before of after the
connection is established.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ably/ably-ios/230)
<!-- Reviewable:end -->
