### PR TITLE
Uniformize stats and history interfaces.

### DIFF
--- a/ably-ios/ARTChannel.h
+++ b/ably-ios/ARTChannel.h
@@ -33,7 +33,6 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
 
 - (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-
 - (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @end

--- a/ably-ios/ARTPresence.h
+++ b/ably-ios/ARTPresence.h
@@ -42,10 +42,8 @@ ART_ASSUME_NONNULL_BEGIN
 /**
  Obtain recent presence history for one channel
  */
-- (NSError *__art_nullable)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (NSError *__art_nullable)history:(art_nullable ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (BOOL)historyWithError:(NSError *__art_nullable *__art_nullable)errorPtr callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (BOOL)history:(art_nullable ARTDataQuery *)query error:(NSError *__art_nullable *__art_nullable)errorPtr callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+- (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+- (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @end
 

--- a/ably-ios/ARTPresence.m
+++ b/ably-ios/ARTPresence.m
@@ -60,23 +60,11 @@
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
 }
 
-- (NSError *)history:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    NSError *error = [[NSError alloc] init];
-    [self historyWithError:&error callback:callback];
-    return error;
+- (void)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *, NSError *))callback {
+    [self history:[[ARTDataQuery alloc] init] callback:callback error:nil];
 }
 
-- (NSError *)history:(ARTDataQuery *)query callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    NSError *error = [[NSError alloc] init];
-    [self history:query error:&error callback:callback];
-    return error;
-}
-
-- (BOOL)historyWithError:(NSError *__autoreleasing  _Nullable *)errorPtr callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    return [self history:[[ARTDataQuery alloc] init] error:errorPtr callback:callback];
-}
-
-- (BOOL)history:(ARTDataQuery *)query error:(NSError **)errorPtr callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *, NSError *))callback {
+- (BOOL)history:(ARTDataQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *, NSError *))callback error:(NSError **)errorPtr {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
     return NO;
 }

--- a/ably-ios/ARTRealtime.h
+++ b/ably-ios/ARTRealtime.h
@@ -60,10 +60,8 @@ Instance the Ably library with the given options.
 
 - (void)time:(ARTTimeCallback)cb;
 
-- (NSError *__art_nullable)stats:(ARTStatsCallback)callback;
-- (NSError *__art_nullable)stats:(art_nullable ARTStatsQuery *)query callback:(ARTStatsCallback)callback;
-- (BOOL)statsWithError:(NSError *__art_nullable *__art_nullable)errorPtr callback:(ARTStatsCallback)callback;
-- (BOOL)stats:(art_nullable ARTStatsQuery *)query error:(NSError *__art_nullable *__art_nullable)errorPtr callback:(ARTStatsCallback)callback;
+- (BOOL)stats:(ARTStatsCallback)callback;
+- (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(ARTStatsCallback)callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 - (void)connect;
 - (void)close;

--- a/ably-ios/ARTRealtime.m
+++ b/ably-ios/ARTRealtime.m
@@ -172,25 +172,12 @@
     [self.transport sendPing];
 }
 
