### PR TITLE
Connection EventEmitter: use enum instead of NSNumber as event type.

### DIFF
--- a/ably-ios/ARTConnection+Private.h
+++ b/ably-ios/ARTConnection+Private.h
@@ -22,7 +22,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)setSerial:(int64_t)serial;
 - (void)setState:(ARTRealtimeConnectionState)state;
 
-- (void)emit:(NSNumber *)event with:(ARTConnectionStateChange *)data;
+- (void)emit:(ARTRealtimeConnectionState)event with:(ARTConnectionStateChange *)data;
 
 @end
 

--- a/ably-ios/ARTConnection.h
+++ b/ably-ios/ARTConnection.h
@@ -31,7 +31,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)close;
 - (void)ping:(void (^)(ARTStatus *))cb;
 
-ART_EMBED_INTERFACE_EVENT_EMITTER(NSNumber *, ARTConnectionStateChange *)
+ART_EMBED_INTERFACE_EVENT_EMITTER(ARTRealtimeConnectionState, ARTConnectionStateChange *)
 
 @end
 

--- a/ably-ios/ARTConnection.m
+++ b/ably-ios/ARTConnection.m
@@ -77,6 +77,35 @@
     }
 }
 
-ART_EMBED_IMPLEMENTATION_EVENT_EMITTER(NSNumber *, ARTConnectionStateChange *)
+- (__GENERIC(ARTEventListener, ARTConnectionStateChange *) *)on:(ARTRealtimeConnectionState)event call:(void (^)(ARTConnectionStateChange *))cb {
+    return [_eventEmitter on:[NSNumber numberWithInt:event] call:cb];
+}
+
+- (__GENERIC(ARTEventListener, ARTConnectionStateChange *) *)on:(void (^)(ARTConnectionStateChange *))cb {
+    return [_eventEmitter on:cb];
+}
+
+- (__GENERIC(ARTEventListener, ARTConnectionStateChange *) *)once:(ARTRealtimeConnectionState)event call:(void (^)(ARTConnectionStateChange *))cb {
+    return [_eventEmitter once:[NSNumber numberWithInt:event] call:cb];
+}
+
+- (__GENERIC(ARTEventListener, ARTConnectionStateChange *) *)once:(void (^)(ARTConnectionStateChange *))cb {
+    return [_eventEmitter once:cb];
+}
+
+- (void)off {
+    [_eventEmitter off];
+}
+- (void)off:(ARTRealtimeConnectionState)event listener:listener {
+    [_eventEmitter off:[NSNumber numberWithInt:event] listener:listener];
+}
+
+- (void)off:(__GENERIC(ARTEventListener, ARTConnectionStateChange *) *)listener {
+    [_eventEmitter off:listener];
+}
+
+- (void)emit:(ARTRealtimeConnectionState)event with:(ARTConnectionStateChange *)data {
+    [_eventEmitter emit:[NSNumber numberWithInt:event] with:data];
+}
 
 @end

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -298,7 +298,7 @@
         }
     }
     
-    [self.connection emit:[NSNumber numberWithInt:state] with:[[ARTConnectionStateChange alloc] initWithCurrent:state previous:previousState reason:errorInfo]];
+    [self.connection emit:state with:[[ARTConnectionStateChange alloc] initWithCurrent:state previous:previousState reason:errorInfo]];
 }
 
 - (void)startConnectTimer {


### PR DESCRIPTION
Internally we still need to wrap the raw enum values in NSNumber,
but that shouldn't be exposed.