### PR TITLE
Fix: expect timestamp with higher delta

### DIFF
--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -1561,7 +1561,7 @@ class Auth : QuickSpec {
                         delay(0.25) {
                             let now = NSDate().artToIntegerMs()
                             let firstParamsTimestamp = params.timestamp.artToIntegerMs()
-                            expect(firstParamsTimestamp).to(beCloseTo(now, within: 1.0))
+                            expect(firstParamsTimestamp).to(beCloseTo(now, within: 1.5))
                             delay(0.25) {
                                 expect(params.timestamp.artToIntegerMs()).to(equal(firstParamsTimestamp))
                                 done()


### PR DESCRIPTION
`TokenParams__timestamp__if_not_explicitly_set__should_be_generated_at_the_getter_and_stick, failed - expected to be close to <1458091169459.0000> (within 1.0000), got <1458091169460.0000>`