-
-- (NSError *)stats:(ARTStatsCallback)callback {
-    NSError *error = nil;
-    [self statsWithError:&error callback:callback];
-    return error;
+- (BOOL)stats:(ARTStatsCallback)callback {
+    return [self stats:[[ARTStatsQuery alloc] init] callback:callback error:nil];
 }
 
-- (NSError *)stats:(ARTStatsQuery *)query callback:(ARTStatsCallback)callback {
-    NSError *error = nil;
-    [self stats:query error:&error callback:callback];
-    return error;
-}
-
-- (BOOL)statsWithError:(NSError *__autoreleasing  _Nullable *)errorPtr callback:(ARTStatsCallback)callback {
-    return [self stats:[[ARTStatsQuery alloc] init] error:errorPtr callback:callback];
-}
-
-- (BOOL)stats:(ARTStatsQuery *)query error:(NSError **)errorPtr callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *, NSError *))callback {
-    return [self.rest stats:query error:errorPtr callback:callback];
+- (BOOL)stats:(ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *, NSError *))callback error:(NSError **)errorPtr {
+    return [self.rest stats:query callback:callback error:errorPtr];
 }
 
 - (void)resetEventEmitter {

--- a/ably-ios/ARTRealtimeChannel.h
+++ b/ably-ios/ARTRealtimeChannel.h
@@ -39,7 +39,6 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)unsubscribe:(NSString *)name listener:(__GENERIC(ARTEventListener, ARTMessage *) *)listener;
 
 - (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-
 - (BOOL)history:(art_nullable ARTRealtimeHistoryQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 ART_EMBED_INTERFACE_EVENT_EMITTER(ARTRealtimeChannelState, ARTErrorInfo *)

--- a/ably-ios/ARTRealtimePresence.h
+++ b/ably-ios/ARTRealtimePresence.h
@@ -53,10 +53,8 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)unsubscribe:(__GENERIC(ARTEventListener, ARTPresenceMessage *) *)listener;
 - (void)unsubscribe:(ARTPresenceAction)action listener:(__GENERIC(ARTEventListener, ARTPresenceMessage *) *)listener;
 
-- (NSError *__art_nullable)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (NSError *__art_nullable)history:(art_nullable ARTRealtimeHistoryQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (BOOL)historyWithError:(NSError *__art_nullable *__art_nullable)errorPtr callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (BOOL)history:(art_nullable ARTRealtimeHistoryQuery *)query error:(NSError *__art_nullable *__art_nullable)errorPtr callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+- (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+- (BOOL)history:(art_nullable ARTRealtimeHistoryQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @end
 

--- a/ably-ios/ARTRealtimePresence.m
+++ b/ably-ios/ARTRealtimePresence.m
@@ -30,24 +30,12 @@
     [super get:query cb:callback];
 }
 
-- (NSError *)history:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    NSError *error = [[NSError alloc] init];
-    [self historyWithError:&error callback:callback];
-    return error;
+- (void)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *, NSError *))callback {
+    [self history:[[ARTRealtimeHistoryQuery alloc] init] callback:callback error:nil];
 }
 
-- (NSError *)history:(ARTRealtimeHistoryQuery *)query callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    NSError *error = [[NSError alloc] init];
-    [self history:query error:&error callback:callback];
-    return error;
-}
-
-- (BOOL)historyWithError:(NSError *__autoreleasing  _Nullable *)errorPtr callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    return [self history:[[ARTRealtimeHistoryQuery alloc] init] error:errorPtr callback:callback];
-}
-
-- (BOOL)history:(ARTRealtimeHistoryQuery *)query error:(NSError *__autoreleasing  _Nullable *)errorPtr callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
-    return [super history:query error:errorPtr callback:callback];
+- (BOOL)history:(ARTRealtimeHistoryQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *, NSError *))callback error:(NSError **)errorPtr {
+    return [super history:query callback:callback error:errorPtr];
 }
 
 - (void)enter:(id)data {

--- a/ably-ios/ARTRest.h
+++ b/ably-ios/ARTRest.h
@@ -30,10 +30,8 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (void)time:(ARTTimeCallback)callback;
 
-- (NSError *__art_nullable)stats:(ARTStatsCallback)callback;
-- (NSError *__art_nullable)stats:(art_nullable ARTStatsQuery *)query callback:(ARTStatsCallback)callback;
-- (BOOL)statsWithError:(NSError *__art_nullable *__art_nullable)errorPtr callback:(ARTStatsCallback)callback;
-- (BOOL)stats:(art_nullable ARTStatsQuery *)query error:(NSError *__art_nullable *__art_nullable)errorPtr callback:(ARTStatsCallback)callback;
+- (BOOL)stats:(ARTStatsCallback)callback;
+- (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(ARTStatsCallback)callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @property (nonatomic, strong, readonly) ARTRestChannels *channels;
 @property (nonatomic, strong, readonly) ARTAuth *auth;

--- a/ably-ios/ARTRest.m
+++ b/ably-ios/ARTRest.m
@@ -194,23 +194,11 @@
     return nil;
 }
 
-- (NSError *)stats:(ARTStatsCallback)callback {
-    NSError *error = nil;
-    [self statsWithError:&error callback:callback];
-    return error;
+- (BOOL)stats:(ARTStatsCallback)callback {
+    return [self stats:[[ARTStatsQuery alloc] init] callback:callback error:nil];
 }
 
-- (NSError *)stats:(ARTStatsQuery *)query callback:(ARTStatsCallback)callback {
-    NSError *error = nil;
-    [self stats:query error:&error callback:callback];
-    return error;
-}
-
-- (BOOL)statsWithError:(NSError *__autoreleasing  _Nullable *)errorPtr callback:(ARTStatsCallback)callback {
-    return [self stats:[[ARTStatsQuery alloc] init] error:errorPtr callback:callback];
-}
-
-- (BOOL)stats:(ARTStatsQuery *)query error:(NSError **)errorPtr callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *, NSError *))callback {
+- (BOOL)stats:(ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *, NSError *))callback error:(NSError **)errorPtr {
     if (query.limit > 1000) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain

--- a/ably-ios/ARTRestPresence.m
+++ b/ably-ios/ARTRestPresence.m
@@ -47,7 +47,7 @@
     [ARTPaginatedResult executePaginated:[self channel].rest withRequest:request andResponseProcessor:responseProcessor callback:callback];
 }
 
