### PR TITLE
Standardise on initialized

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -102,7 +102,7 @@
         _connection = [[ARTConnection alloc] initWithRealtime:self];
         [self.connection setState:ARTRealtimeInitialized];
 
-        [self.logger debug:__FILE__ line:__LINE__ message:@"initialised %p", self];
+        [self.logger debug:__FILE__ line:__LINE__ message:@"initialized %p", self];
         
         if (options.autoConnect) {
             [self connect];
@@ -266,7 +266,7 @@
         }
         // For every Channel
         for (ARTRealtimeChannel* channel in self.channels) {
-            if (channel.state == ARTRealtimeChannelInitialised || channel.state == ARTRealtimeChannelAttaching || channel.state == ARTRealtimeChannelAttached) {
+            if (channel.state == ARTRealtimeChannelInitialized || channel.state == ARTRealtimeChannelAttaching || channel.state == ARTRealtimeChannelAttached) {
                 if(state == ARTRealtimeClosing) {
                     //do nothing. Closed state is coming.
                 }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -41,7 +41,7 @@
     self = [super initWithName:name withOptions:options andRest:realtime.rest];
     if (self) {
         _realtime = realtime;
-        _state = ARTRealtimeChannelInitialised;
+        _state = ARTRealtimeChannelInitialized;
         _queuedMessages = [NSMutableArray array];
         _attachSerial = nil;
         _presenceMap =[[ARTPresenceMap alloc] init];
@@ -128,7 +128,7 @@
 
 - (void)publishProtocolMessage:(ARTProtocolMessage *)pm callback:(void (^)(ARTStatus *))cb {
     switch (self.state) {
-        case ARTRealtimeChannelInitialised:
+        case ARTRealtimeChannelInitialized:
             [self attach];
             // intentional fall-through
         case ARTRealtimeChannelAttaching:
@@ -491,7 +491,7 @@
 
 - (void)detach:(void (^)(ARTErrorInfo * _Nullable))cb {
     switch (self.state) {
-        case ARTRealtimeChannelInitialised:
+        case ARTRealtimeChannelInitialized:
             [self.realtime.logger debug:__FILE__ line:__LINE__ message:@"can't detach when not attached"];
             if (cb) [_detachedEventEmitter once:cb];
             return;

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -64,7 +64,7 @@
         _auth = [[ARTAuth alloc] init:self withOptions:_options];
         _channels = [[ARTRestChannels alloc] initWithRest:self];
 
-        [self.logger debug:__FILE__ line:__LINE__ message:@"initialised %p", self];
+        [self.logger debug:__FILE__ line:__LINE__ message:@"initialized %p", self];
     }
     return self;
 }

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -44,7 +44,7 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeConnectionState) {
 };
 
 typedef NS_ENUM(NSUInteger, ARTRealtimeChannelState) {
-    ARTRealtimeChannelInitialised,
+    ARTRealtimeChannelInitialized,
     ARTRealtimeChannelAttaching,
     ARTRealtimeChannelAttached,
     ARTRealtimeChannelDetaching,
@@ -53,7 +53,7 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeChannelState) {
 };
 
 typedef NS_ENUM(NSUInteger, ARTChannelEvent) {
-    ARTChannelEventInitialised,
+    ARTChannelEventInitialized,
     ARTChannelEventAttaching,
     ARTChannelEventAttached,
     ARTChannelEventDetaching,

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -148,7 +148,7 @@ class RealtimeClientChannel: QuickSpec {
                     defer { client.close() }
 
                     let channel = client.channels.get("test")
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.Initialised))
+                    expect(channel.state).to(equal(ARTRealtimeChannelState.Initialized))
 
                     channel.attach()
                     expect(channel.state).to(equal(ARTRealtimeChannelState.Attaching))
@@ -536,11 +536,11 @@ class RealtimeClientChannel: QuickSpec {
                     var errorInfo: ARTErrorInfo?
                     let channel = client.channels.get("test")
 
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.Initialised))
+                    expect(channel.state).to(equal(ARTRealtimeChannelState.Initialized))
                     channel.detach { errorInfo in
                         expect(errorInfo).to(beNil())
                     }
-                    expect(channel.state).to(equal(ARTRealtimeChannelState.Initialised))
+                    expect(channel.state).to(equal(ARTRealtimeChannelState.Initialized))
 
                     channel.attach()
                     expect(channel.state).toEventually(equal(ARTRealtimeChannelState.Attaching), timeout: testTimeout)
@@ -1134,7 +1134,7 @@ class RealtimeClientChannel: QuickSpec {
                     let publishedMessage = ARTMessage(name: "foo", data: "bar")
 
                     waitUntil(timeout: testTimeout) { done in
-                        expect(channel.state).to(equal(ARTRealtimeChannelState.Initialised))
+                        expect(channel.state).to(equal(ARTRealtimeChannelState.Initialized))
 
                         channel.subscribeWithAttachCallback({ errorInfo in
                             expect(errorInfo).to(beNil())

--- a/Tests/ARTRealtimePresenceTest.m
+++ b/Tests/ARTRealtimePresenceTest.m
@@ -180,7 +180,7 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAttachesTheChannel"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        XCTAssertEqual(channel.state, ARTRealtimeChannelInitialised);
+        XCTAssertEqual(channel.state, ARTRealtimeChannelInitialized);
         [channel.presence enter:@"entered" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             XCTAssertEqual(channel.state, ARTRealtimeChannelAttached);


### PR DESCRIPTION
See discussion in https://github.com/ably/wiki/issues/68

blind whole-repo `s/nitialis/nitializ/`' - haven't tested this (don't know how and don't think I can on a non-mac), so please test before merging