### PR TITLE
Force full channel release.

### DIFF
--- a/ably-ios/ARTRealtimeChannel+Private.h
+++ b/ably-ios/ARTRealtimeChannel+Private.h
@@ -59,8 +59,6 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (void)requestContinueSync;
 
-- (void)releaseChannel;
-
 @end
 
 ART_ASSUME_NONNULL_END

--- a/ably-ios/ARTRealtimeChannel.m
+++ b/ably-ios/ARTRealtimeChannel.m
@@ -324,12 +324,6 @@
     [_detachedEventEmitter emit:[NSNull null] with:nil];
 }
 
-- (void)releaseChannel {
-    [self cancelAttachTimer];
-    [self detachChannel:[ARTStatus state:ARTStateOk]];
-    [self.realtime.channels release:self.name];
-}
-
 - (void)detachChannel:(ARTStatus *)error {
     [self failQueuedMessages:error];
     [self transition:ARTRealtimeChannelDetached status:error];

--- a/ably-ios/ARTRealtimeChannels.h
+++ b/ably-ios/ARTRealtimeChannels.h
@@ -26,6 +26,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (BOOL)exists:(NSString *)name;
 - (ARTRealtimeChannel *)get:(NSString *)name;
 - (ARTRealtimeChannel *)get:(NSString *)name options:(ARTChannelOptions *)options;
+- (void)release:(NSString *)name cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))errorInfo;
 - (void)release:(NSString *)name;
 
 @end

--- a/ably-ios/ARTRealtimeChannels.m
+++ b/ably-ios/ARTRealtimeChannels.m
@@ -52,8 +52,21 @@
     return [_channels exists:name];
 }
 
+- (void)release:(NSString *)name cb:(void (^)(ARTErrorInfo * _Nullable))cb {
+    ARTRealtimeChannel *channel = _channels.channels[name];
+    if (channel) {
+        [channel detach:^(ARTErrorInfo *errorInfo) {
+            [channel off];
+            [channel unsubscribe];
+            [channel.presence unsubscribe];
+            [_channels release:name];
+            if (cb) cb(errorInfo);
+        }];
+    }
+}
+
 - (void)release:(NSString *)name {
-    [_channels release:name];
+    [self release:name cb:nil];
 }
 
 @end

--- a/ably-iosTests/ARTRealtimeAttachTest.m
+++ b/ably-iosTests/ARTRealtimeAttachTest.m
@@ -103,6 +103,7 @@
             }
             else if(channel.state == ARTRealtimeChannelAttaching) {
                 if(detachedReached) {
+                    [channel off];
                     [expectation fulfill];
                 }
             }
@@ -209,6 +210,7 @@
                 [channel detach];
             }
             else if(channel.state == ARTRealtimeChannelDetaching) {
+                [channel off];
                 [expectation fulfill];
             }
             else if(channel.state == ARTRealtimeChannelDetached) {
@@ -299,13 +301,13 @@
                 if(channel.state != ARTRealtimeChannelAttaching) {
                     XCTAssertEqual(channel.state, ARTRealtimeChannelFailed);
                     [expectation fulfill];
+                    [channel off];
                 }
             }];
             [channel attach];
         }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-
 
 - (void)testAttachingChannelFails {
     XCTestExpectation *exp = [self expectationWithDescription:@"testAttachingChannelFails"];

--- a/ably-iosTests/ARTRealtimeChannelTest.m
+++ b/ably-iosTests/ARTRealtimeChannelTest.m
@@ -243,8 +243,7 @@
             XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
             XCTAssertEqualObjects([d valueForKey:@"channel3"], c3);
         }
-        [realtime.channels release:c3.name];
-        {
+        [realtime.channels release:c3.name cb:^(ARTErrorInfo *errorInfo) {
             NSMutableDictionary * d = [[NSMutableDictionary alloc] init];
             for (ARTRealtimeChannel *channel in realtime.channels) {
                 [d setValue:channel forKey:channel.name];
@@ -252,7 +251,7 @@
             XCTAssertEqual([[d allKeys] count], 2);
             XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
             XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
-        }
+        }];
         
         [exp fulfill];
     }];
@@ -385,6 +384,7 @@
 
         [channel2.presence subscribe:^(ARTPresenceMessage *message) {
             XCTAssertEqualObjects(message.clientId, firstClientId);
+            [channel2 off];
             [exp1 fulfill];
         }];
 

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -1297,6 +1297,40 @@ class RealtimeClientChannel: QuickSpec {
 
             }
 
+            context("channels") {
+                // RTS4
+                context("release") {
+                    it("should release a channel") {
+                        let client = ARTRealtime(options: AblyTests.commonAppSetup())
+                        defer { client.close() }
+
+                        let channel = client.channels.get("test")
+                        channel.subscribe { _ in
+                            fail("shouldn't happen")
+                        }
+                        channel.presence.subscribe { _ in
+                            fail("shouldn't happen")
+                        }
+                        waitUntil(timeout: testTimeout) { done in
+                            client.channels.release("test") { errorInfo in
+                                expect(errorInfo).to(beNil())
+                                expect(channel.state).to(equal(ARTRealtimeChannelState.Detached))
+                                done()
+                            }
+                        }
+
+                        let sameChannel = client.channels.get("test")
+                        waitUntil(timeout: testTimeout) { done in
+                            sameChannel.subscribe { _ in
+                                sameChannel.presence.enterClient("foo", data: nil) { _ in
+                                    delay(0.0) { done() } // Delay to make sure EventEmitter finish its cycle.
+                                }
+                            }
+                            sameChannel.publish("foo", data: nil)
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Just removing the channel from the channels collection isn't
enough; the channel might have references elsewehere, including
reference cycles if the listener/subscriber callbacks close over
it.