### PR TITLE
TokenParams.timestamp: use current at getter, not at constructor.

### DIFF
--- a/ably-ios/ARTTokenParams.h
+++ b/ably-ios/ARTTokenParams.h
@@ -37,7 +37,7 @@ ART_ASSUME_NONNULL_BEGIN
 /**
  Timestamp (in millis since the epoch) of this request. Timestamps, in conjunction with the nonce, are used to prevent n requests from being replayed.
  */
-@property (nonatomic, strong, null_resettable) NSDate *timestamp;
+@property (nonatomic, strong, null_resettable, setter=setTimestamp:, getter=getTimestamp) NSDate *timestamp;
 
 @property (nonatomic, readonly, strong) NSString *nonce;
 

--- a/ably-ios/ARTTokenParams.m
+++ b/ably-ios/ARTTokenParams.m
@@ -15,7 +15,9 @@
 #import "ARTEncoder.h"
 #import "ARTTokenRequest.h"
 
-@implementation ARTTokenParams
+@implementation ARTTokenParams {
+    NSDate *_timestamp;
+}
 
 - (instancetype)init {
     return [self initWithClientId:nil nonce:nil];
@@ -27,7 +29,7 @@
 
 - (instancetype)initWithClientId:(NSString *)clientId nonce:(NSString *)nonce {
     if (self = [super init]) {
-        _timestamp = [NSDate date];
+        _timestamp = nil;
         _ttl = [ARTDefault ttl];
         _capability = @"{\"*\":[\"*\"]}"; // allow all
         _clientId = clientId;
@@ -51,11 +53,14 @@
 }
 
 - (void)setTimestamp:(NSDate *)timestamp {
-    if (timestamp == nil) {
-        timestamp = [NSDate date];
-    }
-    
     _timestamp = timestamp;
+}
+
+- (NSDate *)getTimestamp {
+    if (_timestamp == nil) {
+        _timestamp = [NSDate date];
+    }
+    return _timestamp;
 }
 
 - (NSMutableArray *)toArray {

--- a/ablySpec/Auth.swift
+++ b/ablySpec/Auth.swift
@@ -1488,5 +1488,31 @@ class Auth : QuickSpec {
                 }
             }
         }
+
+        describe("TokenParams") {
+            context("timestamp") {
+                it("if explicitly set, should be returned by the getter") {
+                    let params = ARTTokenParams()
+                    params.timestamp = NSDate(timeIntervalSince1970: 123)
+                    expect(params.timestamp).to(equal(NSDate(timeIntervalSince1970: 123)))
+                }
+
+                it("if not explicitly set, should be generated at the getter and stick") {
+                    let params = ARTTokenParams()
+
+                    waitUntil(timeout: testTimeout) { done in
+                        delay(0.25) {
+                            let now = NSDate().artToIntegerMs()
+                            let firstParamsTimestamp = params.timestamp.artToIntegerMs()
+                            expect(firstParamsTimestamp).to(beCloseTo(now, within: 1.0))
+                            delay(0.25) {
+                                expect(params.timestamp.artToIntegerMs()).to(equal(firstParamsTimestamp))
+                                done()
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #129.