### PR TITLE
History request without a query shouldn't throw errors

### DIFF
--- a/ably-ios/ARTChannel.h
+++ b/ably-ios/ARTChannel.h
@@ -32,7 +32,8 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages;
 - (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
 
-- (BOOL)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
+- (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+
 - (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @end

--- a/ably-ios/ARTChannel.m
+++ b/ably-ios/ARTChannel.m
@@ -81,8 +81,8 @@
     return message;
 }
 
-- (BOOL)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback error:(NSError **)errorPtr {
-    return [self history:[[ARTDataQuery alloc] init] callback:callback error:errorPtr];
+- (void)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback {
+    [self history:[[ARTDataQuery alloc] init] callback:callback error:nil];
 }
 
 - (BOOL)history:(ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback error:(NSError **)errorPtr {

--- a/ably-ios/ARTRealtimeChannel.h
+++ b/ably-ios/ARTRealtimeChannel.h
@@ -38,7 +38,8 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)unsubscribe:(__GENERIC(ARTEventListener, ARTMessage *) *)listener;
 - (void)unsubscribe:(NSString *)name listener:(__GENERIC(ARTEventListener, ARTMessage *) *)listener;
 
-- (BOOL)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
+- (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+
 - (BOOL)history:(art_nullable ARTRealtimeHistoryQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 ART_EMBED_INTERFACE_EVENT_EMITTER(ARTRealtimeChannelState, ARTErrorInfo *)

--- a/ably-ios/ARTRealtimeChannel.m
+++ b/ably-ios/ARTRealtimeChannel.m
@@ -512,8 +512,8 @@
     return self.realtime.auth.clientId;
 }
 
-- (BOOL)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback error:(NSError **)errorPtr {
-    return [self history:[[ARTRealtimeHistoryQuery alloc] init] callback:callback error:errorPtr];
+- (void)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback {
+    [self history:[[ARTRealtimeHistoryQuery alloc] init] callback:callback error:nil];
 }
 
 - (BOOL)history:(ARTRealtimeHistoryQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *, NSError *))callback error:(NSError **)errorPtr {

--- a/ably-iosTests/ARTReadmeExamples.m
+++ b/ably-iosTests/ARTReadmeExamples.m
@@ -71,7 +71,7 @@
 
         [channel history:^(ARTPaginatedResult<ARTMessage *> *messagesPage, NSError *error) {
             NSLog(@"%@", messagesPage.items);
-        } error:nil];
+        }];
     }];
 }
 
@@ -89,7 +89,7 @@
                 // retrieved the next page in nextPage
             }];
             NSLog(@"%d", messagesPage.hasNext); // true, there are more pages
-        } error:nil];
+        }];
     }];
 }
 
@@ -150,7 +150,7 @@
                 // retrieved the next page in nextPage
             }];
             NSLog(@"%d", messagesPage.hasNext); // true, there are more pages
-        } error:nil];
+        }];
     }];
 }
 

--- a/ably-iosTests/ARTRealtimeChannelHistoryTest.m
+++ b/ably-iosTests/ARTRealtimeChannelHistoryTest.m
@@ -64,7 +64,7 @@
                         XCTAssertEqualObjects(@"testString", [m1 data]);
 
                         [expectation fulfill];
-                    } error:nil];
+                    }];
                 }];
             }];
         }        
@@ -125,7 +125,7 @@
                     XCTAssertEqualObjects(@"testString", [m1 data]);
                     [expectation1 fulfill];
                     
-                } error:nil];
+                }];
                 [channel2 history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
                     NSArray *messages = [result items];
@@ -135,7 +135,7 @@
                     XCTAssertEqualObjects(@"testString2", [m0 data]);
                     XCTAssertEqualObjects(@"testString", [m1 data]);
                     [expectation2 fulfill];
-                } error:nil];
+                }];
             }];
         }];
     }];

--- a/ably-iosTests/ARTRealtimeCryptoTest.m
+++ b/ably-iosTests/ARTRealtimeCryptoTest.m
@@ -115,7 +115,7 @@
                         XCTAssertEqualObjects([stringMessage data], stringPayload);
                         XCTAssertEqualObjects([firstMessage data], firstMessageText);
                         [exp fulfill];
-                    } error:nil];
+                    }];
                 }];
             }];
         }];

--- a/ably-iosTests/ARTRealtimeMessageTest.m
+++ b/ably-iosTests/ARTRealtimeMessageTest.m
@@ -315,7 +315,7 @@
                     XCTAssertEqualObjects(m1.connectionId, _realtime.connection.id);
                     XCTAssertFalse([m0.connectionId isEqualToString:m1.connectionId]);
                     [exp fulfill];