-- (BOOL)history:(ARTDataQuery *)query error:(NSError **)errorPtr callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback {
+- (BOOL)history:(ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback error:(NSError **)errorPtr {
     if (query.limit > 1000) {
         if (errorPtr) {
             *errorPtr = [NSError errorWithDomain:ARTAblyErrorDomain

--- a/ably-iosTests/ARTRealtimePresenceHistoryTest.m
+++ b/ably-iosTests/ARTRealtimePresenceHistoryTest.m
@@ -122,10 +122,10 @@
                             query.direction = forwards ? ARTQueryDirectionForwards : ARTQueryDirectionBackwards;
                             query.limit = limit;
 
-                            [channel.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+                            [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                                 cb(result, error);
                                 [expectation fulfill];
-                            }];
+                            } error:nil];
                         }];
                     }];
                 }];
@@ -152,14 +152,14 @@
                 [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
 
-                    [channel.presence history:[[ARTRealtimeHistoryQuery alloc] init] error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+                    [channel.presence history:[[ARTRealtimeHistoryQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);
                         NSArray *messages = [result items];
                         XCTAssertEqual(1, messages.count);
                         ARTPresenceMessage *m0 = messages[0];
                         XCTAssertEqualObjects(presenceEnter, [m0 data]);
                         [expectation fulfill];
-                    }];
+                    } error:nil];
                 }];
             }
         }];
@@ -192,7 +192,7 @@
                             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
                             query.direction = ARTQueryDirectionForwards;
 
-                            [channel.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+                            [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                                  XCTAssert(!error);
                                  NSArray *messages = [result items];
                                  XCTAssertEqual(3, messages.count);
@@ -208,7 +208,7 @@
                                  XCTAssertEqualObjects(presenceUpdate, [m2 data]);
                                  XCTAssertEqual(m2.action, ARTPresenceUpdate);
                                  [expectation fulfill];
-                            }];
+                            } error:nil];
                         }];
                     }];
                 }];
@@ -245,7 +245,7 @@
                                 ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
                                 query.direction = ARTQueryDirectionForwards;
 
-                                [channel.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+                                [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                                      XCTAssert(!error);
                                      NSArray *messages = [result items];
                                      XCTAssertEqual(3, messages.count);
@@ -261,7 +261,7 @@
                                      XCTAssertEqualObjects(presenceUpdate, [m2 data]);
                                      XCTAssertEqual(m2.action, ARTPresenceUpdate);
                                      [expectation fulfill];
-                                 }];
+                                 } error:nil];
                             }];
                             
                         }];
