### PR TITLE
Remove block typedefs, use block syntax explicitly.

### DIFF
--- a/Source/ARTAuth.h
+++ b/Source/ARTAuth.h
@@ -42,9 +42,9 @@ ART_ASSUME_NONNULL_BEGIN
  - Parameter callback: Completion callback (ARTTokenDetails, NSError).
  */
 - (void)requestToken:(art_nullable ARTTokenParams *)tokenParams withOptions:(art_nullable ARTAuthOptions *)authOptions
-            callback:(ARTTokenCallback)callback;
+            callback:(void (^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable))callback;
 
-- (void)authorise:(art_nullable ARTTokenParams *)tokenParams options:(art_nullable ARTAuthOptions *)authOptions callback:(ARTTokenCallback)callback;
+- (void)authorise:(art_nullable ARTTokenParams *)tokenParams options:(art_nullable ARTAuthOptions *)authOptions callback:(void (^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable))callback;
 
 - (void)createTokenRequest:(art_nullable ARTTokenParams *)tokenParams options:(art_nullable ARTAuthOptions *)options
                   callback:(void (^)(ARTTokenRequest *__art_nullable tokenRequest, NSError *__art_nullable error))callback;

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -168,7 +168,7 @@
             }
         }];
     } else {
-        ARTAuthCallback tokenRequestFactory = mergedOptions.authCallback? : ^(ARTTokenParams *tokenParams, void(^callback)(ARTTokenDetails *tokenDetails, NSError *error)) {
+        void (^tokenRequestFactory)(ARTTokenParams *, void(^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable)) = mergedOptions.authCallback? : ^(ARTTokenParams *tokenParams, void(^callback)(ARTTokenDetails *tokenDetails, NSError *error)) {
             // Create a TokenRequest and execute it
             [self createTokenRequest:currentTokenParams options:mergedOptions callback:^(ARTTokenRequest *tokenRequest, NSError *error) {
                 if (error) {

--- a/Source/ARTAuthOptions.h
+++ b/Source/ARTAuthOptions.h
@@ -35,7 +35,7 @@ ART_ASSUME_NONNULL_BEGIN
  
  This enables a client to obtain token requests from another entity, so tokens can be renewed without the client requiring access to keys.
  */
-@property (nonatomic, copy, art_nullable) ARTAuthCallback authCallback;
+@property (nonatomic, copy, art_nullable) void (^authCallback)(ARTTokenParams *, void(^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable));
 
 /**
  A URL to queryto obtain a signed token request.

--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -39,7 +39,7 @@
     [_realtime close];
 }
 
-- (void)ping:(ARTRealtimePingCb)cb {
+- (void)ping:(void (^)(ARTErrorInfo *))cb {
     [_realtime ping:cb];
 }
 

--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -18,7 +18,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) ARTLog *logger;
 
-- (void)executeRequest:(NSMutableURLRequest *)request completion:(art_nullable ARTHttpRequestCallback)callback;
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(art_nullable void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback;
 
 @end
 

--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -62,7 +62,8 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init;
 
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body callback:(ARTHttpCb)cb;
+- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body callback:(void (^)(ARTHttpResponse *))cb;
+
 
 @end
 

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -168,7 +168,7 @@
     return self;
 }
 
-- (void)executeRequest:(NSMutableURLRequest *)request completion:(ARTHttpRequestCallback)callback {
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     [self.logger debug:@"%@ %@", request.HTTPMethod, request.URL.absoluteString];
     [self.logger verbose:@"Headers %@", request.allHTTPHeaderFields];
 

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -194,7 +194,7 @@
     }];
 }
 
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body callback:(ARTHttpCb)cb {
+- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body callback:(void (^)(ARTHttpResponse *))cb {
     return [self makeRequest:[[ARTHttpRequest alloc] initWithMethod:method url:url headers:headers body:body] callback:cb];
 }
 

--- a/Source/ARTPaginatedResult+Private.h
+++ b/Source/ARTPaginatedResult+Private.h
@@ -18,7 +18,7 @@ typedef __GENERIC(NSArray, ItemType) *__art_nullable(^ARTPaginatedResultResponse
 
 + (void)executePaginated:(ARTRest *)rest withRequest:(NSMutableURLRequest *)request
               andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor
-                       callback:(ARTPaginatedResultCallback)callback;
+                       callback:(void (^)(__GENERIC(ARTPaginatedResult, ItemType) *__art_nullable result, NSError *__art_nullable error))callback;
 
 @end
 

--- a/Source/ARTPaginatedResult.h
+++ b/Source/ARTPaginatedResult.h
@@ -14,17 +14,14 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface __GENERIC(ARTPaginatedResult, ItemType) : NSObject
 
-// FIXME: review with Stats callback
-typedef void(^ARTPaginatedResultCallback)(__GENERIC(ARTPaginatedResult, ItemType) *__art_nullable result, NSError *__art_nullable error);
-
 @property (nonatomic, strong, readonly) __GENERIC(NSArray, ItemType) *items;
 @property (nonatomic, readonly) BOOL hasNext;
 @property (nonatomic, readonly) BOOL isLast;
 
 - (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
-- (void)first:(ARTPaginatedResultCallback)callback;
-- (void)next:(ARTPaginatedResultCallback)callback;
+- (void)first:(void (^)(__GENERIC(ARTPaginatedResult, ItemType) *__art_nullable result, NSError *__art_nullable error))callback;
+- (void)next:(void (^)(__GENERIC(ARTPaginatedResult, ItemType) *__art_nullable result, NSError *__art_nullable error))callback;
 
 @end
 

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -44,11 +44,11 @@
     return self;
 }
 
-- (void)first:(ARTPaginatedResultCallback)callback {
+- (void)first:(void (^)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, NSError *__art_nullable error))callback {
     [self.class executePaginated:_rest withRequest:_relFirst andResponseProcessor:_responseProcessor callback:callback];
 }
 
-- (void)next:(ARTPaginatedResultCallback)callback {
+- (void)next:(void (^)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, NSError *__art_nullable error))callback {
     if (!_relNext) {
         // If there is no next page, we can't make a request, so we answer the callback
         // with a nil PaginatedResult. That's why the callback has the result as nullable
@@ -99,7 +99,7 @@ static NSMutableURLRequest *requestRelativeTo(NSMutableURLRequest *request, NSSt
     return [NSMutableURLRequest requestWithURL:url];
 }
 
-+ (void)executePaginated:(ARTRest *)rest withRequest:(NSMutableURLRequest *)request andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor callback:(ARTPaginatedResultCallback)callback {
++ (void)executePaginated:(ARTRest *)rest withRequest:(NSMutableURLRequest *)request andResponseProcessor:(ARTPaginatedResultResponseProcessor)responseProcessor callback:(void (^)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, NSError *__art_nullable error))callback {
     [rest.logger debug:__FILE__ line:__LINE__ message:@"Paginated request: %@", request];
 
     [rest executeRequest:request withAuthOption:ARTAuthenticationOn completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {

--- a/Source/ARTQueuedMessage.h
+++ b/Source/ARTQueuedMessage.h
@@ -16,9 +16,9 @@
 @property (readonly, strong, nonatomic) ARTProtocolMessage *msg;
 @property (readonly, strong, nonatomic) NSMutableArray *cbs;
 
-- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb;
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb;
+- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg callback:(void (^)(ARTStatus *))cb;
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg callback:(void (^)(ARTStatus *))cb;
 
-- (ARTStatusCallback)cb;
+- (void (^)(ARTStatus *))cb;
 
 @end

--- a/Source/ARTQueuedMessage.m
+++ b/Source/ARTQueuedMessage.m
@@ -13,7 +13,7 @@
 
 @implementation ARTQueuedMessage
 
-- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
+- (instancetype)initWithProtocolMessage:(ARTProtocolMessage *)msg callback:(void (^)(ARTStatus *))cb {
     self = [super init];
     if (self) {
         _msg = msg;
@@ -25,7 +25,7 @@
     return self;
 }
 
-- (BOOL)mergeFrom:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
+- (BOOL)mergeFrom:(ARTProtocolMessage *)msg callback:(void (^)(ARTStatus *))cb {
     if ([self.msg mergeFrom:msg]) {
         if (cb) {
             [self.cbs addObject:cb];
@@ -35,9 +35,9 @@
     return NO;
 }
 
-- (ARTStatusCallback)cb {
+- (void (^)(ARTStatus *))cb {
     return ^(ARTStatus * status) {
-        for (ARTStatusCallback cb in self.cbs) {
+        for (void (^cb)(ARTStatus *) in self.cbs) {
             cb(status);
         }
     };

--- a/Source/ARTRealtime+Private.h
+++ b/Source/ARTRealtime+Private.h
@@ -81,7 +81,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)resetEventEmitter;
 
 // Message sending
-- (void)send:(ARTProtocolMessage *)msg callback:(art_nullable ARTStatusCallback)cb;
+- (void)send:(ARTProtocolMessage *)msg callback:(art_nullable void (^)(ARTStatus *))cb;
 
 - (CFRunLoopTimerRef)startTimer:(void(^)())onTimeout interval:(NSTimeInterval)interval;
 - (void)cancelTimer:(CFRunLoopTimerRef)timer;

--- a/Source/ARTRealtime+Private.h
+++ b/Source/ARTRealtime+Private.h
@@ -54,14 +54,14 @@ ART_ASSUME_NONNULL_BEGIN
 /// Client is trying to resume the last connection
 @property (readwrite, assign, nonatomic) BOOL resuming;
 
-@property (nonatomic, copy, art_nullable) ARTRealtimePingCb pingCb;
+@property (nonatomic, copy, art_nullable) void (^pingCb)(ARTErrorInfo *__art_nullable);
 @property (readonly, getter=getClientOptions) ARTClientOptions *options;
 
 @end
 
 @interface ARTRealtime (Private)
 
-- (void)ping:(ARTRealtimePingCb)cb;
+- (void)ping:(void (^)(ARTErrorInfo *))cb;
 - (BOOL)isActive;
 
 // Transport Events

--- a/Source/ARTRealtime.h
+++ b/Source/ARTRealtime.h
@@ -60,8 +60,8 @@ Instance the Ably library with the given options.
 
 - (void)time:(ARTTimeCallback)cb;
 
-- (BOOL)stats:(ARTStatsCallback)callback;
-- (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(ARTStatsCallback)callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
+- (BOOL)stats:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback;
+- (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 - (void)connect;
 - (void)close;

--- a/Source/ARTRealtime.h
+++ b/Source/ARTRealtime.h
@@ -58,7 +58,7 @@ Instance the Ably library with the given options.
 */
 - (instancetype)initWithOptions:(ARTClientOptions *)options;
 
-- (void)time:(ARTTimeCallback)cb;
+- (void)time:(void (^)(NSDate *__art_nullable, NSError *__art_nullable))cb;
 
 - (BOOL)stats:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback;
 - (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -173,7 +173,7 @@
     [self.transport sendPing];
 }
 
-- (BOOL)stats:(ARTStatsCallback)callback {
+- (BOOL)stats:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback {
     return [self stats:[[ARTStatsQuery alloc] init] callback:callback error:nil];
 }
 

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -560,8 +560,7 @@
     return [self shouldQueueEvents] || [self shouldSendEvents];
 }
 
-- (void)sendImpl:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
-
+- (void)sendImpl:(ARTProtocolMessage *)msg callback:(void (^)(ARTStatus *))cb {
     if (msg.ackRequired) {
         msg.msgSerial = self.msgSerial++;
         ARTQueuedMessage *qm = [[ARTQueuedMessage alloc] initWithProtocolMessage:msg callback:cb];
@@ -572,7 +571,7 @@
     [self.transport send:msg];
 }
 
-- (void)send:(ARTProtocolMessage *)msg callback:(ARTStatusCallback)cb {
+- (void)send:(ARTProtocolMessage *)msg callback:(void (^)(ARTStatus *))cb {
     if ([self shouldSendEvents]) {
         [self sendImpl:msg callback:cb];
     } else if ([self shouldQueueEvents]) {

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -164,7 +164,7 @@
     [self.rest time:cb];
 }
 
-- (void)ping:(ARTRealtimePingCb) cb {
+- (void)ping:(void (^)(ARTErrorInfo *)) cb {
     if(self.connection.state == ARTRealtimeClosed || self.connection.state == ARTRealtimeFailed) {
         [NSException raise:@"Can't ping a closed or failed connection" format:@"%@:", [ARTRealtime ARTRealtimeStateToStr:self.connection.state]];
     }

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -39,7 +39,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (void)onChannelMessage:(ARTProtocolMessage *)message;
 - (void)publishPresence:(ARTPresenceMessage *)pm callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable))cb;
-- (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb;
+- (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(void (^)(ARTStatus *))cb;
 
 - (void)setAttached:(ARTProtocolMessage *)message;
 - (void)setDetached:(ARTProtocolMessage *)message;

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -126,7 +126,7 @@
     }];
 }
 
-- (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb {
+- (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(void (^)(ARTStatus *))cb {
     switch (self.state) {
         case ARTRealtimeChannelInitialised:
             [self attach];
@@ -157,8 +157,7 @@
     }
 }
 
-
-- (void)sendMessage:(ARTProtocolMessage *)pm callback:(ARTStatusCallback)cb {
+- (void)sendMessage:(ARTProtocolMessage *)pm callback:(void (^)(ARTStatus *))cb {
     __block BOOL gotFailure = false;
     NSString *oldConnectionId = self.realtime.connection.id;
     __block ARTEventListener *listener = [self.realtime.connection on:^(ARTConnectionStateChange *stateChange) {

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -36,11 +36,11 @@ ART_ASSUME_NONNULL_BEGIN
 
 // MARK: ARTHTTPExecutor
 
-- (void)executeRequest:(NSMutableURLRequest *)request completion:(ARTHttpRequestCallback)callback;
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback;
 
 // MARK: Internal
 
-- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(ARTHttpRequestCallback)callback;
+- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback;
 
 - (void)calculateAuthorization:(ARTAuthMethod)method completion:(void (^)(NSString *__art_nonnull authorization, NSError *__art_nullable error))callback;
 

--- a/Source/ARTRest.h
+++ b/Source/ARTRest.h
@@ -30,8 +30,8 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (void)time:(ARTTimeCallback)callback;
 
-- (BOOL)stats:(ARTStatsCallback)callback;
-- (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(ARTStatsCallback)callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
+- (BOOL)stats:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback;
+- (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;
 
 @property (nonatomic, strong, readonly) ARTRestChannels *channels;
 @property (nonatomic, strong, readonly) ARTAuth *auth;

--- a/Source/ARTRest.h
+++ b/Source/ARTRest.h
@@ -28,7 +28,7 @@ ART_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithKey:(NSString *)key;
 - (instancetype)initWithToken:(NSString *)tokenId;
 
-- (void)time:(ARTTimeCallback)callback;
+- (void)time:(void (^)(NSDate *__art_nullable, NSError *__art_nullable))callback;
 
 - (BOOL)stats:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback;
 - (BOOL)stats:(art_nullable ARTStatsQuery *)query callback:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback error:(NSError *__art_nullable *__art_nullable)errorPtr;

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -81,7 +81,7 @@
     [self.logger debug:__FILE__ line:__LINE__ message:@"%p dealloc", self];
 }
 
-- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(ARTHttpRequestCallback)callback {
+- (void)executeRequest:(NSMutableURLRequest *)request withAuthOption:(ARTAuthentication)authOption completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     request.URL = [NSURL URLWithString:request.URL.relativeString relativeToURL:self.baseUrl];
     
     NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
@@ -103,11 +103,11 @@
     }
 }
 
-- (void)executeRequestWithAuthentication:(NSMutableURLRequest *)request withMethod:(ARTAuthMethod)method completion:(ARTHttpRequestCallback)callback {
+- (void)executeRequestWithAuthentication:(NSMutableURLRequest *)request withMethod:(ARTAuthMethod)method completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     [self executeRequestWithAuthentication:request withMethod:method force:NO completion:callback];
 }
 
-- (void)executeRequestWithAuthentication:(NSMutableURLRequest *)request withMethod:(ARTAuthMethod)method force:(BOOL)force completion:(ARTHttpRequestCallback)callback {
+- (void)executeRequestWithAuthentication:(NSMutableURLRequest *)request withMethod:(ARTAuthMethod)method force:(BOOL)force completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     [self calculateAuthorization:method force:force completion:^(NSString *authorization, NSError *error) {
         if (error && callback) {
             callback(nil, nil, error);
@@ -119,7 +119,7 @@
     }];
 }
 
-- (void)executeRequest:(NSMutableURLRequest *)request completion:(ARTHttpRequestCallback)callback {
+- (void)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     [self.logger debug:__FILE__ line:__LINE__ message:@"%p executing request %@", self, request];
     [self.httpExecutor executeRequest:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (response.statusCode >= 400) {

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -194,7 +194,7 @@
     return nil;
 }
 
-- (BOOL)stats:(ARTStatsCallback)callback {
+- (BOOL)stats:(void (^)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable, NSError *__art_nullable))callback {
     return [self stats:[[ARTStatsQuery alloc] init] callback:callback error:nil];
 }
 

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTStatusCallback)(ARTStatus *status);
-
 typedef void (^ARTHttpCb)(ARTHttpResponse *response);
 
 typedef void (^ARTHttpRequestCallback)(NSHTTPURLResponse *__art_nullable response, NSData *__art_nullable data, NSError *__art_nullable error);

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTStatsCallback)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable result, NSError *__art_nullable error);
-
 typedef void (^ARTTimeCallback)(NSDate *__art_nullable time, NSError *__art_nullable error);
 
 typedef void (^ARTAuthCallback)(ARTTokenParams *tokenParams, void(^callback)(ARTTokenDetails *__art_nullable tokenDetails, NSError *__art_nullable error));

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTHttpCb)(ARTHttpResponse *response);
-
 typedef void (^ARTHttpRequestCallback)(NSHTTPURLResponse *__art_nullable response, NSData *__art_nullable data, NSError *__art_nullable error);
 
 typedef void (^ARTStatsCallback)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable result, NSError *__art_nullable error);

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTAuthCallback)(ARTTokenParams *tokenParams, void(^callback)(ARTTokenDetails *__art_nullable tokenDetails, NSError *__art_nullable error));
-
 typedef void (^ARTTokenCallback)(ARTTokenDetails *__art_nullable tokenDetails, NSError *__art_nullable error);
 
 // FIXME: review

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTRealtimePingCb)(ARTErrorInfo *__art_nullable);
-
 typedef void (^ARTStatusCallback)(ARTStatus *status);
 
 typedef void (^ARTHttpCb)(ARTHttpResponse *response);

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTHttpRequestCallback)(NSHTTPURLResponse *__art_nullable response, NSData *__art_nullable data, NSError *__art_nullable error);
-
 typedef void (^ARTStatsCallback)(__GENERIC(ARTPaginatedResult, ARTStats *) *__art_nullable result, NSError *__art_nullable error);
 
 typedef void (^ARTTimeCallback)(NSDate *__art_nullable time, NSError *__art_nullable error);

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -84,10 +84,6 @@ uint64_t timeIntervalToMiliseconds(NSTimeInterval seconds);
 
 NSString *generateNonce();
 
-// MARK: Callbacks definitions
-
-typedef void (^ARTTokenCallback)(ARTTokenDetails *__art_nullable tokenDetails, NSError *__art_nullable error);
-
 // FIXME: review
 @protocol ARTCancellable
 - (void)cancel;

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -86,8 +86,6 @@ NSString *generateNonce();
 
 // MARK: Callbacks definitions
 
-typedef void (^ARTTimeCallback)(NSDate *__art_nullable time, NSError *__art_nullable error);
-
 typedef void (^ARTAuthCallback)(ARTTokenParams *tokenParams, void(^callback)(ARTTokenDetails *__art_nullable tokenDetails, NSError *__art_nullable error));
 
 typedef void (^ARTTokenCallback)(ARTTokenDetails *__art_nullable tokenDetails, NSError *__art_nullable error);

--- a/Source/ARTURLSessionServerTrust.h
+++ b/Source/ARTURLSessionServerTrust.h
@@ -9,8 +9,12 @@
 #import <UIKit/UIKit.h>
 #import "ARTTypes.h"
 
+ART_ASSUME_NONNULL_BEGIN
+
 @interface ARTURLSessionServerTrust : NSObject<NSURLSessionDelegate, NSURLSessionTaskDelegate>
 
-- (void)get:(NSURLRequest *)request completion:(ARTHttpRequestCallback)callback;
+- (void)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback;
 
 @end
+
+ART_ASSUME_NONNULL_END

--- a/Source/ARTURLSessionServerTrust.m
+++ b/Source/ARTURLSessionServerTrust.m
@@ -23,7 +23,7 @@
     return self;
 }
 
-- (void)get:(NSURLRequest *)request completion:(ARTHttpRequestCallback)callback {
+- (void)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         callback((NSHTTPURLResponse *)response, data, error);
     }];

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -57,7 +57,7 @@ private func queryStats(client: ARTRest, _ query: ARTStatsQuery) -> ARTPaginated
     return stats!
 }
 
-private func getPage(paginator: (ARTPaginatedResultCallback) -> Void) -> ARTPaginatedResult {
+private func getPage(paginator: ((ARTPaginatedResult?, NSError?) -> Void) -> Void) -> ARTPaginatedResult {
     var newResult: ARTPaginatedResult?
     let dummyError = NSError(domain: "", code: -1, userInfo: nil);
     var error: NSError? = dummyError

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -422,7 +422,7 @@ class MockHTTPExecutor: NSObject, ARTHTTPExecutor {
     var requests: [NSMutableURLRequest] = []
     var responses: [NSHTTPURLResponse] = []
 
-    func executeRequest(request: NSMutableURLRequest, completion callback: ARTHttpRequestCallback?) {
+    func executeRequest(request: NSMutableURLRequest, completion callback: ((NSHTTPURLResponse?, NSData?, NSError?) -> Void)?) {
         self.requests.append(request)
         self.executor.executeRequest(request, completion: { response, data, error in
             if let httpResponse = response {

--- a/Tests/ARTRealtimePresenceHistoryTest.m
+++ b/Tests/ARTRealtimePresenceHistoryTest.m
@@ -98,7 +98,7 @@
     return @"persisted:runTestChannelName";
 }
 
--(void) runTestLimit:(int)limit forwards:(bool)forwards callback:(ARTPaginatedResultCallback)cb {
+-(void) runTestLimit:(int)limit forwards:(bool)forwards callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error))cb {
     XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
@@ -402,7 +402,7 @@
 
 
 // TODO: consider using a pattern similar to ARTTestUtil testPublish.
--(void) runTestTimeForwards:(bool) forwards limit:(int) limit callback:(ARTPaginatedResultCallback) cb {
+-(void) runTestTimeForwards:(bool) forwards limit:(int) limit callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error)) cb {
     __block long long timeOffset= 0;
     
     XCTestExpectation *e = [self expectationWithDescription:@"getTime"];


### PR DESCRIPTION
Typedefs for block types are pretty annoying, because when checking how you should call some method that takes a callback you then need also to check the signature of the callback type. Now it's all inlined and explicit, if more verbose.