### PR TITLE
Rename all cb: to callback:

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ channel.subscribe("myEvent") { message in
 **Objective-C**
 
 ```objective-c
-[channel subscribe:@"myEvent" cb:^(ARTMessage *message) {
+[channel subscribe:@"myEvent" callback:^(ARTMessage *message) {
     NSLog(@"%@", message.name);
     NSLog(@"%@", message.data);
 }];
@@ -256,7 +256,7 @@ channel.presence.enter("john.doe") { errorInfo in
 **Objective-C**
 
 ```objective-c
-[channel.presence enter:@"john.doe" cb:^(ARTErrorInfo *errorInfo) {
+[channel.presence enter:@"john.doe" callback:^(ARTErrorInfo *errorInfo) {
     [channel.presence get:^(ARTPaginatedResult<ARTPresenceMessage *> *result, NSError *error) {
         // members is the array of members present
     }];

--- a/Source/ARTChannel.h
+++ b/Source/ARTChannel.h
@@ -25,13 +25,13 @@ ART_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options andLogger:(ARTLog *)logger;
 
 - (void)publish:(art_nullable NSString *)name data:(art_nullable id)data;
-- (void)publish:(art_nullable NSString *)name data:(art_nullable id)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
+- (void)publish:(art_nullable NSString *)name data:(art_nullable id)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
 
 - (void)publish:(art_nullable NSString *)name data:(art_nullable id)data clientId:(NSString *)clientId;
-- (void)publish:(art_nullable NSString *)name data:(art_nullable id)data clientId:(NSString *)clientId cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
+- (void)publish:(art_nullable NSString *)name data:(art_nullable id)data clientId:(NSString *)clientId callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
 
 - (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages;
-- (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
+- (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
 
 - (void)history:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
 - (BOOL)history:(art_nullable ARTDataQuery *)query callback:(void(^)(__GENERIC(ARTPaginatedResult, ARTMessage *) *__art_nullable result, NSError *__art_nullable error))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -41,28 +41,28 @@
 }
 
 - (void)publish:(NSString *)name data:(id)data {
-    [self publish:name data:data cb:nil];
+    [self publish:name data:data callback:nil];
 }
 
-- (void)publish:(art_nullable NSString *)name data:(art_nullable id)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback {
+- (void)publish:(art_nullable NSString *)name data:(art_nullable id)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback {
     [self internalPostMessages:[self encodeMessageIfNeeded:[[ARTMessage alloc] initWithName:name data:data]]
                       callback:callback];
 }
 
 - (void)publish:(NSString *)name data:(id)data clientId:(NSString *)clientId {
-    [self publish:name data:data clientId:clientId cb:nil];
+    [self publish:name data:data clientId:clientId callback:nil];
 }
 
-- (void)publish:(NSString *)name data:(id)data clientId:(NSString *)clientId cb:(void (^)(ARTErrorInfo * _Nullable))callback {
+- (void)publish:(NSString *)name data:(id)data clientId:(NSString *)clientId callback:(void (^)(ARTErrorInfo * _Nullable))callback {
     [self internalPostMessages:[self encodeMessageIfNeeded:[[ARTMessage alloc] initWithName:name data:data clientId:clientId]]
                       callback:callback];
 }
 
 - (void)publish:(NSArray<ARTMessage *> *)messages {
-    [self publish:messages cb:nil];
+    [self publish:messages callback:nil];
 }
 
-- (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback {
+- (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback {
     [self internalPostMessages:[messages artMap:^id(ARTMessage *message) {
         return [self encodeMessageIfNeeded:message];
     }] callback:callback];

--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -62,7 +62,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init;
 
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body cb:(ARTHttpCb)cb;
+- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body callback:(ARTHttpCb)cb;
 
 @end
 

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -194,11 +194,11 @@
     }];
 }
 
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body cb:(ARTHttpCb)cb {
-    return [self makeRequest:[[ARTHttpRequest alloc] initWithMethod:method url:url headers:headers body:body] cb:cb];
+- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body callback:(ARTHttpCb)cb {
+    return [self makeRequest:[[ARTHttpRequest alloc] initWithMethod:method url:url headers:headers body:body] callback:cb];
 }
 
-- (id<ARTCancellable>)makeRequest:(ARTHttpRequest *)artRequest cb:(void (^)(ARTHttpResponse *))cb __deprecated {
+- (id<ARTCancellable>)makeRequest:(ARTHttpRequest *)artRequest callback:(void (^)(ARTHttpResponse *))cb __deprecated {
 
     if(![artRequest.method isEqualToString:@"GET"] && ![artRequest.method isEqualToString:@"POST"]){
         [NSException raise:@"Http method must be GET or POST" format:@""];

--- a/Source/ARTPresence.h
+++ b/Source/ARTPresence.h
@@ -37,7 +37,7 @@ ART_ASSUME_NONNULL_BEGIN
  Get the presence state for one channel
  */
 - (void)get:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
-- (void)get:(ARTPresenceQuery *)query cb:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+- (void)get:(ARTPresenceQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
 
 /**
  Obtain recent presence history for one channel

--- a/Source/ARTPresence.m
+++ b/Source/ARTPresence.m
@@ -53,10 +53,10 @@
 }
 
 - (void)get:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, NSError *error))callback {
-    [self get:[[ARTPresenceQuery alloc] init] cb:callback];
+    [self get:[[ARTPresenceQuery alloc] init] callback:callback];
 }
 
-- (void)get:(ARTPresenceQuery *)query cb:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
+- (void)get:(ARTPresenceQuery *)query callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
     NSAssert(false, @"-[%@ %@] should always be overriden.", self.class, NSStringFromSelector(_cmd));
 }
 

--- a/Source/ARTQueuedMessage.h
+++ b/Source/ARTQueuedMessage.h
@@ -16,8 +16,8 @@
 @property (readonly, strong, nonatomic) ARTProtocolMessage *msg;
 @property (readonly, strong, nonatomic) NSMutableArray *cbs;
 
-- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg cb:(ARTStatusCallback)cb;
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg cb:(ARTStatusCallback)cb;
+- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb;
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb;
 
 - (ARTStatusCallback)cb;
 

--- a/Source/ARTQueuedMessage.m
+++ b/Source/ARTQueuedMessage.m
@@ -13,7 +13,7 @@
 
 @implementation ARTQueuedMessage
 
-- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg cb:(ARTStatusCallback)cb {
+- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
     self = [super init];
     if (self) {
         _msg = msg;
@@ -25,7 +25,7 @@
     return self;
 }
 
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg cb:(ARTStatusCallback)cb {
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
     if ([self.msg mergeFrom:msg]) {
         if (cb) {
             [self.cbs addObject:cb];

--- a/Source/ARTRealtime+Private.h
+++ b/Source/ARTRealtime+Private.h
@@ -81,7 +81,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)resetEventEmitter;
 
 // Message sending
-- (void)send:(ARTProtocolMessage *)msg cb:(art_nullable ARTStatusCallback)cb;
+- (void)send:(ARTProtocolMessage *)msg callback:(art_nullable ARTStatusCallback)cb;
 
 - (CFRunLoopTimerRef)startTimer:(void(^)())onTimeout interval:(NSTimeInterval)interval;
 - (void)cancelTimer:(CFRunLoopTimerRef)timer;

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -559,11 +559,11 @@
     return [self shouldQueueEvents] || [self shouldSendEvents];
 }
 
-- (void)sendImpl:(ARTProtocolMessage *)msg cb:(ARTStatusCallback)cb {
+- (void)sendImpl:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
 
     if (msg.ackRequired) {
         msg.msgSerial = self.msgSerial++;
-        ARTQueuedMessage *qm = [[ARTQueuedMessage alloc] initWithProtocolMessage:msg cb:cb];
+        ARTQueuedMessage *qm = [[ARTQueuedMessage alloc] initWithProtocolMessage:msg callback:cb];
         [self.pendingMessages addObject:qm];
     }
 
@@ -571,17 +571,17 @@
     [self.transport send:msg];
 }
 
-- (void)send:(ARTProtocolMessage *)msg cb:(ARTStatusCallback)cb {
+- (void)send:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
     if ([self shouldSendEvents]) {
-        [self sendImpl:msg cb:cb];
+        [self sendImpl:msg callback:cb];
     } else if ([self shouldQueueEvents]) {
         BOOL merged = NO;
         if ([self.queuedMessages count]) {
             ARTQueuedMessage *lastQueued = [self.queuedMessages objectAtIndex:(self.queuedMessages.count) - 1];
-            merged = [lastQueued mergeFrom:msg cb:cb];
+            merged = [lastQueued mergeFrom:msg callback:cb];
         }
         if (!merged) {
-            ARTQueuedMessage *qm = [[ARTQueuedMessage alloc] initWithProtocolMessage:msg cb:cb];
+            ARTQueuedMessage *qm = [[ARTQueuedMessage alloc] initWithProtocolMessage:msg callback:cb];
             [self.queuedMessages addObject:qm];
         }
     } else {
@@ -597,7 +597,7 @@
     self.queuedMessages = [NSMutableArray array];
 
     for (ARTQueuedMessage *message in qms) {
-        [self sendImpl:message.msg cb:message.cb];
+        [self sendImpl:message.msg callback:message.cb];
     }
 }
 

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -38,8 +38,8 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)transition:(ARTRealtimeChannelState)state status:(ARTStatus *)status;
 
 - (void)onChannelMessage:(ARTProtocolMessage *)message;
-- (void)publishPresence:(ARTPresenceMessage *)pm cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
-- (void)publishProtocolMessage:(ARTProtocolMessage *)pm cb:(ARTStatusCallback)cb;
+- (void)publishPresence:(ARTPresenceMessage *)pm callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb;
 
 - (void)setAttached:(ARTProtocolMessage *)message;
 - (void)setDetached:(ARTProtocolMessage *)message;

--- a/Source/ARTRealtimeChannel.h
+++ b/Source/ARTRealtimeChannel.h
@@ -30,9 +30,9 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)detach:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribe:(void (^)(ARTMessage *message))cb;
-- (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribeWithAttachCallback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))onAttach cb:(void (^)(ARTMessage *message))cb;
-- (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribe:(NSString *)name cb:(void (^)(ARTMessage *message))cb;
-- (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribe:(NSString *)name onAttach:(art_nullable void (^)(ARTErrorInfo *__art_nullable))onAttach cb:(void (^)(ARTMessage *message))cb;
+- (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribeWithAttachCallback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))onAttach callback:(void (^)(ARTMessage *message))cb;
+- (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribe:(NSString *)name callback:(void (^)(ARTMessage *message))cb;
+- (__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)subscribe:(NSString *)name onAttach:(art_nullable void (^)(ARTErrorInfo *__art_nullable))onAttach callback:(void (^)(ARTMessage *message))cb;
 
 - (void)unsubscribe;
 - (void)unsubscribe:(__GENERIC(ARTEventListener, ARTMessage *) *__art_nullable)listener;

--- a/Source/ARTRealtimeChannels.h
+++ b/Source/ARTRealtimeChannels.h
@@ -26,7 +26,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (BOOL)exists:(NSString *)name;
 - (ARTRealtimeChannel *)get:(NSString *)name;
 - (ARTRealtimeChannel *)get:(NSString *)name options:(ARTChannelOptions *)options;
-- (void)release:(NSString *)name cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))errorInfo;
+- (void)release:(NSString *)name callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))errorInfo;
 - (void)release:(NSString *)name;
 
 @end

--- a/Source/ARTRealtimeChannels.m
+++ b/Source/ARTRealtimeChannels.m
@@ -52,7 +52,7 @@
     return [_channels exists:name];
 }
 
-- (void)release:(NSString *)name cb:(void (^)(ARTErrorInfo * _Nullable))cb {
+- (void)release:(NSString *)name callback:(void (^)(ARTErrorInfo * _Nullable))cb {
     ARTRealtimeChannel *channel = _channels.channels[name];
     if (channel) {
         [channel detach:^(ARTErrorInfo *errorInfo) {
@@ -66,7 +66,7 @@
 }
 
 - (void)release:(NSString *)name {
-    [self release:name cb:nil];
+    [self release:name callback:nil];
 }
 
 @end

--- a/Source/ARTRealtimePresence.h
+++ b/Source/ARTRealtimePresence.h
@@ -27,28 +27,28 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithChannel:(ARTRealtimeChannel *)channel;
 
-- (void)get:(ARTRealtimePresenceQuery *)query cb:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
+- (void)get:(ARTRealtimePresenceQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *__art_nullable result, NSError *__art_nullable error))callback;
 
 - (void)enter:(id __art_nullable)data;
-- (void)enter:(id __art_nullable)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)enter:(id __art_nullable)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (void)update:(id __art_nullable)data;
-- (void)update:(id __art_nullable)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)update:(id __art_nullable)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (void)leave:(id __art_nullable)data;
-- (void)leave:(id __art_nullable)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)leave:(id __art_nullable)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (void)enterClient:(NSString *)clientId data:(id __art_nullable)data;
-- (void)enterClient:(NSString *)clientId data:(id __art_nullable)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)enterClient:(NSString *)clientId data:(id __art_nullable)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (void)updateClient:(NSString *)clientId data:(id __art_nullable)data;
-- (void)updateClient:(NSString *)clientId data:(id __art_nullable)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)updateClient:(NSString *)clientId data:(id __art_nullable)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (void)leaveClient:(NSString *)clientId data:(id __art_nullable)data;
-- (void)leaveClient:(NSString *)clientId data:(id __art_nullable)data cb:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
+- (void)leaveClient:(NSString *)clientId data:(id __art_nullable)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
 
 - (__GENERIC(ARTEventListener, ARTPresenceMessage *) *)subscribe:(void (^)(ARTPresenceMessage *message))cb;
-- (__GENERIC(ARTEventListener, ARTPresenceMessage *) *)subscribe:(ARTPresenceAction)action cb:(void (^)(ARTPresenceMessage *message))cb;
+- (__GENERIC(ARTEventListener, ARTPresenceMessage *) *)subscribe:(ARTPresenceAction)action callback:(void (^)(ARTPresenceMessage *message))cb;
 - (void)unsubscribe;
 - (void)unsubscribe:(__GENERIC(ARTEventListener, ARTPresenceMessage *) *)listener;
 - (void)unsubscribe:(ARTPresenceAction)action listener:(__GENERIC(ARTEventListener, ARTPresenceMessage *) *)listener;

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -25,9 +25,9 @@
     return (ARTRealtimeChannel *)super.channel;
 }
 
-- (void)get:(ARTRealtimePresenceQuery *)query cb:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
+- (void)get:(ARTRealtimePresenceQuery *)query callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
     [[self channel] throwOnDisconnectedOrFailed];
-    [super get:query cb:callback];
+    [super get:query callback:callback];
 }
 
 - (void)history:(void (^)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *, NSError *))callback {
@@ -39,18 +39,18 @@
 }
 
 - (void)enter:(id)data {
-    [self enter:data cb:nil];
+    [self enter:data callback:nil];
 }
 
-- (void)enter:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
-    [self enterClient:[self channel].clientId data:data cb:cb];
+- (void)enter:(id)data callback:(void (^)(ARTErrorInfo * _Nullable))cb {
+    [self enterClient:[self channel].clientId data:data callback:cb];
 }
 
 - (void)enterClient:(NSString *)clientId data:(id)data {
-    [self enterClient:clientId data:data cb:nil];
+    [self enterClient:clientId data:data callback:nil];
 }
 
-- (void)enterClient:(NSString *)clientId data:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
+- (void)enterClient:(NSString *)clientId data:(id)data callback:(void (^)(ARTErrorInfo * _Nullable))cb {
     if(!clientId) {
         if (cb) cb([ARTErrorInfo createWithCode:ARTStateNoClientId message:@"attempted to publish presence message without clientId"]);
         return;
@@ -61,22 +61,22 @@
     msg.data = data;
 
     msg.connectionId = [self channel].realtime.connection.id;
-    [[self channel] publishPresence:msg cb:cb];
+    [[self channel] publishPresence:msg callback:cb];
 }
 
 - (void)update:(id)data {
-    [self update:data cb:nil];
+    [self update:data callback:nil];
 }
 
-- (void)update:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
-    [self updateClient:[self channel].clientId data:data cb:cb];
+- (void)update:(id)data callback:(void (^)(ARTErrorInfo * _Nullable))cb {
+    [self updateClient:[self channel].clientId data:data callback:cb];
 }
 
 - (void)updateClient:(NSString *)clientId data:(id)data {
-    [self updateClient:clientId data:data cb:nil];
+    [self updateClient:clientId data:data callback:nil];
 }
 
-- (void)updateClient:(NSString *)clientId data:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
+- (void)updateClient:(NSString *)clientId data:(id)data callback:(void (^)(ARTErrorInfo * _Nullable))cb {
     if (!clientId) {
         if (cb) cb([ARTErrorInfo createWithCode:ARTStateNoClientId message:@"attempted to publish presence message without clientId"]);
         return;
@@ -87,22 +87,22 @@
     msg.data = data;
     msg.connectionId = [self channel].realtime.connection.id;
 
-    [[self channel] publishPresence:msg cb:cb];
+    [[self channel] publishPresence:msg callback:cb];
 }
 
 - (void)leave:(id)data {
-    [self leave:data cb:nil];
+    [self leave:data callback:nil];
 }
 
-- (void)leave:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
-    [self leaveClient:[self channel].clientId data:data cb:cb];
+- (void)leave:(id)data callback:(void (^)(ARTErrorInfo * _Nullable))cb {
+    [self leaveClient:[self channel].clientId data:data callback:cb];
 }
 
 - (void)leaveClient:(NSString *)clientId data:(id)data {
-    [self leaveClient:clientId data:data cb:nil];
+    [self leaveClient:clientId data:data callback:nil];
 }
 
-- (void)leaveClient:(NSString *)clientId data:(id)data cb:(void (^)(ARTErrorInfo * _Nullable))cb {
+- (void)leaveClient:(NSString *)clientId data:(id)data callback:(void (^)(ARTErrorInfo * _Nullable))cb {
     if (!clientId) {
         if (cb) cb([ARTErrorInfo createWithCode:ARTStateNoClientId message:@"attempted to publish presence message without clientId"]);
         return;
@@ -117,7 +117,7 @@
     msg.data = data;
     msg.clientId = clientId;
     msg.connectionId = [self channel].realtime.connection.id;
-    [[self channel] publishPresence:msg cb:cb];
+    [[self channel] publishPresence:msg callback:cb];
 }
 
 - (BOOL)isSyncComplete {
@@ -129,7 +129,7 @@
     return [[self channel].presenceEventEmitter on:cb];
 }
 
-- (ARTEventListener<ARTPresenceMessage *> *)subscribe:(ARTPresenceAction)action cb:(void (^)(ARTPresenceMessage * _Nonnull))cb {
+- (ARTEventListener<ARTPresenceMessage *> *)subscribe:(ARTPresenceAction)action callback:(void (^)(ARTPresenceMessage * _Nonnull))cb {
     [[self channel] attach];
     return [[self channel].presenceEventEmitter on:[NSNumber numberWithUnsignedInteger:action] call:cb];
 }

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -187,7 +187,7 @@
 }
 
 - (id<ARTCancellable>)internetIsUp:(void (^)(bool isUp)) cb {
-    [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://internet-up.ably-realtime.com/is-the-internet-up.txt"] headers:nil body:nil cb:^(ARTHttpResponse *response) {
+    [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://internet-up.ably-realtime.com/is-the-internet-up.txt"] headers:nil body:nil callback:^(ARTHttpResponse *response) {
         NSString * str = [[NSString alloc] initWithData:response.body encoding:NSUTF8StringEncoding];
         cb(response.status == 200 && [str isEqualToString:@"yes\n"]);
     }];

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -28,7 +28,7 @@
     return (ARTRestChannel *)super.channel;
 }
 
-- (void)get:(ARTPresenceQuery *)query cb:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
+- (void)get:(ARTPresenceQuery *)query callback:(void (^)(ARTPaginatedResult<ARTPresenceMessage *> * _Nullable, NSError * _Nullable))callback {
     NSURL *requestUrl = [NSURL URLWithString:[[self channel].basePath stringByAppendingPathComponent:@"presence"]];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl];
 

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -257,7 +257,7 @@ class Auth : QuickSpec {
                                     currentChannel.subscribe({ message in
                                         done()
                                     })
-                                    currentChannel.publish(nil, data: "ping", cb:nil)
+                                    currentChannel.publish(nil, data: "ping", callback:nil)
                                 }
                             }
                         }

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -923,7 +923,7 @@ class RealtimeClientChannel: QuickSpec {
                             result = message.data as? String
                         }
 
-                        channel.publish("event", data: expectedResult, cb: nil)
+                        channel.publish("event", data: expectedResult, callback: nil)
 
                         expect(result).toEventually(equal(expectedResult), timeout: testTimeout)
                     }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -412,7 +412,7 @@ class RealtimeClientConnection: QuickSpec {
                         TotalReach.shared++
                     }
 
-                    channel.publish(nil, data: "message_string", cb: nil)
+                    channel.publish(nil, data: "message_string", callback: nil)
                 }
 
                 // Sends 50 messages from different clients to the same channel
@@ -519,7 +519,7 @@ class RealtimeClientConnection: QuickSpec {
                                     let channel = client.channels.get("test")
                                     channel.on { errorInfo in
                                         if channel.state == .Attached {
-                                            channel.presence.enterClient("client_string", data: nil, cb: { errorInfo in
+                                            channel.presence.enterClient("client_string", data: nil, callback: { errorInfo in
                                                 expect(errorInfo).to(beNil())
                                                 done()
                                             })
@@ -590,7 +590,7 @@ class RealtimeClientConnection: QuickSpec {
                                     let channel = client.channels.get("test")
                                     channel.on { errorInfo in
                                         if channel.state == .Attached {
-                                            channel.presence.enterClient("invalid", data: nil, cb: { errorInfo in
+                                            channel.presence.enterClient("invalid", data: nil, callback: { errorInfo in
                                                 expect(errorInfo).toNot(beNil())
                                                 done()
                                             })
@@ -655,7 +655,7 @@ class RealtimeClientConnection: QuickSpec {
                         expect(TotalMessages.succeeded).toEventually(equal(TotalMessages.expected), timeout: testTimeout)
 
                         waitUntil(timeout: testTimeout) { done in
-                            channel.presence.enterClient("invalid", data: nil, cb: { errorInfo in
+                            channel.presence.enterClient("invalid", data: nil, callback: { errorInfo in
                                 expect(errorInfo).toNot(beNil())
                                 done()
                             })
@@ -706,7 +706,7 @@ class RealtimeClientConnection: QuickSpec {
                         waitUntil(timeout: testTimeout) { done in
                             channel.on { errorInfo in
                                 if channel.state == .Attached {
-                                    channel.publish(nil, data: "message", cb: { errorInfo in
+                                    channel.publish(nil, data: "message", callback: { errorInfo in
                                         expect(errorInfo).toNot(beNil())
                                         done()
                                     })
@@ -736,7 +736,7 @@ class RealtimeClientConnection: QuickSpec {
                         waitUntil(timeout: testTimeout) { done in
                             channel.on { errorInfo in
                                 if channel.state == .Attached {
-                                    channel.publish(nil, data: "message", cb: { errorInfo in
+                                    channel.publish(nil, data: "message", callback: { errorInfo in
                                         expect(errorInfo).toNot(beNil())
                                         done()
                                     })
@@ -771,7 +771,7 @@ class RealtimeClientConnection: QuickSpec {
                         expect(channel.state).toEventually(equal(ARTRealtimeChannelState.Attached), timeout: testTimeout)
 
                         var gotPublishedCallback = false
-                        channel.publish(nil, data: "message", cb: { errorInfo in
+                        channel.publish(nil, data: "message", callback: { errorInfo in
                             expect(errorInfo).toNot(beNil())
                             gotPublishedCallback = true
                         })
@@ -972,7 +972,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     for index in 0...3 {
                         waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: "message", cb: { errorInfo in
+                            channel.publish(nil, data: "message", callback: { errorInfo in
                                 expect(errorInfo).to(beNil())
                                 // Updated
                                 expect(client.connection.serial).to(equal(Int64(index)))
@@ -996,7 +996,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     var lastSerial: Int64 = 0
                     for _ in 1...5 {
-                        channel.publish(nil, data: "message", cb: { errorInfo in
+                        channel.publish(nil, data: "message", callback: { errorInfo in
                             expect(errorInfo).to(beNil())
                             lastSerial = client.connection.serial
                         })
@@ -1011,7 +1011,7 @@ class RealtimeClientConnection: QuickSpec {
 
                     waitUntil(timeout: testTimeout) { done in
                         expect(recoveredClient.connection.serial).to(equal(lastSerial))
-                        recoveredClient.channels.get("test").publish(nil, data: "message", cb: { errorInfo in
+                        recoveredClient.channels.get("test").publish(nil, data: "message", callback: { errorInfo in
                             expect(errorInfo).to(beNil())
                             expect(recoveredClient.connection.serial).to(equal(lastSerial + 1))
                             done()
@@ -1449,7 +1449,7 @@ class RealtimeClientConnection: QuickSpec {
                         channel1.subscribeWithAttachCallback({ errorInfo in
                             expect(errorInfo).to(beNil())
                             done()
-                        }, cb: { message in
+                        }, callback: { message in
                             receivedMessages.append(message.data as! String)
                         })
                     }
@@ -1557,7 +1557,7 @@ class RealtimeClientConnection: QuickSpec {
                     expect(channel.state).to(equal(ARTRealtimeChannelState.Attached))
 
                     waitUntil(timeout: testTimeout + options.disconnectedRetryTimeout) { done in
-                        channel.publish(nil, data: "queuedMessage", cb: { errorInfo in
+                        channel.publish(nil, data: "queuedMessage", callback: { errorInfo in
                             expect(errorInfo).to(beNil())
                             done()
                         })
@@ -1589,7 +1589,7 @@ class RealtimeClientConnection: QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             // Reject publishing of messages
-                            channel.publish(nil, data: "message", cb: { errorInfo in
+                            channel.publish(nil, data: "message", callback: { errorInfo in
                                 expect(errorInfo).toNot(beNil())
                                 expect(errorInfo!.code).to(equal(90001))
                                 done()
@@ -1602,7 +1602,7 @@ class RealtimeClientConnection: QuickSpec {
 
                         waitUntil(timeout: testTimeout) { done in
                             // Accept publishing of messages
-                            channel.publish(nil, data: "message", cb: { errorInfo in
+                            channel.publish(nil, data: "message", callback: { errorInfo in
                                 expect(errorInfo).to(beNil())
                                 done()
                             })
@@ -1628,7 +1628,7 @@ class RealtimeClientConnection: QuickSpec {
                         
                         waitUntil(timeout: testTimeout) { done in
                             // Reject publishing of messages
-                            channel.publish(nil, data: "message", cb: { errorInfo in
+                            channel.publish(nil, data: "message", callback: { errorInfo in
                                 expect(errorInfo).toNot(beNil())
                                 expect(errorInfo!.code).to(equal(90001))
                                 done()
@@ -1658,7 +1658,7 @@ class RealtimeClientConnection: QuickSpec {
                     
                     waitUntil(timeout: testTimeout) { done in
                         // Reject publishing of messages
-                        channel.publish(nil, data: "message", cb: { errorInfo in
+                        channel.publish(nil, data: "message", callback: { errorInfo in
                             expect(errorInfo).toNot(beNil())
                             expect(errorInfo!.code).to(equal(90001))
                             done()

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -244,7 +244,7 @@ class RestClientChannel: QuickSpec {
 
                 invalidCases.forEach { caseItem in
                     waitUntil(timeout: testTimeout) { done in
-                        expect { channel.publish(nil, data: caseItem, cb: nil) }.to(raiseException(named: NSInvalidArgumentException))
+                        expect { channel.publish(nil, data: caseItem, callback: nil) }.to(raiseException(named: NSInvalidArgumentException))
                         done()
                     }
                 }
@@ -263,7 +263,7 @@ class RestClientChannel: QuickSpec {
 
                 encodingCases.forEach { caseItem in
                     waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: caseItem.value, cb: { error in
+                        channel.publish(nil, data: caseItem.value, callback: { error in
                             expect(error).to(beNil())
                             guard let httpBody = mockExecutor.requests.last!.HTTPBody else {
                                 XCTFail("HTTPBody is nil");
@@ -281,7 +281,7 @@ class RestClientChannel: QuickSpec {
                 it("binary payload should be encoded as Base64 and represented as a JSON string") {
                     client.httpExecutor = mockExecutor
                     waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: binaryData, cb: { error in
+                        channel.publish(nil, data: binaryData, callback: { error in
                             expect(error).to(beNil())
                             guard let httpBody = mockExecutor.requests.last!.HTTPBody else {
                                 XCTFail("HTTPBody is nil");
@@ -300,7 +300,7 @@ class RestClientChannel: QuickSpec {
                 it("string payload should be represented as a JSON string") {
                     client.httpExecutor = mockExecutor
                     waitUntil(timeout: testTimeout) { done in
-                        channel.publish(nil, data: text, cb: { error in
+                        channel.publish(nil, data: text, callback: { error in
                             expect(error).to(beNil())
 
                             if let request = mockExecutor.requests.last, let http = request.HTTPBody {
@@ -324,7 +324,7 @@ class RestClientChannel: QuickSpec {
                         client.httpExecutor = mockExecutor
                         // JSON Array
                         waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: array, cb: { error in
+                            channel.publish(nil, data: array, callback: { error in
                                 expect(error).to(beNil())
 
                                 if let request = mockExecutor.requests.last, let http = request.HTTPBody {
@@ -345,7 +345,7 @@ class RestClientChannel: QuickSpec {
                         client.httpExecutor = mockExecutor
                         // JSON Object
                         waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: dictionary, cb: { error in
+                            channel.publish(nil, data: dictionary, callback: { error in
                                 expect(error).to(beNil())
 
                                 if let request = mockExecutor.requests.last, let http = request.HTTPBody {
@@ -370,7 +370,7 @@ class RestClientChannel: QuickSpec {
 
                     cases.forEach { caseTest in
                         waitUntil(timeout: testTimeout) { done in
-                            channel.publish(nil, data: caseTest, cb: { error in
+                            channel.publish(nil, data: caseTest, callback: { error in
                                 expect(error).to(beNil())
                                 done()
                             })

--- a/Tests/ARTHttpTest.m
+++ b/Tests/ARTHttpTest.m
@@ -33,7 +33,7 @@
 -(void) testPingGoogle {
     XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
     
-    [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://www.google.com"] headers:nil body:nil cb:^(ARTHttpResponse *response) {
+    [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://www.google.com"] headers:nil body:nil callback:^(ARTHttpResponse *response) {
         XCTAssertEqual(response.status, 200);
         [expectation fulfill];
     }];
@@ -43,7 +43,7 @@
 - (void)testNonExistantPath {
     XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
 
-    [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://rest.ably.io"] headers:nil body:nil cb:^(ARTHttpResponse *response) {
+    [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://rest.ably.io"] headers:nil body:nil callback:^(ARTHttpResponse *response) {
         XCTAssertEqual(response.status, 404);
         [expectation fulfill];
     }];

--- a/Tests/ARTReadmeExamples.m
+++ b/Tests/ARTReadmeExamples.m
@@ -62,7 +62,7 @@
             NSLog(@"%@", message.data);
         }];
         
-        [channel subscribe:@"myEvent" cb:^(ARTMessage *message) {
+        [channel subscribe:@"myEvent" callback:^(ARTMessage *message) {
             NSLog(@"%@", message.name);
             NSLog(@"%@", message.data);
         }];
@@ -99,7 +99,7 @@
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *client) {
         ARTRealtimeChannel *channel = [client.channels get:@"test"];
         
-        [channel.presence enter:@"john.doe" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:@"john.doe" callback:^(ARTErrorInfo *errorInfo) {
             [channel.presence get:^(ARTPaginatedResult<ARTPresenceMessage *> *result, NSError *error) {
                 // members is the array of members present
             }];

--- a/Tests/ARTRealtimeAttachTest.m
+++ b/Tests/ARTRealtimeAttachTest.m
@@ -291,7 +291,7 @@
 
 - (void)testAttachRestricted {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability cb:^(ARTClientOptions * options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions * options) {
 
             ARTRealtime * realtime =[[ARTRealtime alloc] initWithOptions:options];
             _realtime = realtime;
@@ -368,7 +368,7 @@
 
 - (void)testPresenceEnterRestricted {
     XCTestExpectation *expect = [self expectationWithDescription:@"testSimpleDisconnected"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
         // Connection
         options.clientId = @"some_client_id";
         options.autoConnect = false;
@@ -389,7 +389,7 @@
             ARTErrorInfo *errorInfo = stateChange.reason;
             if (state == ARTRealtimeConnected) {
                 ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
-                [channel.presence enter:@"not_allowed_here" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:@"not_allowed_here" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNotNil(errorInfo);
                     [expect fulfill];
                 }];

--- a/Tests/ARTRealtimeChannelHistoryTest.m
+++ b/Tests/ARTRealtimeChannelHistoryTest.m
@@ -50,9 +50,9 @@
 
         if (state == ARTRealtimeConnected) {
             ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testHistory"];
-            [channel publish:nil data:@"testString" cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [channel publish:nil data:@"testString2" cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                     [channel history:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);
@@ -74,14 +74,14 @@
 -(void) publishTestStrings:(ARTRealtimeChannel *) channel
                      count:(int) count
                     prefix:(NSString *) prefix
-                        cb:(void (^) (ARTErrorInfo *errorInfo)) cb
+                        callback:(void (^) (ARTErrorInfo *errorInfo)) cb
 {
     {
         __block int numReceived =0;
         __block bool done =false;
         for(int i=0; i < count; i++) {
             NSString * pub = [prefix stringByAppendingString:[NSString stringWithFormat:@"%d", i]];
-            [channel publish:nil data:pub cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
                 if(channel.state != ARTStateOk) {
                     if(!done) {
                         done = true;
@@ -111,9 +111,9 @@
         NSString * both = @"historyBoth";
         ARTRealtimeChannel *channel1 = [realtime.channels get:both];
         ARTRealtimeChannel *channel2 = [realtime.channels get:both];
-        [channel1 publish:nil data:@"testString" cb:^(ARTErrorInfo *errorInfo) {
+        [channel1 publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel2 publish:nil data:@"testString2" cb:^(ARTErrorInfo *errorInfo) {
+            [channel2 publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [channel1 history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
@@ -148,9 +148,9 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testHistory"];
-        [channel publish:nil data:@"testString" cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel publish:nil data:@"testString2" cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 ARTRealtimeHistoryQuery* query = [[ARTRealtimeHistoryQuery alloc] init];
                 query.direction = ARTQueryDirectionForwards;
@@ -177,7 +177,7 @@
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"realHistChan"];
         
-        [self publishTestStrings:channel count:5 prefix:@"testString" cb:^(ARTErrorInfo *errorInfo){
+        [self publishTestStrings:channel count:5 prefix:@"testString" callback:^(ARTErrorInfo *errorInfo){
             XCTAssertNil(errorInfo);
 
             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -234,7 +234,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"histRealBackChan"];
-        [self publishTestStrings:channel count:5 prefix:@"testString" cb:^(ARTErrorInfo *errorInfo){
+        [self publishTestStrings:channel count:5 prefix:@"testString" callback:^(ARTErrorInfo *errorInfo){
             XCTAssertNil(errorInfo);
 
             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -452,7 +452,7 @@
 
     NSString *channelName = @"test_history_time_forwards";
     XCTestExpectation *expecation = [self expectationWithDescription:@"send_first_batch"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRealtime * realtime =[[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
 
@@ -465,7 +465,7 @@
         for(int i=0; i < firstBatchTotal; i++) {
             NSString *pub = [NSString stringWithFormat:@"test%d", i];
             sleep([ARTTestUtil smallSleep]);
-            [channel publish:nil data:pub cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 ++numReceived;
                 if (numReceived == firstBatchTotal) {

--- a/Tests/ARTRealtimeChannelTest.m
+++ b/Tests/ARTRealtimeChannelTest.m
@@ -151,7 +151,7 @@
         ARTEventListener __block *subscription = [channel subscribe:^(ARTMessage *message) {
             if([[message data] isEqualToString:@"testString"]) {
                 [channel unsubscribe:subscription];
-                [channel publish:nil data:lostMessage cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:nil data:lostMessage callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -160,7 +160,7 @@
             }
         }];
 
-        [channel publish:nil data:@"testString" cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             NSString * finalMessage = @"final";
             [channel subscribe:^(ARTMessage * message) {
@@ -168,7 +168,7 @@
                     [expectation fulfill];
                 }
             }];
-            [channel publish:nil data:finalMessage cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:nil data:finalMessage callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
         }];
@@ -190,7 +190,7 @@
             }
             else if(channel.state == ARTRealtimeChannelDetached) {
                 if(!gotCb) {
-                    [channel publish:nil data:@"will_fail" cb:^(ARTErrorInfo *errorInfo) {
+                    [channel publish:nil data:@"will_fail" callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNotNil(errorInfo);
                         XCTAssertEqual(90001, errorInfo.code);
                         gotCb = true;
@@ -215,7 +215,7 @@
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
             }
             else if(channel.state == ARTRealtimeChannelFailed) {
-                [channel publish:nil data:@"will_fail" cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:nil data:@"will_fail" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNotNil(errorInfo);
                     [expectation fulfill];
                 }];
@@ -243,7 +243,7 @@
             XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
             XCTAssertEqualObjects([d valueForKey:@"channel3"], c3);
         }
-        [realtime.channels release:c3.name cb:^(ARTErrorInfo *errorInfo) {
+        [realtime.channels release:c3.name callback:^(ARTErrorInfo *errorInfo) {
             NSMutableDictionary * d = [[NSMutableDictionary alloc] init];
             for (ARTRealtimeChannel *channel in realtime.channels) {
                 [d setValue:channel forKey:channel.name];
@@ -271,9 +271,9 @@
         NSData * keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
         ARTCipherParams * params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
         ARTRealtimeChannel *c2 = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
-        [c1 publish:nil data:firstMessage cb:^(ARTErrorInfo *errorInfo) {
+        [c1 publish:nil data:firstMessage callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [c2 publish:nil data:secondMessage cb:^(ARTErrorInfo *errorInfo) {
+            [c2 publish:nil data:secondMessage callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
         }];
@@ -353,7 +353,7 @@
 
     XCTestExpectation *exp1 = [self expectationWithDescription:@"testClientIdPreserved1"];
     XCTestExpectation *exp2 = [self expectationWithDescription:@"testClientIdPreserved2"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO callback:^(ARTClientOptions *options) {
         // First instance
         options.clientId = firstClientId;
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -390,7 +390,7 @@
         waitForWithTimeout(&attached, @[channel, channel2], 20.0);
 
         // Enters "firstClientId"
-        [channel.presence enter:@"First Client" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:@"First Client" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             [exp2 fulfill];
         }];

--- a/Tests/ARTRealtimeConnectTest.m
+++ b/Tests/ARTRealtimeConnectTest.m
@@ -136,9 +136,9 @@
             if(state == ARTRealtimeConnected) {
                 XCTAssertEqual(realtime.connection.serial, -1);
                 ARTRealtimeChannel * c =[realtime.channels get:@"chan"];
-                [c publish:nil data:@"message" cb:^(ARTErrorInfo *errorInfo) {
+                [c publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertEqual(realtime.connection.serial, 0);
-                    [c publish:nil data:@"message2" cb:^(ARTErrorInfo *errorInfo) {
+                    [c publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertEqual(realtime.connection.serial, 1);
                         [expectation fulfill];
                     }];
@@ -207,7 +207,7 @@
 
 - (void)testConnectStates {
     XCTestExpectation *exp = [self expectationWithDescription:@"testConnectStates"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.autoConnect = false;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;

--- a/Tests/ARTRealtimeCryptoTest.m
+++ b/Tests/ARTRealtimeCryptoTest.m
@@ -56,9 +56,9 @@
         NSData *dataPayload = [dataStr  dataUsingEncoding:NSUTF8StringEncoding];
         NSString *stringPayload = @"someString";
 
-        [channel publish:nil data:dataPayload cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel publish:nil data:stringPayload cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
                 [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
@@ -87,7 +87,7 @@
         _realtime = realtime;
 
         ARTRealtimeChannel * channel = [realtime.channels get:channelName];
-        [channel publish:nil data:firstMessageText cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:firstMessageText callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             NSData * ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
             NSData * keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
@@ -96,9 +96,9 @@
             XCTAssert(c);
             NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
             NSString * stringPayload = @"someString";
-            [c publish:nil data:dataPayload cb:^(ARTErrorInfo *errorInfo) {
+            [c publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [c publish:nil data:stringPayload cb:^(ARTErrorInfo *errorInfo) {
+                [c publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                     [c history:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);

--- a/Tests/ARTRealtimeInitTest.m
+++ b/Tests/ARTRealtimeInitTest.m
@@ -41,7 +41,7 @@
 }
 
 -(void) getBaseOptions:(void (^)(ARTClientOptions * options)) cb {
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO cb:cb];
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO callback:cb];
 }
 
 
@@ -128,7 +128,7 @@
 
 -(void) testInitAutoConnectFalse {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.autoConnect = false;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;

--- a/Tests/ARTRealtimeMessageTest.m
+++ b/Tests/ARTRealtimeMessageTest.m
@@ -79,7 +79,7 @@
                 }];
                 [ARTTestUtil repeat:count delay:(delay / 1000.0) block:^(int i) {
                     NSString *msg = [NSString stringWithFormat:@"Test message (_multiple_send) %d", i];
-                    [channel publish:@"test_event" data:msg cb:^(ARTErrorInfo *errorInfo) { 
+                    [channel publish:@"test_event" data:msg callback:^(ARTErrorInfo *errorInfo) { 
                     }];
                 }];
             }
@@ -97,7 +97,7 @@
             XCTAssertEqualObjects([message data], @"testString");
             [expectation fulfill];
         }];
-        [channel publish:nil data:@"testString" cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
     }];
@@ -110,7 +110,7 @@
     XCTestExpectation *exp3 = [self expectationWithDescription:@"testSingleSendEchoText3"];
     NSString *channelName = @"testSingleEcho";
     
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRealtime * realtime1 = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime1;
         ARTRealtime * realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -147,7 +147,7 @@
 
         waitForWithTimeout(&attached, @[channel, channel2], 20.0);
 
-        [channel2 publish:nil data:@"testStringEcho" cb:^(ARTErrorInfo *errorInfo) {
+        [channel2 publish:nil data:@"testStringEcho" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             [exp3 fulfill];
         }];
@@ -169,7 +169,7 @@
     NSString * message1 = @"message1";
     NSString * message2 = @"message2";
     
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
     
@@ -185,10 +185,10 @@
                 [exp fulfill];
             }
         }];
-        [channel publish:nil data:message1 cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             ARTRealtimeChannel * channel2 = [_realtime2.channels get:channelName];
-            [channel2 publish:nil data:message2 cb:^(ARTErrorInfo *errorInfo) {
+            [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
         }];
@@ -202,7 +202,7 @@
     NSString * message1 = @"message1";
     NSString * message2 = @"message2";
     
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.echoMessages = false;
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -212,10 +212,10 @@
             XCTAssertEqualObjects([message data], message2);
             [exp fulfill];
         }];
-        [channel publish:nil data:message1 cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             ARTRealtimeChannel * channel2 = [_realtime2.channels get:channelName];
-            [channel2 publish:nil data:message2 cb:^(ARTErrorInfo *errorInfo) {
+            [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
         }];
@@ -271,14 +271,14 @@
                 }
                 else {
                     connectingHappened = true;
-                    [channel publish:nil data:connectingMessage cb:^(ARTErrorInfo *errorInfo) {
+                    [channel publish:nil data:connectingMessage callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
                         [realtime onDisconnected];
                     }];
                 }
             }
             else if(state == ARTRealtimeDisconnected) {
-                [channel publish:nil data:disconnectedMessage cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:nil data:disconnectedMessage callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
                 [realtime connect];
@@ -293,15 +293,15 @@
 - (void)testConnectionIdsInMessage {
     XCTestExpectation *exp = [self expectationWithDescription:@"testConnectionIdsInMessage"];
     NSString * channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         XCTAssertFalse([_realtime2.connection.key isEqualToString:_realtime.connection.key]);
         ARTRealtimeChannel *c1 = [_realtime.channels get:channelName];
-        [c1 publish:nil data:@"message" cb:^(ARTErrorInfo *errorInfo) {
+        [c1 publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             ARTRealtimeChannel *c2 = [_realtime2.channels get:channelName];
-            [c2 publish:nil data:@"message2" cb:^(ARTErrorInfo *errorInfo) {
+            [c2 publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [c1 history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
@@ -336,7 +336,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel publish:nil data:@"testString" cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -357,7 +357,7 @@
         NSArray * messages = [@[@"test1", @"test2", @"test3"] artMap:^id(id data) {
             return [[ARTMessage alloc] initWithName:nil data:data];
         }];
-        [channel publish:messages cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:messages callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
         __block int messageCount =0;
@@ -383,7 +383,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        [channel publish:@"messageName" data:@"test" cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:@"messageName" data:@"test" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
         [channel subscribe:^(ARTMessage *message) {
@@ -404,16 +404,16 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel subscribe:messageName cb:^(ARTMessage *message) {
+        [channel subscribe:messageName callback:^(ARTMessage *message) {
             XCTAssertEqualObjects([message data], messageContent);
             [exp fulfill];
         }];
 
-        [channel publish:nil data:@"unnamed_wont_arrive" cb:^(ARTErrorInfo *errorInfo) {
+        [channel publish:nil data:@"unnamed_wont_arrive" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel publish:@"wrongName" data:@"wrong_name_wont_arrive" cb:^(ARTErrorInfo *errorInfo) {
+            [channel publish:@"wrongName" data:@"wrong_name_wont_arrive" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [channel publish:messageName data:messageContent cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:messageName data:messageContent callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }];

--- a/Tests/ARTRealtimePresenceHistoryTest.m
+++ b/Tests/ARTRealtimePresenceHistoryTest.m
@@ -65,7 +65,7 @@
     if (!_realtime) {
         ARTClientOptions * options = [ARTTestUtil clientOptions];
         options.clientId = [self getClientId];
-        [ARTTestUtil setupApp:options cb:^(ARTClientOptions *options) {
+        [ARTTestUtil setupApp:options callback:^(ARTClientOptions *options) {
             if (options) {
                 _realtime = [[ARTRealtime alloc] initWithOptions:options];
                 _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -98,7 +98,7 @@
     return @"persisted:runTestChannelName";
 }
 
--(void) runTestLimit:(int)limit forwards:(bool)forwards cb:(ARTPaginatedResultCallback)cb {
+-(void) runTestLimit:(int)limit forwards:(bool)forwards callback:(ARTPaginatedResultCallback)cb {
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
@@ -110,12 +110,12 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:[self enter1Str] cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:[self enter1Str] callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                     //second enter gets treated as an update.
-                    [channel.presence enter:[self enter2Str] cb:^(ARTErrorInfo *errorInfo) {
+                    [channel.presence enter:[self enter2Str] callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence update:[self updateStr] cb:^(ARTErrorInfo *errorInfo2) {
+                        [channel.presence update:[self updateStr] callback:^(ARTErrorInfo *errorInfo2) {
                             XCTAssertNil(errorInfo2);
 
                             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -149,7 +149,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
 
                     [channel.presence history:[[ARTRealtimeHistoryQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
@@ -182,11 +182,11 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter1 cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter1 callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
-                    [channel.presence enter:presenceEnter2 cb:^(ARTErrorInfo *errorInfo) {
+                    [channel.presence enter:presenceEnter2 callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence update:presenceUpdate cb:^(ARTErrorInfo *errorInfo2) {
+                        [channel.presence update:presenceUpdate callback:^(ARTErrorInfo *errorInfo2) {
                             XCTAssertNil(errorInfo2);
 
                             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -235,11 +235,11 @@
             {
                 [self withRealtimeClientId2:^(ARTRealtime *realtime2) {
                     ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
-                    [channel2.presence enter:presenceEnter1 cb:^(ARTErrorInfo *errorInfo) {
+                    [channel2.presence enter:presenceEnter1 callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence enter:presenceEnter2 cb:^(ARTErrorInfo *errorInfo) {
+                        [channel.presence enter:presenceEnter2 callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
-                            [channel2.presence update:presenceUpdate cb:^(ARTErrorInfo *errorInfo) {
+                            [channel2.presence update:presenceUpdate callback:^(ARTErrorInfo *errorInfo) {
                                 XCTAssertNil(errorInfo);
 
                                 ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -291,12 +291,12 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter1 cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter1 callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
 
-                    [channel.presence enter:presenceEnter2 cb:^(ARTErrorInfo *errorInfo) {
+                    [channel.presence enter:presenceEnter2 callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence update:presenceUpdate cb:^(ARTErrorInfo *errorInfo2) {
+                        [channel.presence update:presenceUpdate callback:^(ARTErrorInfo *errorInfo2) {
                             XCTAssertNil(errorInfo2);
 
                             ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -330,7 +330,7 @@
 
 -(void) testLimitForward
 {
-    [self runTestLimit:2 forwards:true cb:^(ARTPaginatedResult *result, NSError *error) {
+    [self runTestLimit:2 forwards:true callback:^(ARTPaginatedResult *result, NSError *error) {
         XCTAssert(!error);
         NSArray *messages = [result items];
         XCTAssertEqual(2, messages.count);
@@ -359,7 +359,7 @@
 
 
 - (void)testLimitBackward {
-    [self runTestLimit:2 forwards:false cb:^(ARTPaginatedResult *result, NSError *error) {
+    [self runTestLimit:2 forwards:false callback:^(ARTPaginatedResult *result, NSError *error) {
         XCTAssert(!error);
         NSArray *messages = [result items];
         XCTAssertEqual(2, messages.count);
@@ -402,7 +402,7 @@
 
 
 // TODO: consider using a pattern similar to ARTTestUtil testPublish.
--(void) runTestTimeForwards:(bool) forwards limit:(int) limit cb:(ARTPaginatedResultCallback) cb {
+-(void) runTestTimeForwards:(bool) forwards limit:(int) limit callback:(ARTPaginatedResultCallback) cb {
     __block long long timeOffset= 0;
     
     XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
@@ -434,14 +434,14 @@
     
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:[self enter1Str] cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:[self enter1Str] callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
 
                     __block int numReceived=0;
                     for(int i=0;i < firstBatchTotal; i++)
                     {
                         NSString * str = [NSString stringWithFormat:@"update%d", i];
-                        [channel.presence update:str cb:^(ARTErrorInfo *errorInfo) {
+                        [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
                             sleep([ARTTestUtil smallSleep]);
                             numReceived++;
@@ -463,7 +463,7 @@
         __block int numReceived=0;
         for(int i=0;i < secondBatchTotal; i++) {
             NSString * str = [NSString stringWithFormat:@"second_updates%d", i];
-            [channel.presence update:str cb:^(ARTErrorInfo *errorInfo) {
+            [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 sleep([ARTTestUtil smallSleep]);
                 numReceived++;
@@ -482,7 +482,7 @@
         XCTestExpectation *thirdBatchExpectation = [self expectationWithDescription:@"thirdBatchExpectation"];
         for(int i=0;i < thirdBatchTotal; i++) {
             NSString * str = [NSString stringWithFormat:@"third_updates%d", i];
-            [channel.presence update:str cb:^(ARTErrorInfo *errorInfo) {
+            [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
                 sleep([ARTTestUtil smallSleep]);
                 XCTAssertNil(errorInfo);
                 numReceived++;
@@ -509,7 +509,7 @@
 }
 
 - (void)testTimeForward {
-    [self runTestTimeForwards:true limit:100 cb:^(ARTPaginatedResult *result, NSError *error) {
+    [self runTestTimeForwards:true limit:100 callback:^(ARTPaginatedResult *result, NSError *error) {
         XCTAssert(!error);
         XCTAssertFalse([result hasNext]);
         NSArray *page = [result items];
@@ -525,7 +525,7 @@
 }
 
 - (void)testTimeBackward {
-    [self runTestTimeForwards:false limit:100 cb:^(ARTPaginatedResult *result, NSError *error) {
+    [self runTestTimeForwards:false limit:100 callback:^(ARTPaginatedResult *result, NSError *error) {
         XCTAssert(!error);
         XCTAssertFalse([result hasNext]);
         NSArray * page = [result items];
@@ -553,11 +553,11 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:[self enter1Str] cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:[self enter1Str] callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
-                    [channel.presence enter:[self enter2Str] cb:^(ARTErrorInfo *errorInfo) {
+                    [channel.presence enter:[self enter2Str] callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence update:[self updateStr] cb:^(ARTErrorInfo *errorInfo2) {
+                        [channel.presence update:[self updateStr] callback:^(ARTErrorInfo *errorInfo2) {
                             XCTAssertNil(errorInfo2);
                             [self withRealtimeClientId2:^(ARTRealtime *realtime2) {
                                 ARTRealtimeChannel * channel2 = [realtime2.channels get:[self channelName]];
@@ -605,19 +605,19 @@
     
     NSString * channelName = @"chanName";
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         _realtime3 = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel * c1 =[_realtime.channels get:channelName];
-        [c1.presence enter:presenceEnter1 cb:^(ARTErrorInfo *errorInfo) {
+        [c1.presence enter:presenceEnter1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             ARTRealtimeChannel * c2 =[_realtime2.channels get:channelName];
-            [c2.presence enter:presenceEnter2 cb:^(ARTErrorInfo *errorInfo) {
+            [c2.presence enter:presenceEnter2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 ARTRealtimeChannel * c3 =[_realtime3.channels get:channelName];
-                [c3.presence enter:presenceEnter3 cb:^(ARTErrorInfo *errorInfo) {
+                [c3.presence enter:presenceEnter3 callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                     [c1.presence history:[[ARTRealtimeHistoryQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);

--- a/Tests/ARTRealtimePresenceTest.m
+++ b/Tests/ARTRealtimePresenceTest.m
@@ -68,7 +68,7 @@
     if (!_realtime) {
         ARTClientOptions *options = [ARTTestUtil clientOptions];
         options.clientId = [self getClientId];
-        [ARTTestUtil setupApp:options cb:^(ARTClientOptions *options) {
+        [ARTTestUtil setupApp:options callback:^(ARTClientOptions *options) {
             if (options) {
                 _realtime = [[ARTRealtime alloc] initWithOptions:options];
                 _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -123,7 +123,7 @@
 
             waitForWithTimeout(&attached, @[channel, channel2], 20.0);
 
-            [channel2 publish:nil data:@"testStringEcho" cb:^(ARTErrorInfo *errorInfo) {
+            [channel2 publish:nil data:@"testStringEcho" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [expectation3 fulfill];
             }];
@@ -169,7 +169,7 @@
             [expectPresenceMessage fulfill];
 
         }];
-        [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
         [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
@@ -181,7 +181,7 @@
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
         XCTAssertEqual(channel.state, ARTRealtimeChannelInitialised);
-        [channel.presence enter:@"entered" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:@"entered" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             XCTAssertEqual(channel.state, ARTRealtimeChannelAttached);
             [exp fulfill];
@@ -213,7 +213,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence update:@"update"  cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence update:@"update"  callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
@@ -245,7 +245,7 @@
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached)
             {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -265,7 +265,7 @@
             
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence leave:presenceLeave cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:presenceLeave callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -283,7 +283,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -302,7 +302,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence enter:secondEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:secondEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -319,7 +319,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -339,7 +339,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence update:update cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -356,7 +356,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -375,7 +375,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence update:nil cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence update:nil callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -392,7 +392,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -411,7 +411,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -430,7 +430,7 @@
         }];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -460,7 +460,7 @@
         
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence update:update cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -475,16 +475,16 @@
     NSString * enter2 = @"enter2";
     NSString * channelName = @"channelName";
     XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         [options setClientId:[self getSecondClientId]];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
         ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-        [channel.presence enter:enter cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel2.presence enter:enter2 cb:^(ARTErrorInfo *errorInfo) {
+            [channel2.presence enter:enter2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
 
                 [channel2.presence get:^(ARTPaginatedResult *result, NSError *error) {
@@ -511,7 +511,7 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
-        [channel.presence enter:@"thisWillFail" cb:^(ARTErrorInfo *errorInfo){
+        [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo){
             XCTAssertNotNil(errorInfo);
             [exp fulfill];
         }];
@@ -528,7 +528,7 @@
                 [channel detach];
             }
             else if(channel.state == ARTRealtimeChannelDetached) {
-                [channel.presence enter:@"thisWillFail" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNotNil(errorInfo);
                     [expectation fulfill];
                 }];
@@ -548,7 +548,7 @@
                 [channel setFailed:[ARTStatus state:ARTStateError]];
             }
             else if(channel.state == ARTRealtimeChannelFailed) {
-                [channel.presence enter:@"thisWillFail" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNotNil(errorInfo);
                     [expectation fulfill];
                 }];
@@ -564,19 +564,19 @@
 -(void) testFilterPresenceByClientId {
     XCTestExpectation *exp = [self expectationWithDescription:@"testSingleSendEchoText"];
     NSString * channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence publishPresenceEnter:@"hi" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence publishPresenceEnter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             [options setClientId: [self getSecondClientId]];
             XCTAssertEqual(options.clientId, [self getSecondClientId]);
            _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
             ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            [channel2.presence publishPresenceEnter:@"hi2" cb:^(ARTErrorInfo *errorInfo) {
+            [channel2.presence publishPresenceEnter:@"hi2" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [channel2.presence getWithParams:@{@"client_id" : [self getSecondClientId]} cb:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
+                [channel2.presence getWithParams:@{@"client_id" : [self getSecondClientId]} callback:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
                     XCTAssertNil(errorInfo);
                     NSArray *messages = [result currentItems];
                     XCTAssertEqual(1, messages.count);
@@ -602,7 +602,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter)  {
                 XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:leave cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:leave callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertEqualObjects([message data], enter);
                     [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);
@@ -624,7 +624,7 @@
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached)
             {
-                [channel.presence enter:enter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -642,7 +642,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -661,7 +661,7 @@
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached)
             {
-                [channel.presence update:enter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence update:enter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }
@@ -680,7 +680,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter)  {
                 XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertEqualObjects([message data], enter);
                 }];
             }
@@ -689,7 +689,7 @@
                 [expectation fulfill];
             }
         }];
-        [channel.presence enter:enter cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
         [channel attach];
@@ -706,7 +706,7 @@
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
             if(message.action == ARTPresenceEnter)  {
                 XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:leave cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:leave callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertEqualObjects([message data], enter);
                 }];
             }
@@ -715,7 +715,7 @@
                 [expectation fulfill];
             }
         }];
-        [channel.presence enter:enter cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
         }];
         [channel attach];
@@ -732,7 +732,7 @@
                 [channel detach];
             }
             else if(channel.state == ARTRealtimeChannelDetached) {
-                XCTAssertThrows([channel.presence leave:@"thisWillFail" cb:^(ARTErrorInfo *errorInfo) {}]);
+                XCTAssertThrows([channel.presence leave:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {}]);
                 [expectation fulfill];
             }
         }];
@@ -750,7 +750,7 @@
                 [channel setFailed:[ARTStatus state:ARTStateError]];
             }
             else if(channel.state == ARTRealtimeChannelFailed) {
-                XCTAssertThrows([channel.presence leave:@"thisWillFail" cb:^(ARTErrorInfo *errorInfo) {}]);
+                XCTAssertThrows([channel.presence leave:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {}]);
                 [expectation fulfill];
             }
         }];
@@ -769,7 +769,7 @@
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                [channel.presence enter:presenceEnter cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNotNil(errorInfo);
                     [exp fulfill];
                 }];
@@ -813,9 +813,9 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
-        [channel.presence  enterClient:clientId data:nil cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence  enterClient:clientId data:nil callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence  enterClient:clientId2 data:nil cb:^(ARTErrorInfo *errorInfo) {
+            [channel.presence  enterClient:clientId2 data:nil callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
@@ -841,7 +841,7 @@
             ARTRealtimeConnectionState state = stateChange.current;
             if(state == ARTRealtimeConnected) {
                 [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                [channel.presence  enterClient:@"clientId" data:@"" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence  enterClient:@"clientId" data:@"" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNotNil(errorInfo);
                     [exp fulfill];
                 }];
@@ -856,15 +856,15 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"testWithNoClientIdUpdateLeaveEnterAnotherClient"];
     NSString * otherClientId = @"otherClientId";
     NSString * data = @"data";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = nil;
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:@"channelName"];
-        [channel.presence  enterClient:otherClientId data:@"" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence  enterClient:otherClientId data:@"" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence updateClient:otherClientId data:data cb:^(ARTErrorInfo *errorInfo) {
+            [channel.presence updateClient:otherClientId data:data callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [channel.presence leaveClient:otherClientId data:@"" cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leaveClient:otherClientId data:@"" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                 }];
             }];
@@ -914,13 +914,13 @@
             [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus * s) {
                 if (c == ARTRealtimeChannelAttached) {
                     //channel2 enters itself
-                    [channel2.presence enterClient:@"channel2Enter" data:@"joins" cb:^(ARTErrorInfo *errorInfo) {
+                    [channel2.presence enterClient:@"channel2Enter" data:@"joins" callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
 
                         [ARTTestUtil bigSleep];
 
                         //channel enters itself
-                        [channel.presence enter:@"hi" cb:^(ARTErrorInfo *errorInfo) {
+                        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
                             //channel enters 250 others
                             [ARTTestUtil publishEnterMessages:@"aClientId" count:count channel:channel completion:^{
@@ -952,13 +952,13 @@
 -(void) testPresenceMap {
     XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
     NSString * channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
         }];
-        [channel.presence enter:@"hi" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             [options setClientId: [self getSecondClientId]];
             XCTAssertEqual(options.clientId, [self getSecondClientId]);
@@ -989,19 +989,19 @@
 -(void) testPresenceMapWaitOnSync {
     XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
     NSString * channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
         [channel.presence subscribeToPresence:^(ARTPresenceMessage * message) {
         }];
-        [channel.presence publishPresenceEnter:@"hi" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence publishPresenceEnter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             [options setClientId: [self getSecondClientId]];
             XCTAssertEqual(options.clientId, [self getSecondClientId]);
             _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
             ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            [channel2.presence getWithParams:@{@"wait_for_sync": @"true"} cb:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
+            [channel2.presence getWithParams:@{@"wait_for_sync": @"true"} callback:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
                 XCTAssertNil(errorInfo);
                 ARTPresenceMap * map = channel2.presenceMap;
                 ARTPresenceMessage * m =[map getClient:[self getClientId]];
@@ -1021,16 +1021,16 @@
 -(void) testLeaveBeforeEnterThrows {
     XCTestExpectation *exp = [self expectationWithDescription:@"testLeaveBeforeEnterThrows"];
     NSString * channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        XCTAssertThrows([channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) {}]); // leave before enter
-        [channel.presence enter:nil cb:^(ARTErrorInfo *errorInfo) {
+        XCTAssertThrows([channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {}]); // leave before enter
+        [channel.presence enter:nil callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) { //leave after enter
+            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) { //leave after enter
                 XCTAssertNil(errorInfo);
-                XCTAssertThrows([channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) {}]); // leave after leave
+                XCTAssertThrows([channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {}]); // leave after leave
                 [exp fulfill];
             }];
         }];
@@ -1050,28 +1050,28 @@
         __block bool gotUpdate = false;
         __block bool gotEnter = false;
         __block bool gotLeave = false;
-        ARTEventListener *leaveSub = [channel.presence subscribe:ARTPresenceLeave cb:^(ARTPresenceMessage * message) {
+        ARTEventListener *leaveSub = [channel.presence subscribe:ARTPresenceLeave callback:^(ARTPresenceMessage * message) {
             XCTAssertEqualObjects([message data], leave1);
             gotLeave = true;
         }];
-        ARTEventListener *updateSub=[channel.presence subscribe:ARTPresenceUpdate cb:^(ARTPresenceMessage * message) {
+        ARTEventListener *updateSub=[channel.presence subscribe:ARTPresenceUpdate callback:^(ARTPresenceMessage * message) {
             XCTAssertEqualObjects([message data], update1);
             gotUpdate = true;
         }];
-        ARTEventListener *enterSub =[channel.presence subscribe:ARTPresenceEnter cb:^(ARTPresenceMessage * message) {
+        ARTEventListener *enterSub =[channel.presence subscribe:ARTPresenceEnter callback:^(ARTPresenceMessage * message) {
             XCTAssertEqualObjects([message data], enter1);
             gotEnter = true;
         }];
-        [channel.presence enter:enter1 cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:enter1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence update:update1 cb:^(ARTErrorInfo *errorInfo) {
+            [channel.presence update:update1 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [channel.presence unsubscribe:updateSub];
                 [channel.presence unsubscribe:enterSub];
-                [channel.presence update:@"noone will get this" cb:^(ARTErrorInfo *errorInfo) {
-                    [channel.presence leave:leave1 cb:^(ARTErrorInfo *errorInfo) {
+                [channel.presence update:@"noone will get this" callback:^(ARTErrorInfo *errorInfo) {
+                    [channel.presence leave:leave1 callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence enter:@"nor this" cb:^(ARTErrorInfo *errorInfo) {
+                        [channel.presence enter:@"nor this" callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
                             XCTAssertTrue(gotUpdate);
                             XCTAssertTrue(gotEnter);
@@ -1102,7 +1102,7 @@
         const int count = 120;
         
         //channel enters itself
-        [channel.presence enter:@"hi" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             //channel enters all others
             [ARTTestUtil publishEnterMessages:@"aClientId" count:count channel:channel completion:^{
@@ -1114,7 +1114,7 @@
                     [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus * s) {
                         if(c == ARTRealtimeChannelAttached) {
                             //channel2 enters itself
-                            [channel2.presence enterClient:@"channel2Enter" data:@"joins" cb:^(ARTErrorInfo *errorInfo) {
+                            [channel2.presence enterClient:@"channel2Enter" data:@"joins" callback:^(ARTErrorInfo *errorInfo) {
                                 XCTAssertNil(errorInfo);
                             }];
                         }
@@ -1158,22 +1158,22 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceNoSideEffects"];
     NSString * channelName = @"channelName";
     NSString * client1 = @"client1";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {}];
-        [channel.presence enter:@"hi" cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
 
             [ARTTestUtil testRealtime:^(ARTRealtime *realtime2) {
                 _realtime2 = realtime2;
                 ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-                [channel2.presence enterClient:client1 data:@"data" cb:^(ARTErrorInfo *errorInfo) {
+                [channel2.presence enterClient:client1 data:@"data" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
-                    [channel2.presence updateClient:client1 data:@"data2" cb:^(ARTErrorInfo *errorInfo) {
+                    [channel2.presence updateClient:client1 data:@"data2" callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel2.presence leaveClient:client1 data:@"data3" cb:^(ARTErrorInfo *errorInfo) {
+                        [channel2.presence leaveClient:client1 data:@"data3" callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
                             [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
                                 XCTAssert(!error);
@@ -1198,12 +1198,12 @@
 -(void) testPresenceWithData {
     XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceWithData"];
     NSString * channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
         NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-        [channel.presence enter:dataPayload cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:dataPayload callback:^(ARTErrorInfo *errorInfo) {
              XCTAssertNil(errorInfo);
             [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
                 XCTAssert(!error);
@@ -1225,7 +1225,7 @@
     XCTestExpectation *exp2 = [self expectationWithDescription:@"testPresenceWithDataOnLeave2"];
     NSString * channelName = @"channelName";
     NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
@@ -1262,9 +1262,9 @@
         waitForWithTimeout(&attached, @[channel, channel2], 20.0);
 
         // Presence
-        [channel.presence enter:dataPayload cb:^(ARTErrorInfo *errorInfo) {
+        [channel.presence enter:dataPayload callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence leave:@"" cb:^(ARTErrorInfo *errorInfo) {
+            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [exp2 fulfill];
             }];

--- a/Tests/ARTRealtimeRecoverTest.m
+++ b/Tests/ARTRealtimeRecoverTest.m
@@ -44,7 +44,7 @@
 
 - (void)withRealtime:(void (^)(ARTRealtime *realtime))cb {
     if (!_realtime) {
-        [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+        [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
             _options = options;
             _realtime = [[ARTRealtime alloc] initWithOptions:options];
             cb(_realtime);
@@ -55,7 +55,7 @@
     }
 }
 
-- (void)withRealtimeRecover:(NSString *) recover cb:(void (^)(ARTRealtime *realtime))cb {
+- (void)withRealtimeRecover:(NSString *) recover callback:(void (^)(ARTRealtime *realtime))cb {
     _options.recover = recover;
     _realtimeRecover = [[ARTRealtime alloc] initWithOptions:_options];
     cb(_realtimeRecover);
@@ -67,7 +67,7 @@
     NSString * c2Message= @"c2 says hi";
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
 
         __block NSString *firstConnectionId = nil;
@@ -78,7 +78,7 @@
 
                 ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
                 // Sending a message
-                [channel publish:nil data:c1Message cb:^(ARTErrorInfo *errorInfo) {
+                [channel publish:nil data:c1Message callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                     [_realtime onDisconnected];
                 }];
@@ -92,7 +92,7 @@
                     ARTRealtimeConnectionState state2 = stateChange.current;
                     if (state2 == ARTRealtimeConnected) {
                         // Sending other message to the same channel to check if the recovered connection receives it
-                        [c2 publish:nil data:c2Message cb:^(ARTErrorInfo *errorInfo) {
+                        [c2 publish:nil data:c2Message callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
 
                             options.recover = _realtime.connection.recoveryKey;
@@ -121,7 +121,7 @@
 
 - (void)testRecoverFails {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.recover = @"bad_recovery_key:1234";
         _realtimeRecover = [[ARTRealtime alloc] initWithOptions:options];
         [_realtimeRecover.connection on:^(ARTConnectionStateChange *stateChange) {

--- a/Tests/ARTRealtimeResumeTest.m
+++ b/Tests/ARTRealtimeResumeTest.m
@@ -55,7 +55,7 @@
     NSString * message2 = @"message2";
     NSString * message3 = @"message3";
     NSString * message4 = @"message4";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         
@@ -69,8 +69,8 @@
         [channel2 on:^(ARTErrorInfo *errorInfo) {
             //both channels are attached. lets get to work.
             if(channel2.state == ARTRealtimeChannelAttached) {
-                [channel2 publish:nil data:message1 cb:^(ARTErrorInfo *errorInfo) {
-                    [channel2 publish:nil data:message2 cb:^(ARTErrorInfo *errorInfo) {
+                [channel2 publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
+                    [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
                     }];
                 }];
@@ -81,8 +81,8 @@
             if([msg isEqualToString:message2]) {
                 //disconnect connection1
                 [_realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                [channel2 publish:nil data:message3 cb:^(ARTErrorInfo *errorInfo) {
-                    [channel2 publish:nil data:message4 cb:^(ARTErrorInfo *errorInfo) {
+                [channel2 publish:nil data:message3 callback:^(ARTErrorInfo *errorInfo) {
+                    [channel2 publish:nil data:message4 callback:^(ARTErrorInfo *errorInfo) {
                         [_realtime connect];
                     }];
                 }];

--- a/Tests/ARTRestCapabilityTest.m
+++ b/Tests/ARTRestCapabilityTest.m
@@ -41,7 +41,7 @@
 - (void)withRestRestrictCap:(void (^)(ARTRest *rest))cb {
     if (!_rest) {
         ARTClientOptions * theOptions = [ARTTestUtil clientOptions];
-        [ARTTestUtil setupApp:theOptions withAlteration:TestAlterationRestrictCapability cb:^(ARTClientOptions *options) {
+        [ARTTestUtil setupApp:theOptions withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
             if (options) {
                 options.clientId = @"client_string";
                 
@@ -69,11 +69,11 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
     [self withRestRestrictCap:^(ARTRest * rest) {
         ARTRestChannel *channel = [rest.channels get:@"canpublish:test"];
-        [channel publish:nil data:@"publish" cb:^(ARTErrorInfo *error) {
+        [channel publish:nil data:@"publish" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             NSLog(@"%@", error);
             ARTRestChannel *channel2 = [rest.channels get:@"cannotPublishToThisChannelName"];
-            [channel2 publish:nil data:@"publish" cb:^(ARTErrorInfo *error) {
+            [channel2 publish:nil data:@"publish" callback:^(ARTErrorInfo *error) {
                 XCTAssert(error);
                 NSLog(@"%@", error);
                 [expectation fulfill];

--- a/Tests/ARTRestChannelHistoryTest.m
+++ b/Tests/ARTRestChannelHistoryTest.m
@@ -348,7 +348,7 @@
 
     NSString *channelName = @"testHistoryTwoClients";
     XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
         ARTRest *rest2 = [[ARTRest alloc] initWithOptions:options];

--- a/Tests/ARTRestChannelPublishTest.m
+++ b/Tests/ARTRestChannelPublishTest.m
@@ -43,9 +43,9 @@
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testTypesByText"];
-        [channel publish:nil data:message1 cb:^(ARTErrorInfo *error) {
+        [channel publish:nil data:message1 callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
-            [channel publish:nil data:message2 cb:^(ARTErrorInfo *error) {
+            [channel publish:nil data:message2 callback:^(ARTErrorInfo *error) {
                 XCTAssert(!error);
                 ARTDataQuery *query = [[ARTDataQuery alloc] init];
                 query.direction = ARTQueryDirectionForwards;
@@ -78,7 +78,7 @@
                               [[ARTMessage alloc] initWithName:nil data:test2],
                               [[ARTMessage alloc] initWithName:nil data:test3]];
 
-        [channel publish:messages cb:^(ARTErrorInfo *error) {
+        [channel publish:messages callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [channel history:^(ARTPaginatedResult *result, NSError *error) {
                 XCTAssert(!error);
@@ -102,7 +102,7 @@
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testTypesByText"];
-        XCTAssertThrows([channel publish:nil data:channel cb:^(ARTErrorInfo *error){}]);
+        XCTAssertThrows([channel publish:nil data:channel callback:^(ARTErrorInfo *error){}]);
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];

--- a/Tests/ARTRestCryptoTest.m
+++ b/Tests/ARTRestCryptoTest.m
@@ -45,9 +45,9 @@
         XCTAssert(c);
         NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
         NSString * stringPayload = @"someString";
-        [c publish:nil data:dataPayload cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
-            [c publish:nil data:stringPayload cb:^(ARTErrorInfo *error) {
+            [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
                 XCTAssert(!error);
                 [c history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
@@ -81,9 +81,9 @@
         XCTAssert(c);
         NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
         NSString * stringPayload = @"someString";
-        [c publish:nil data:dataPayload cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
-            [c publish:nil data:stringPayload cb:^(ARTErrorInfo *error) {
+            [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
                 XCTAssert(!error);
                 [c history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);

--- a/Tests/ARTRestInitTest.m
+++ b/Tests/ARTRestInitTest.m
@@ -51,14 +51,14 @@
 
 -(void)testInitWithKey {
     XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKey"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         @try {
             [ARTClientOptions setDefaultEnvironment:@"sandbox"];
             ARTRest *rest = [[ARTRest alloc] initWithKey:options.key];
             _rest = rest;
             ARTChannel *c = [rest.channels get:@"test"];
             XCTAssert(c);
-            [c publish:nil data:@"message" cb:^(ARTErrorInfo *error) {
+            [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
                 XCTAssertNil(error);
                 [exp fulfill];
             }];
@@ -83,7 +83,7 @@
         _rest = rest;
         ARTChannel * c = [rest.channels get:@"test"];
         XCTAssert(c);
-        [c publish:nil data:@"message" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
             XCTAssert(error);
             XCTAssertEqual(40005, error.code); //invalid credential
             [exp fulfill];
@@ -97,12 +97,12 @@
 
 -(void)testInitWithOptions {
     XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
        ARTChannel * c = [rest.channels get:@"test"];
        XCTAssert(c);
-       [c publish:nil data:@"message" cb:^(ARTErrorInfo *error) {
+       [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
            XCTAssert(!error);
            [exp fulfill];
        }];
@@ -112,14 +112,14 @@
 
 -(void)testInitWithOptionsEnvironment {
     XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTClientOptions *envOptions = [[ARTClientOptions alloc] init];
         envOptions.key = options.key;
         envOptions.environment = @"sandbox";
         ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
         ARTChannel * c = [rest.channels get:@"test"];
-        [c publish:nil data:@"message" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [exp fulfill];
         }];
@@ -129,12 +129,12 @@
 
 -(void)testGetAuth {
     XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
         ARTChannel * c = [rest.channels get:@"test"];
         XCTAssert(c);
-        [c publish:nil data:@"message" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             ARTAuth * auth = rest.auth;
             XCTAssert(auth);

--- a/Tests/ARTRestTokenTest.m
+++ b/Tests/ARTRestTokenTest.m
@@ -42,7 +42,7 @@
 
 - (void)testTokenSimple {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testRestTimeBadHost"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
         ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
@@ -50,7 +50,7 @@
         ARTAuth * auth = rest.auth;
         XCTAssertEqual(auth.method, ARTAuthMethodToken);
         ARTRestChannel *c = [rest.channels get:@"getChannel"];
-        [c publish:nil data:@"something" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [expectation fulfill];
         }];
@@ -60,7 +60,7 @@
 
 - (void)testInitWithBadToken {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
         options.token = @"this_is_a_bad_token";
@@ -69,7 +69,7 @@
         ARTAuth * auth = rest.auth;
         XCTAssertEqual(auth.method, ARTAuthMethodToken);
         ARTChannel * c= [rest.channels get:@"getChannel"];
-        [c publish:nil data:@"something" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
             XCTAssert(error);
             [expectation fulfill];
         }];
@@ -79,7 +79,7 @@
 
 -(void)testAuthURLForcesToken {
     XCTestExpectation *exp = [self expectationWithDescription:@"testClientIdForcesToken"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.authUrl = [NSURL URLWithString:@"some_url"];
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
@@ -92,13 +92,13 @@
 
 -(void)testTTLDefaultOneHour {
     XCTestExpectation *exp = [self expectationWithDescription:@"testTTLDefaultOneHour"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = @"clientIdThatForcesToken";
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
         ARTAuth *auth = rest.auth;
         ARTChannel *c = [rest.channels get:@"getChannel"];
-        [c publish:nil data:@"invokeTokenRequest" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"invokeTokenRequest" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             NSTimeInterval secs = [auth.tokenDetails.expires timeIntervalSinceDate:auth.tokenDetails.issued];
             XCTAssertEqual(secs, 3600);
@@ -110,7 +110,7 @@
 
 - (void)testInitWithBorrowedAuthCb {
     XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
         ARTRest * firstRest = [[ARTRest alloc] initWithOptions:options];
@@ -121,7 +121,7 @@
         _rest2 = secondRest;
         XCTAssertEqual(auth.method, ARTAuthMethodToken);
         ARTChannel *c = [secondRest.channels get:@"getChannel"];
-        [c publish:nil data:@"something" cb:^(ARTErrorInfo *error) {
+        [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [expectation fulfill];
         }];

--- a/Tests/ARTTestUtil.h
+++ b/Tests/ARTTestUtil.h
@@ -35,10 +35,10 @@ typedef NS_ENUM(NSUInteger, TestAlteration) {
 + (ARTCipherDataEncoder *)getTestCipherEncoder;
 
 // FIXME: why is `setupApp` using a callback? hard reading... could be a blocking method (only once per test)
-+ (void)setupApp:(ARTClientOptions *)options cb:(void(^)(ARTClientOptions *options))cb;
-+ (void)setupApp:(ARTClientOptions *)options withAlteration:(TestAlteration) alt cb:(void (^)(ARTClientOptions *))cb;
-+ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug cb:(void (^)(ARTClientOptions *))cb;
-+ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration) alt cb:(void (^)(ARTClientOptions *))cb;
++ (void)setupApp:(ARTClientOptions *)options callback:(void(^)(ARTClientOptions *options))cb;
++ (void)setupApp:(ARTClientOptions *)options withAlteration:(TestAlteration) alt callback:(void (^)(ARTClientOptions *))cb;
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug callback:(void (^)(ARTClientOptions *))cb;
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration) alt callback:(void (^)(ARTClientOptions *))cb;
 + (float)timeout;
 
 + (ARTClientOptions *)clientOptions;

--- a/Tests/ARTTestUtil.m
+++ b/Tests/ARTTestUtil.m
@@ -45,7 +45,7 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
     return [ARTTestUtil getFileByName:@"ably-common/test-resources/test-app-setup.json"];
 }
 
-+ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration)alt  appId:(NSString *)appId cb:(void (^)(ARTClientOptions *))cb {
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration)alt  appId:(NSString *)appId callback:(void (^)(ARTClientOptions *))cb {
     NSString *str = [ARTTestUtil getTestAppSetupJson];
     if (str == nil) {
         [NSException raise:@"error getting test-app-setup.json loaded. Maybe ably-common is missing" format:@""];
@@ -118,20 +118,20 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
     }];
 }
 
-+ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration)alt cb:(void (^)(ARTClientOptions *))cb {
-    [ARTTestUtil setupApp:options withDebug:debug withAlteration:alt appId:nil cb:cb];
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug withAlteration:(TestAlteration)alt callback:(void (^)(ARTClientOptions *))cb {
+    [ARTTestUtil setupApp:options withDebug:debug withAlteration:alt appId:nil callback:cb];
 }
 
-+ (void)setupApp:(ARTClientOptions *)options withAlteration:(TestAlteration)alt cb:(void (^)(ARTClientOptions *))cb {
-    [ARTTestUtil setupApp:options withDebug:NO withAlteration:alt cb:cb];
++ (void)setupApp:(ARTClientOptions *)options withAlteration:(TestAlteration)alt callback:(void (^)(ARTClientOptions *))cb {
+    [ARTTestUtil setupApp:options withDebug:NO withAlteration:alt callback:cb];
 }
 
-+ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug cb:(void (^)(ARTClientOptions *))cb {
-    [ARTTestUtil setupApp:options withDebug:debug withAlteration:TestAlterationNone cb:cb];
++ (void)setupApp:(ARTClientOptions *)options withDebug:(BOOL)debug callback:(void (^)(ARTClientOptions *))cb {
+    [ARTTestUtil setupApp:options withDebug:debug withAlteration:TestAlterationNone callback:cb];
 }
 
-+ (void)setupApp:(ARTClientOptions *)options cb:(void (^)(ARTClientOptions *))cb {
-    [ARTTestUtil setupApp:options withDebug:NO withAlteration:TestAlterationNone cb:cb];
++ (void)setupApp:(ARTClientOptions *)options callback:(void (^)(ARTClientOptions *))cb {
+    [ARTTestUtil setupApp:options withDebug:NO withAlteration:TestAlterationNone callback:cb];
 }
 
 + (ARTClientOptions *)clientOptions {
@@ -180,14 +180,14 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
 
     weakCallback = callback = ^(ARTErrorInfo *error) {
         if (++numReceived != count) {
-            [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] cb:weakCallback];
+            [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] callback:weakCallback];
         }
         else {
             completion();
         }
     };
 
-    [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] cb:callback];
+    [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] callback:callback];
 }
 
 + (void)publishRealtimeMessages:(NSString *)prefix count:(int)count channel:(ARTRealtimeChannel *)channel completion:(void (^)())completion {
@@ -199,13 +199,13 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
     weakCb = cb = ^(ARTErrorInfo *errorInfo) {
         ++numReceived;
         if(numReceived !=count) {
-            [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] cb:weakCb];
+            [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] callback:weakCb];
         }
         else {
             completion();
         }
     };
-    [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] cb:cb];
+    [channel publish:nil data:[NSString stringWithFormat:pattern, numReceived] callback:cb];
     
 }
 
@@ -218,31 +218,31 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
     weakCb = cb = ^(ARTErrorInfo *errorInfo) {
         ++numReceived;
         if (numReceived != count) {
-            [channel.presence enterClient:[NSString stringWithFormat:pattern, numReceived] data:@"entered" cb:weakCb];
+            [channel.presence enterClient:[NSString stringWithFormat:pattern, numReceived] data:@"entered" callback:weakCb];
         }
         else {
             completion();
         }
     };
-    [channel.presence enterClient:[NSString stringWithFormat:pattern, numReceived] data:@"" cb:weakCb];
+    [channel.presence enterClient:[NSString stringWithFormat:pattern, numReceived] data:@"" callback:weakCb];
 }
 
 + (void)testRest:(ARTRestConstructorCb)cb {
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         cb(rest);
     }];
 }
 
 + (void)testRealtime:(ARTClientOptions *)options callback:(ARTRealtimeConstructorCb)cb {
-    [ARTTestUtil setupApp:options cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:options callback:^(ARTClientOptions *options) {
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         cb(realtime);
     }];
 }
 
 + (void)testRealtime:(ARTRealtimeConstructorCb)cb {
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         cb(realtime);
     }];
@@ -250,7 +250,7 @@ void waitForWithTimeout(NSUInteger *counter, NSArray *list, NSTimeInterval timeo
 
 + (void)testRealtimeV2:(XCTestCase *)testCase withDebug:(BOOL)debug callback:(ARTRealtimeTestCallback)callback {
     XCTestExpectation *expectation = [testCase expectationWithDescription:@"testRealtime"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug cb:^(ARTClientOptions *options) {
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug callback:^(ARTClientOptions *options) {
         ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;


### PR DESCRIPTION
We were using both, inconsistently. `callback:` is longer, but
clearer, plus that's considered a good thing in iOS.