@@ -302,7 +302,7 @@
                             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
                             query.direction = ARTQueryDirectionBackwards;
 
-                            [channel.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+                            [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                                  XCTAssert(!error);
                                  NSArray *messages = [result items];
                                  XCTAssertEqual(3, messages.count);
@@ -318,7 +318,7 @@
                                  XCTAssertEqualObjects(presenceEnter1, [m2 data]);
                                  XCTAssertEqual(m2.action, ARTPresenceEnter);
                                  [expectation fulfill];
-                             }];
+                             } error:nil];
                         }];
                     }];
                 }];
@@ -500,10 +500,10 @@
         query.direction = forwards ? ARTQueryDirectionForwards : ARTQueryDirectionBackwards;
 
         XCTestExpectation *historyExpecation = [self expectationWithDescription:@"historyExpecation"];
-        [channel.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+        [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
             cb(result, error);
             [historyExpecation fulfill];
-        }];
+        } error:nil];
         [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
     }];
 }
@@ -565,7 +565,7 @@
                                     if(channel2.state == ARTRealtimeChannelAttached) {
                                         ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
                                         query.direction = ARTQueryDirectionForwards;
-                                        [channel2.presence history:query error:nil callback:^(ARTPaginatedResult *c2Result, NSError *error2) {
+                                        [channel2.presence history:query callback:^(ARTPaginatedResult *c2Result, NSError *error2) {
                                             XCTAssert(!error2);
                                             NSArray *messages = [c2Result items];
                                             XCTAssertEqual(3, messages.count);
@@ -582,7 +582,7 @@
                                             XCTAssertEqualObjects([self updateStr], [m2 data]);
                                             XCTAssertEqual(m2.action, ARTPresenceUpdate);
                                             [expectation fulfill];
-                                        }];
+                                        } error:nil];
                                     }
                                 }];
                                 [channel2 attach];
@@ -619,7 +619,7 @@
                 ARTRealtimeChannel * c3 =[_realtime3.channels get:channelName];
                 [c3.presence enter:presenceEnter3 cb:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
-                    [c1.presence history:[[ARTRealtimeHistoryQuery alloc] init] error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+                    [c1.presence history:[[ARTRealtimeHistoryQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);
                         NSArray *messages = [result items];
                         XCTAssertEqual(3, messages.count);
@@ -636,7 +636,7 @@
                             XCTAssertEqualObjects(presenceEnter1, [m data]);
                         }
                         [expectation fulfill];
-                    }];
+                    } error:nil];
                 }];
             }];
         }];

--- a/ably-iosTests/ARTRestPresenceTest.m
+++ b/ably-iosTests/ARTRestPresenceTest.m
@@ -86,12 +86,12 @@
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
-        [channel.presence history:[[ARTDataQuery alloc] init] error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+        [channel.presence history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
             XCTAssert(!error);
             NSArray *presence = [result items];
             XCTAssertEqual(6, [presence count]);
             [expectation fulfill];
-        }];
+        } error:nil];
     }];
      [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
@@ -101,14 +101,14 @@
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
-        [channel.presence history:[[ARTDataQuery alloc] init] error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+        [channel.presence history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
             XCTAssert(!error);
             NSArray *presence = [result items];
             XCTAssertEqual(6, [presence count]);
             ARTPresenceMessage * m = [presence objectAtIndex:[presence count] -1];
             XCTAssertEqualObjects(@"true", [m data]);
             [expectation fulfill];
-        }];
+        } error:nil];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
@@ -120,14 +120,14 @@
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
         ARTDataQuery *query = [[ARTDataQuery alloc] init];
         query.direction = ARTQueryDirectionForwards;