-                } error:nil];
+                }];
             }];
         }];
     }];

--- a/ably-iosTests/ARTRestChannelPublishTest.m
+++ b/ably-iosTests/ARTRestChannelPublishTest.m
@@ -91,7 +91,7 @@
                 XCTAssertEqualObjects([m1 data], test2);
                 XCTAssertEqualObjects([m2 data], test1);
                 [exp fulfill];
-            } error:nil];
+            }];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];

--- a/ably-iosTests/ARTRestCryptoTest.m
+++ b/ably-iosTests/ARTRestCryptoTest.m
@@ -59,7 +59,7 @@
                     XCTAssertEqualObjects([dataMessage data], dataPayload);
                     XCTAssertEqualObjects([stringMessage data], stringPayload);
                     [exp fulfill];
-                } error:nil];
+                }];
             }];
         }];
     }];
@@ -96,7 +96,7 @@
                     XCTAssertEqualObjects([dataMessage data], dataPayload);
                     XCTAssertEqualObjects([stringMessage data], stringPayload);
                     [exp fulfill];
-                } error:nil];
+                }];
             }];
         }];
     }];

--- a/ablySpec/ReadmeExamples.swift
+++ b/ablySpec/ReadmeExamples.swift
@@ -78,7 +78,7 @@ class ReadmeExamples : QuickSpec {
 
             let channel = client.channels.get("test")
 
-            try! channel.history { messagesPage, error in
+            channel.history { messagesPage, error in
                 let messagesPage = messagesPage!
                 print(messagesPage.items)
                 print(messagesPage.items.first)
@@ -149,7 +149,7 @@ class ReadmeExamples : QuickSpec {
             let client = ARTRest(options: options)
             let channel = client.channels.get("test")
 
-            try! channel.history { messagesPage, error in
+            channel.history { messagesPage, error in
                 let messagesPage = messagesPage!
                 print(messagesPage.items.first)
                 print((messagesPage.items.first as? ARTMessage)?.data) // payload for the message

--- a/ablySpec/RealtimeClientChannel.swift
+++ b/ablySpec/RealtimeClientChannel.swift
@@ -1231,7 +1231,7 @@ class RealtimeClientChannel: QuickSpec {
                     }
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             expect(result).to(beAKindOf(ARTPaginatedResult))
                             expect(result!.items).to(haveCount(1))
                             expect(result!.hasNext).to(beFalse())

--- a/ablySpec/RestClientChannel.swift
+++ b/ablySpec/RestClientChannel.swift
@@ -36,7 +36,7 @@ class RestClientChannel: QuickSpec {
                     
                     channel.publish(name, data: data) { error in
                         publishError = error
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             publishedMessage = result?.items.first as? ARTMessage
                         }
                     }
@@ -55,7 +55,7 @@ class RestClientChannel: QuickSpec {
                     
                     channel.publish(name, data: nil) { error in
                         publishError = error
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             publishedMessage = result?.items.first as? ARTMessage
                         }
                     }
@@ -74,7 +74,7 @@ class RestClientChannel: QuickSpec {
                     
                     channel.publish(nil, data: data) { error in
                         publishError = error
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             publishedMessage = result?.items.first as? ARTMessage
                         }
                     }
@@ -93,7 +93,7 @@ class RestClientChannel: QuickSpec {
                     
                     channel.publish(nil, data: nil) { error in
                         publishError = error
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             publishedMessage = result?.items.first as? ARTMessage
                         }
                     }
@@ -111,7 +111,7 @@ class RestClientChannel: QuickSpec {
                     
                     channel.publish([ARTMessage(name: name, data: data)]) { error in
                         publishError = error
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             publishedMessage = result?.items.first as? ARTMessage
                         }
                     }
@@ -139,7 +139,7 @@ class RestClientChannel: QuickSpec {
                     channel.publish(messages) { error in
                         publishError = error
                         client.httpExecutor = oldExecutor
-                        try! channel.history { result, _ in
+                        channel.history { result, _ in
                             if let items = result?.items as? [ARTMessage] {
                                 publishedMessages.appendContentsOf(items)
                             }
@@ -377,7 +377,7 @@ class RestClientChannel: QuickSpec {
                     }
 
                     var totalReceived = 0
-                    try! channel.history { result, error in
+                    channel.history { result, error in
                         expect(error).to(beNil())
                         guard let result = result else {
                             XCTFail("Result is nil")


### PR DESCRIPTION
I notice this problem from the README examples.