-        [channel.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error) {
+        [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
             XCTAssert(!error);
             NSArray *presence = [result items];
             XCTAssertEqual(6, [presence count]);
             ARTPresenceMessage * m = [presence objectAtIndex:0];
             XCTAssertEqualObjects(@"true", [m data]);
             [expectation fulfill];
-        }];
+        } error:nil];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
@@ -140,7 +140,7 @@
         ARTDataQuery *query = [[ARTDataQuery alloc] init];
         query.limit = 1001;
         NSError *error;
-        BOOL valid = [channelOne.presence history:query error:&error callback:^(ARTPaginatedResult *result, NSError *error){}];
+        BOOL valid = [channelOne.presence history:query callback:^(ARTPaginatedResult *result, NSError *error){} error:&error];
         XCTAssertFalse(valid);
         XCTAssertNotNil(error);
         XCTAssert(error.code == ARTDataQueryErrorLimit);
@@ -157,7 +157,7 @@
         ARTDataQuery *query = [[ARTDataQuery alloc] init];
         query.limit = 1001;
         // Forcing an invalid query where the error is ignored and the result should be invalid (the request was canceled)
-        BOOL requested = [channelOne.presence history:query error:nil callback:^(ARTPaginatedResult *result, NSError *error){}];
+        BOOL requested = [channelOne.presence history:query callback:^(ARTPaginatedResult *result, NSError *error){} error:nil];
         XCTAssertFalse(requested);
         [exp fulfill];
     }];

--- a/ablySpec/RealtimeClient.swift
+++ b/ablySpec/RealtimeClient.swift
@@ -213,7 +213,7 @@ class RealtimeClient: QuickSpec {
                     // Async
                     waitUntil(timeout: testTimeout) { done in
                         // Proxy from `client.rest.stats`
-                        client.stats(query, callback: { paginated, error in
+                        try! client.stats(query, callback: { paginated, error in
                             expect(paginated).toNot(beNil())
                             done()
                         })
@@ -227,7 +227,7 @@ class RealtimeClient: QuickSpec {
                     var paginatedResult: ARTPaginatedResult?
 
                     // Realtime
-                    client.stats(query, callback: { paginated, error in
+                    try! client.stats(query, callback: { paginated, error in
                         if let e = error {
                             XCTFail(e.description)
                         }
@@ -240,7 +240,7 @@ class RealtimeClient: QuickSpec {
 
                     // Rest
                     waitUntil(timeout: testTimeout) { done in
-                        client.rest.stats(query, callback: { paginated, error in
+                        try! client.rest.stats(query, callback: { paginated, error in
                             defer { done() }
                             if let e = error {
                                 XCTFail(e.description)

--- a/ablySpec/RestClientStats.swift
+++ b/ablySpec/RestClientStats.swift
@@ -41,7 +41,7 @@ private func queryStats(client: ARTRest, _ query: ARTStatsQuery) -> ARTPaginated
     let dummyError = NSError(domain: "", code: -1, userInfo: nil);
     var error: NSError? = dummyError
 
-    client.stats(query, callback: { result, err in
+    try! client.stats(query, callback: { result, err in
         stats = result
         error = err
     })
@@ -312,8 +312,7 @@ class RestClientStats: QuickSpec {
                             query.start = NSDate.distantFuture()
                             query.end = NSDate.distantPast()
 
-                            let error = client.stats(query, callback:{ status, result in })
-                            expect(error).toNot(beNil())
+                            expect{try client.stats(query, callback:{ status, result in })}.to(throwError())
                         }
                     }
                     
@@ -340,8 +339,7 @@ class RestClientStats: QuickSpec {
                             
                             query.limit = 1001;
 
-                            let error = client.stats(query, callback: { status, result in })
-                            expect(error).toNot(beNil())
+                            expect{try client.stats(query, callback:{ status, result in })}.to(throwError())
                         }
                     }
                     


### PR DESCRIPTION
We changed `Channel.history`, but left `Presence.history` and `stats` behind.