### PR TITLE
Test suite: avoid calling the `fulfill` after the wait context has ended

### DIFF
--- a/Tests/ARTFallbackTest.m
+++ b/Tests/ARTFallbackTest.m
@@ -14,12 +14,11 @@
 
 @implementation ARTFallbackTest
 
--(void)testAllHostsIncludedOnce {
-    
-    ARTFallback * f = [[ARTFallback alloc] init];
-    NSArray * defaultHosts = [ARTDefault fallbackHosts];
-    NSSet * defaultSet = [NSSet setWithArray:defaultHosts];
-    NSMutableArray * hostsRandomised = [NSMutableArray array];
+- (void)testAllHostsIncludedOnce {
+    ARTFallback *f = [[ARTFallback alloc] init];
+    NSArray *defaultHosts = [ARTDefault fallbackHosts];
+    NSSet *defaultSet = [NSSet setWithArray:defaultHosts];
+    NSMutableArray *hostsRandomised = [NSMutableArray array];
     for(int i=0;i < [defaultHosts count]; i++) {
         [hostsRandomised addObject:[f popFallbackHost]];
     }

--- a/Tests/ARTHttpTest.m
+++ b/Tests/ARTHttpTest.m
@@ -30,7 +30,7 @@
     [super tearDown];
 }
 
--(void) testPingGoogle {
+- (void)testPingGoogle {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
     
     [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://www.google.com"] headers:nil body:nil callback:^(ARTHttpResponse *response) {
@@ -50,6 +50,5 @@
 
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-
 
 @end

--- a/Tests/ARTHttpTest.m
+++ b/Tests/ARTHttpTest.m
@@ -31,7 +31,7 @@
 }
 
 -(void) testPingGoogle {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
     
     [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://www.google.com"] headers:nil body:nil callback:^(ARTHttpResponse *response) {
         XCTAssertEqual(response.status, 200);
@@ -41,7 +41,7 @@
     [self waitForExpectationsWithTimeout:10.0 handler:nil];
 }
 - (void)testNonExistantPath {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"get"];
 
     [self.http makeRequestWithMethod:@"GET" url:[NSURL URLWithString:@"http://rest.ably.io"] headers:nil body:nil callback:^(ARTHttpResponse *response) {
         XCTAssertEqual(response.status, 404);

--- a/Tests/ARTReadmeExamples.m
+++ b/Tests/ARTReadmeExamples.m
@@ -75,7 +75,7 @@
     }];
 }
 
-- (void) testQueryingTheHistory {
+- (void)testQueryingTheHistory {
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *client) {
         ARTRealtimeChannel *channel = [client.channels get:@"test"];
@@ -133,7 +133,6 @@
 - (void)testRestPublishMessage {
     [ARTTestUtil testRest:^(ARTRest *client) {
         ARTRestChannel *channel = [client.channels get:@"test"];
-        
         [channel publish:@"myEvent" data:@"Hello!"];
     }];
 }

--- a/Tests/ARTRealtimeAttachTest.m
+++ b/Tests/ARTRealtimeAttachTest.m
@@ -42,7 +42,7 @@
 }
 
 - (void) testAttachOnce {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"attachOnce"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attachOnce"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -81,7 +81,7 @@
 }
 
 -(void) testSkipsFromDetachingToAttaching {
-    XCTestExpectation *  expectation = [self expectationWithDescription:@"detaching_to_attaching"];
+    __weak XCTestExpectation * expectation = [self expectationWithDescription:@"detaching_to_attaching"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"detaching_to_attaching"];
@@ -115,8 +115,8 @@
 }
 
 - (void) testAttachMultipleChannels {
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"test_attach_multiple1"];
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"test_attach_multiple2"];
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"test_attach_multiple1"];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"test_attach_multiple2"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel1 = [realtime.channels get:@"test_attach_multiple1"];
@@ -141,7 +141,7 @@
 
 
 - (void)testDetach {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -165,7 +165,7 @@
 }
 
 - (void)testDetaching {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block BOOL detachingHit = NO;
@@ -198,7 +198,7 @@
 }
 
 -(void) testSkipsFromAttachingToDetaching {
-    XCTestExpectation *  expectation = [self expectationWithDescription:@"attaching_to_detaching"];
+    __weak XCTestExpectation * expectation = [self expectationWithDescription:@"attaching_to_detaching"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attaching_to_detaching"];
@@ -224,7 +224,7 @@
 }
 
 -(void)testDetachingIgnoresDetach {
-    XCTestExpectation *  expectation = [self expectationWithDescription:@"testDetachingIgnoresDetach"];
+    __weak XCTestExpectation * expectation = [self expectationWithDescription:@"testDetachingIgnoresDetach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -252,7 +252,7 @@
 }
 
 - (void) testAttachFailsOnFailedConnection {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testAttachFailsOnFailedConnection"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testAttachFailsOnFailedConnection"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -290,8 +290,8 @@
 }
 
 - (void)testAttachRestricted {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions * options) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
 
             ARTRealtime * realtime =[[ARTRealtime alloc] initWithOptions:options];
             _realtime = realtime;
@@ -310,7 +310,7 @@
 }
 
 - (void)testAttachingChannelFails {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testAttachingChannelFails"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachingChannelFails"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
@@ -329,7 +329,7 @@
 }
 
 - (void)testAttachedChannelFails {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testAttachedChannelFails"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachedChannelFails"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
@@ -348,7 +348,7 @@
 }
 
 - (void)testChannelClosesOnClose {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testChannelClosesOnClose"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testChannelClosesOnClose"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
@@ -367,7 +367,7 @@
 }
 
 - (void)testPresenceEnterRestricted {
-    XCTestExpectation *expect = [self expectationWithDescription:@"testSimpleDisconnected"];
+    __weak XCTestExpectation *expect = [self expectationWithDescription:@"testSimpleDisconnected"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
         // Connection
         options.clientId = @"some_client_id";

--- a/Tests/ARTRealtimeAttachTest.m
+++ b/Tests/ARTRealtimeAttachTest.m
@@ -23,6 +23,7 @@
 @interface ARTRealtimeAttachTest : XCTestCase {
     ARTRealtime *_realtime;
 }
+
 @end
 
 @implementation ARTRealtimeAttachTest
@@ -41,7 +42,7 @@
     [super tearDown];
 }
 
-- (void) testAttachOnce {
+- (void)testAttachOnce {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attachOnce"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -80,7 +81,7 @@
 
 }
 
--(void) testSkipsFromDetachingToAttaching {
+- (void)testSkipsFromDetachingToAttaching {
     __weak XCTestExpectation * expectation = [self expectationWithDescription:@"detaching_to_attaching"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -111,10 +112,9 @@
     }];
     
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-
 }
 
-- (void) testAttachMultipleChannels {
+- (void)testAttachMultipleChannels {
     __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"test_attach_multiple1"];
     __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"test_attach_multiple2"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
@@ -197,7 +197,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testSkipsFromAttachingToDetaching {
+- (void)testSkipsFromAttachingToDetaching {
     __weak XCTestExpectation * expectation = [self expectationWithDescription:@"attaching_to_detaching"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -251,7 +251,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void) testAttachFailsOnFailedConnection {
+- (void)testAttachFailsOnFailedConnection {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testAttachFailsOnFailedConnection"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -290,22 +290,22 @@
 }
 
 - (void)testAttachRestricted {
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions * options) {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
 
-            ARTRealtime * realtime =[[ARTRealtime alloc] initWithOptions:options];
-            _realtime = realtime;
+        ARTRealtime *realtime =[[ARTRealtime alloc] initWithOptions:options];
+        _realtime = realtime;
 
-            ARTRealtimeChannel * channel = [realtime.channels get:@"some_unpermitted_channel"];
-            [channel on:^(ARTErrorInfo *errorInfo) {
-                if(channel.state != ARTRealtimeChannelAttaching) {
-                    XCTAssertEqual(channel.state, ARTRealtimeChannelFailed);
-                    [expectation fulfill];
-                    [channel off];
-                }
-            }];
-            [channel attach];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
+        [channel on:^(ARTErrorInfo *errorInfo) {
+            if(channel.state != ARTRealtimeChannelAttaching) {
+                XCTAssertEqual(channel.state, ARTRealtimeChannelFailed);
+                [expectation fulfill];
+                [channel off];
+            }
         }];
+        [channel attach];
+    }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 

--- a/Tests/ARTRealtimeChannelHistoryTest.m
+++ b/Tests/ARTRealtimeChannelHistoryTest.m
@@ -18,11 +18,11 @@
 #import "ARTTestUtil.h"
 
 @interface ARTRealtimeChannelHistoryTest : XCTestCase {
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtime2;
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtime2;
 }
-@end
 
+@end
 
 @implementation ARTRealtimeChannelHistoryTest
 
@@ -87,44 +87,39 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) publishTestStrings:(ARTRealtimeChannel *) channel
-                     count:(int) count
-                    prefix:(NSString *) prefix
-                        callback:(void (^) (ARTErrorInfo *errorInfo)) cb
-{
-    {
-        __block int numReceived =0;
-        __block bool done =false;
-        for(int i=0; i < count; i++) {
-            NSString * pub = [prefix stringByAppendingString:[NSString stringWithFormat:@"%d", i]];
-            [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
-                if(channel.state != ARTStateOk) {
-                    if(!done) {
-                        done = true;
-                        cb(errorInfo);
-                    }
+- (void)publishTestStrings:(ARTRealtimeChannel *)channel count:(int)count prefix:(NSString *)prefix callback:(void (^)(ARTErrorInfo *errorInfo))cb {
+    __block int numReceived = 0;
+    __block bool done = false;
+
+    for (int i=0; i < count; i++) {
+        NSString *pub = [prefix stringByAppendingString:[NSString stringWithFormat:@"%d", i]];
+        [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
+            if(channel.state != ARTStateOk) {
+                if(!done) {
+                    done = true;
+                    cb(errorInfo);
+                }
+                return;
+            }
+            ++numReceived;
+            if(numReceived ==count) {
+                if(!done) {
+                    done = true;
+                    cb(errorInfo);
                     return;
                 }
-                ++numReceived;
-                if(numReceived ==count) {
-                    if(!done) {
-                        done = true;
-                        cb(errorInfo);
-                        return;
-                    }
-                    
-                }
-            }];
-        }
+                
+            }
+        }];
     }
 }
 
-- (void) testHistoryBothChannels {
+- (void)testHistoryBothChannels {
     __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"historyBothChanels1"];
     __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"historyBothChanels2"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        NSString * both = @"historyBoth";
+        NSString *both = @"historyBoth";
         ARTRealtimeChannel *channel1 = [realtime.channels get:both];
         ARTRealtimeChannel *channel2 = [realtime.channels get:both];
         [channel1 publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
@@ -158,7 +153,6 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
 - (void)testHistoryForward {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryForward"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
@@ -187,7 +181,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testHistoryForwardPagination {
+- (void)testHistoryForwardPagination {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryForwardPagination"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -203,35 +197,35 @@
             [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                  XCTAssert(!error);
                  XCTAssertTrue([result hasNext]);
-                 NSArray * items = [result items];
+                 NSArray *items = [result items];
                  XCTAssertEqual([items count], 2);
-                 ARTMessage * firstMessage = [items objectAtIndex:0];
-                 ARTMessage * secondMessage =[items objectAtIndex:1];
+                 ARTMessage *firstMessage = [items objectAtIndex:0];
+                 ARTMessage *secondMessage =[items objectAtIndex:1];
                  XCTAssertEqualObjects(@"testString0", [firstMessage data]);
                  XCTAssertEqualObjects(@"testString1", [secondMessage data]);
                  [result next:^(ARTPaginatedResult *result2, NSError *error) {
                      XCTAssert(!error);
-                     NSArray * items = [result2 items];
+                     NSArray *items = [result2 items];
                      XCTAssertEqual([items count], 2);
-                     ARTMessage * firstMessage = [items objectAtIndex:0];
-                     ARTMessage * secondMessage =[items objectAtIndex:1];
+                     ARTMessage *firstMessage = [items objectAtIndex:0];
+                     ARTMessage *secondMessage =[items objectAtIndex:1];
                      XCTAssertEqualObjects(@"testString2", [firstMessage data]);
                      XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                      
                      [result2 next:^(ARTPaginatedResult *result3, NSError *error) {
                          XCTAssert(!error);
                          XCTAssertFalse([result3 hasNext]);
-                         NSArray * items = [result3 items];
+                         NSArray *items = [result3 items];
                          XCTAssertEqual([items count], 1);
-                         ARTMessage * firstMessage = [items objectAtIndex:0];
+                         ARTMessage *firstMessage = [items objectAtIndex:0];
                          XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                          [result3 first:^(ARTPaginatedResult *result4, NSError *error) {
                              XCTAssertNil(errorInfo);
                              XCTAssertTrue([result4 hasNext]);
-                             NSArray * items = [result4 items];
+                             NSArray *items = [result4 items];
                              XCTAssertEqual([items count], 2);
-                             ARTMessage * firstMessage = [items objectAtIndex:0];
-                             ARTMessage * secondMessage =[items objectAtIndex:1];
+                             ARTMessage *firstMessage = [items objectAtIndex:0];
+                             ARTMessage *secondMessage =[items objectAtIndex:1];
                              XCTAssertEqualObjects(@"testString0", [firstMessage data]);
                              XCTAssertEqualObjects(@"testString1", [secondMessage data]);
                              [expectation fulfill];
@@ -241,11 +235,10 @@
              } error:nil];
         }];
     }];
-
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testHistoryBackwardPagination {
+- (void)testHistoryBackwardPagination {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryBackwardagination"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -260,18 +253,18 @@
             [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                  XCTAssert(!error);
                  XCTAssertTrue([result hasNext]);
-                 NSArray * items = [result items];
+                 NSArray *items = [result items];
                  XCTAssertEqual([items count], 2);
-                 ARTMessage * firstMessage = [items objectAtIndex:0];
-                 ARTMessage * secondMessage =[items objectAtIndex:1];
+                 ARTMessage *firstMessage = [items objectAtIndex:0];
+                 ARTMessage *secondMessage =[items objectAtIndex:1];
                  XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                  XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                  [result next:^(ARTPaginatedResult *result2, NSError *error) {
                      XCTAssert(!error);
-                     NSArray * items = [result2 items];
+                     NSArray *items = [result2 items];
                      XCTAssertEqual([items count], 2);
-                     ARTMessage * firstMessage = [items objectAtIndex:0];
-                     ARTMessage * secondMessage =[items objectAtIndex:1];
+                     ARTMessage *firstMessage = [items objectAtIndex:0];
+                     ARTMessage *secondMessage =[items objectAtIndex:1];
                      
                      XCTAssertEqualObjects(@"testString2", [firstMessage data]);
                      XCTAssertEqualObjects(@"testString1", [secondMessage data]);
@@ -279,26 +272,26 @@
                      [result2 next:^(ARTPaginatedResult *result3, NSError *error) {
                          XCTAssert(!error);
                          XCTAssertFalse([result3 hasNext]);
-                         NSArray * items = [result3 items];
+                         NSArray *items = [result3 items];
                          XCTAssertEqual([items count], 1);
-                         ARTMessage * firstMessage = [items objectAtIndex:0];
+                         ARTMessage *firstMessage = [items objectAtIndex:0];
                          XCTAssertEqualObjects(@"testString0", [firstMessage data]);
                          [result3 first:^(ARTPaginatedResult *result4, NSError *error) {
                              XCTAssert(!error);
                              XCTAssertTrue([result4 hasNext]);
-                             NSArray * items = [result4 items];
+                             NSArray *items = [result4 items];
                              XCTAssertEqual([items count], 2);
-                             ARTMessage * firstMessage = [items objectAtIndex:0];
-                             ARTMessage * secondMessage =[items objectAtIndex:1];
+                             ARTMessage *firstMessage = [items objectAtIndex:0];
+                             ARTMessage *secondMessage =[items objectAtIndex:1];
                              XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                              XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                              [result2 first:^(ARTPaginatedResult *result, NSError *error) {
                                  XCTAssert(!error);
                                  XCTAssertTrue([result hasNext]);
-                                 NSArray * items = [result items];
+                                 NSArray *items = [result items];
                                  XCTAssertEqual([items count], 2);
-                                 ARTMessage * firstMessage = [items objectAtIndex:0];
-                                 ARTMessage * secondMessage =[items objectAtIndex:1];
+                                 ARTMessage *firstMessage = [items objectAtIndex:0];
+                                 ARTMessage *secondMessage =[items objectAtIndex:1];
                                  XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                                  XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                                 [expectation fulfill];
@@ -313,7 +306,7 @@
 }
 
 - (void)testTimeBackwards {
-    __block long long timeOffset= 0;
+    __block long long timeOffset = 0;
 
     __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
@@ -430,14 +423,14 @@
                             [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                                 XCTAssert(!error);
                                 XCTAssertFalse([result hasNext]);
-                                NSArray * items = [result items];
+                                NSArray *items = [result items];
                                 XCTAssertTrue(items != nil);
                                 XCTAssertEqual([items count], secondBatchTotal);
                                 for (int i=0; i < [items count]; i++) {
-                                    NSString * pattern = [secondBatch stringByAppendingString:@"%d"];
-                                    NSString * goalStr = [NSString stringWithFormat:pattern, i];
+                                    NSString *pattern = [secondBatch stringByAppendingString:@"%d"];
+                                    NSString *goalStr = [NSString stringWithFormat:pattern, i];
 
-                                    ARTMessage * m = [items objectAtIndex:i];
+                                    ARTMessage *m = [items objectAtIndex:i];
                                     XCTAssertEqualObjects(goalStr, [m data]);
                                 }
                                 [expectation fulfill];
@@ -461,7 +454,7 @@
     NSString *channelName = @"test_history_time_forwards";
     __weak XCTestExpectation *expecation = [self expectationWithDescription:@"send_first_batch"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRealtime * realtime =[[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime =[[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
 
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
@@ -470,7 +463,7 @@
         //send first batch, which we won't recieve in the history request
         __block int numReceived =0;
 
-        for(int i=0; i < firstBatchTotal; i++) {
+        for (int i=0; i < firstBatchTotal; i++) {
             NSString *pub = [NSString stringWithFormat:@"test%d", i];
 
             [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
@@ -487,12 +480,12 @@
                     [channel2 history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);
                         XCTAssertFalse([result hasNext]);
-                        NSArray * items = [result items];
+                        NSArray *items = [result items];
                         XCTAssertTrue(items != nil);
                         XCTAssertEqual([items count], firstBatchTotal);
                         for(int i=0;i < [items count]; i++) {
-                            NSString * goalStr = [NSString stringWithFormat:@"test%d",firstBatchTotal -1 - i];
-                            ARTMessage * m = [items objectAtIndex:i];
+                            NSString *goalStr = [NSString stringWithFormat:@"test%d",firstBatchTotal -1 - i];
+                            ARTMessage *m = [items objectAtIndex:i];
                             XCTAssertEqualObjects(goalStr, [m data]);
                         }
                         [expecation fulfill];

--- a/Tests/ARTRealtimeChannelTest.m
+++ b/Tests/ARTRealtimeChannelTest.m
@@ -53,7 +53,7 @@
 }
 
 - (void)testAttach {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"attach"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -75,7 +75,7 @@
 
 
 - (void)testAttachBeforeConnect     {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"attach_before_connect"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_before_connect"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach_before_connect"];
@@ -91,7 +91,7 @@
 }
 
 - (void)testAttachDetach {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach_detach"];
@@ -114,7 +114,7 @@
 
 - (void) testAttachDetachAttach {
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach_attach"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach_attach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach_detach_attach"];
@@ -143,8 +143,8 @@
 
 - (void)testSubscribeUnsubscribe {
     
-    XCTestExpectation *expectation = [self expectationWithDescription:@"publish"];
     NSString * lostMessage = @"lost";
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"publish"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"test"];
@@ -179,7 +179,7 @@
 
 
 - (void) testSuspendingDetachesChannel {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
@@ -206,7 +206,7 @@
 }
 
 - (void) testFailingFailsChannel {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
@@ -227,7 +227,7 @@
 }
 
 - (void) testGetChannels {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *c1 = [realtime.channels get:@"channel"];
@@ -259,10 +259,10 @@
 }
 
 - (void) testGetSameChannelWithParams {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
     NSString * channelName = @"channel";
     NSString * firstMessage = @"firstMessage";
     NSString * secondMessage = @"secondMessage";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *c1 = [realtime.channels get:channelName];
@@ -294,7 +294,7 @@
 
 
 - (void)testAttachFails {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testAttachFails"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachFails"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
@@ -324,8 +324,8 @@
     NSString *firstClientId = @"firstClientId";
     NSString *channelName = @"channelName";
 
-    XCTestExpectation *exp1 = [self expectationWithDescription:@"testClientIdPreserved1"];
-    XCTestExpectation *exp2 = [self expectationWithDescription:@"testClientIdPreserved2"];
+    __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testClientIdPreserved1"];
+    __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testClientIdPreserved2"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO callback:^(ARTClientOptions *options) {
         // First instance
         options.clientId = firstClientId;

--- a/Tests/ARTRealtimeChannelTest.m
+++ b/Tests/ARTRealtimeChannelTest.m
@@ -23,13 +23,12 @@
 #import "ARTChannelOptions.h"
 
 @interface ARTRealtimeChannelTest : XCTestCase {
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtime2;
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtime2;
 }
 @end
 
 @implementation ARTRealtimeChannelTest
-
 
 - (void)setUp {
     [super setUp];
@@ -69,12 +68,10 @@
             }
         }];
     }];
-    
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
-- (void)testAttachBeforeConnect     {
+- (void)testAttachBeforeConnect {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_before_connect"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -86,7 +83,6 @@
             }
         }];
     }];
-    
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
@@ -108,12 +104,10 @@
             }
         }];
     }];
-    
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void) testAttachDetachAttach {
-    
+- (void)testAttachDetachAttach {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach_attach"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -140,11 +134,9 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
 - (void)testSubscribeUnsubscribe {
-    
-    NSString * lostMessage = @"lost";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"publish"];
+    NSString *lostMessage = @"lost";
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"test"];
@@ -162,8 +154,8 @@
 
         [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            NSString * finalMessage = @"final";
-            [channel subscribe:^(ARTMessage * message) {
+            NSString *finalMessage = @"final";
+            [channel subscribe:^(ARTMessage *message) {
                 if([[message data] isEqualToString:finalMessage]) {
                     [expectation fulfill];
                 }
@@ -175,10 +167,8 @@
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
- 
 
-
-- (void) testSuspendingDetachesChannel {
+- (void)testSuspendingDetachesChannel {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -205,7 +195,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void) testFailingFailsChannel {
+- (void)testFailingFailsChannel {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -226,7 +216,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void) testGetChannels {
+- (void)testGetChannels {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -234,7 +224,7 @@
         ARTRealtimeChannel *c2 = [realtime.channels get:@"channel2"];
         ARTRealtimeChannel *c3 = [realtime.channels get:@"channel3"];
         {
-            NSMutableDictionary * d = [[NSMutableDictionary alloc] init];
+            NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
             for (ARTRealtimeChannel *channel in realtime.channels) {
                 [d setValue:channel forKey:channel.name];
             }
@@ -244,7 +234,7 @@
             XCTAssertEqualObjects([d valueForKey:@"channel3"], c3);
         }
         [realtime.channels release:c3.name callback:^(ARTErrorInfo *errorInfo) {
-            NSMutableDictionary * d = [[NSMutableDictionary alloc] init];
+            NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
             for (ARTRealtimeChannel *channel in realtime.channels) {
                 [d setValue:channel forKey:channel.name];
             }
@@ -258,18 +248,18 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void) testGetSameChannelWithParams {
-    NSString * channelName = @"channel";
-    NSString * firstMessage = @"firstMessage";
-    NSString * secondMessage = @"secondMessage";
+- (void)testGetSameChannelWithParams {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
+    NSString *channelName = @"channel";
+    NSString *firstMessage = @"firstMessage";
+    NSString *secondMessage = @"secondMessage";
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *c1 = [realtime.channels get:channelName];
-        NSData * ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
         
-        NSData * keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
-        ARTCipherParams * params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
+        NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+        ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
         ARTRealtimeChannel *c2 = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
         [c1 publish:nil data:firstMessage callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
@@ -278,7 +268,7 @@
             }];
         }];
         __block int messageCount =0;
-        [c1 subscribe:^(ARTMessage * message) {
+        [c1 subscribe:^(ARTMessage *message) {
             if(messageCount ==0) {
                 XCTAssertEqualObjects([message data], firstMessage);
             }
@@ -291,7 +281,6 @@
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-
 
 - (void)testAttachFails {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachFails"];

--- a/Tests/ARTRealtimeConnectTest.m
+++ b/Tests/ARTRealtimeConnectTest.m
@@ -18,7 +18,7 @@
 #import "ARTRealtimeChannel.h"
 
 @interface ARTRealtimeConnectTest : XCTestCase {
-    ARTRealtime * _realtime;
+    ARTRealtime *_realtime;
 }
 @end
 
@@ -38,7 +38,8 @@
     }
     _realtime = nil;
 }
-- (void)testConnectText{
+
+- (void)testConnectText {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectText"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -95,7 +96,6 @@
         [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-    
 }
 
 - (void)testConnectStateChangeClose {
@@ -135,7 +135,7 @@
         
             if(state == ARTRealtimeConnected) {
                 XCTAssertEqual(realtime.connection.serial, -1);
-                ARTRealtimeChannel * c =[realtime.channels get:@"chan"];
+                ARTRealtimeChannel *c =[realtime.channels get:@"chan"];
                 [c publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertEqual(realtime.connection.serial, 0);
                     [c publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
@@ -150,9 +150,7 @@
         [realtime connect];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-    
 }
-
 
 - (void)testConnectAfterClose {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"test_connect_text"];
@@ -202,14 +200,13 @@
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-    
 }
 
 - (void)testConnectStates {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectStates"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.autoConnect = false;
-        ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
         __block bool gotInitialized =false;
         __block bool gotConnecting =false;
@@ -303,6 +300,5 @@
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-
 
 @end

--- a/Tests/ARTRealtimeConnectTest.m
+++ b/Tests/ARTRealtimeConnectTest.m
@@ -39,7 +39,7 @@
     _realtime = nil;
 }
 - (void)testConnectText{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectText"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectText"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -53,7 +53,7 @@
 }
 
 - (void)testConnectPing {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectPing"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectPing"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -70,7 +70,7 @@
 }
 
 - (void)testConnectStateChange {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.autoConnect = false;
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
@@ -99,7 +99,7 @@
 }
 
 - (void)testConnectStateChangeClose {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.autoConnect = false;
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
@@ -125,7 +125,7 @@
 }
 
 - (void)testConnectionSerial {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.autoConnect = false;
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
@@ -155,7 +155,7 @@
 
 
 - (void)testConnectAfterClose {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"test_connect_text"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"test_connect_text"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block int connectionCount=0;
@@ -180,7 +180,7 @@
 }
 
 - (void)testConnectingFromClosing {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         __block bool connectHappened = false;
@@ -206,7 +206,7 @@
 }
 
 - (void)testConnectStates {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testConnectStates"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectStates"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.autoConnect = false;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -274,7 +274,7 @@
 }
 
 - (void)testConnectPingError {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testConnectPingError"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectPingError"];
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.autoConnect = false;
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {

--- a/Tests/ARTRealtimeCryptoTest.m
+++ b/Tests/ARTRealtimeCryptoTest.m
@@ -44,7 +44,7 @@
 }
 
 - (void)testSendEncodedMessage {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessage"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessage"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         NSData * ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
@@ -80,7 +80,7 @@
 }
 
 - (void)testSendEncodedMessageOnExistingChannel {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessageOnExistingChannel"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessageOnExistingChannel"];
     NSString *channelName = @"channelName";
     NSString *firstMessageText = @"firstMessage";
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {

--- a/Tests/ARTRealtimeCryptoTest.m
+++ b/Tests/ARTRealtimeCryptoTest.m
@@ -20,18 +20,12 @@
 #import "ARTChannelOptions.h"
 
 @interface ARTRealtimeCryptoTest : XCTestCase {
-    ARTRealtime * _realtime;
+    ARTRealtime *_realtime;
 }
 
 @end
 
 @implementation ARTRealtimeCryptoTest
-
-- (void)setUp {
-    [super setUp];
-
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
 
 - (void)tearDown {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
@@ -47,7 +41,7 @@
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessage"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        NSData * ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
         NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
         ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
         ARTRealtimeChannel *channel = [realtime.channels get:@"test" options:[[ARTChannelOptions alloc] initWithCipher: params]];
@@ -68,7 +62,7 @@
                     XCTAssertTrue(page != nil);
                     XCTAssertEqual([page count], 2);
                     ARTMessage *stringMessage = [page objectAtIndex:0];
-                    ARTMessage * dataMessage = [page objectAtIndex:1];
+                    ARTMessage *dataMessage = [page objectAtIndex:1];
                     XCTAssertEqualObjects([dataMessage data], dataPayload);
                     XCTAssertEqualObjects([stringMessage data], stringPayload);
                     [exp fulfill];
@@ -86,16 +80,16 @@
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
 
-        ARTRealtimeChannel * channel = [realtime.channels get:channelName];
+        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel publish:nil data:firstMessageText callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            NSData * ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
-            NSData * keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
-            ARTCipherParams * params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
-            ARTRealtimeChannel * c = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
+            NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+            NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+            ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
+            ARTRealtimeChannel *c = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
             XCTAssert(c);
-            NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-            NSString * stringPayload = @"someString";
+            NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+            NSString *stringPayload = @"someString";
             [c publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 [c publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
@@ -103,12 +97,12 @@
                     [c history:^(ARTPaginatedResult *result, NSError *error) {
                         XCTAssert(!error);
                         XCTAssertFalse([result hasNext]);
-                        NSArray * page = [result items];
+                        NSArray *page = [result items];
                         XCTAssertTrue(page != nil);
                         XCTAssertEqual([page count], 3);
-                        ARTMessage * stringMessage = [page objectAtIndex:0];
-                        ARTMessage * dataMessage = [page objectAtIndex:1];
-                        ARTMessage * firstMessage = [page objectAtIndex:2];
+                        ARTMessage *stringMessage = [page objectAtIndex:0];
+                        ARTMessage *dataMessage = [page objectAtIndex:1];
+                        ARTMessage *firstMessage = [page objectAtIndex:2];
                         XCTAssertEqualObjects([dataMessage data], dataPayload);
                         XCTAssertEqualObjects([stringMessage data], stringPayload);
                         XCTAssertEqualObjects([firstMessage data], firstMessageText);

--- a/Tests/ARTRealtimeInitTest.m
+++ b/Tests/ARTRealtimeInitTest.m
@@ -21,15 +21,11 @@
 #import "ARTDefault.h"
 
 @interface ARTRealtimeInitTest : XCTestCase {
-    ARTRealtime * _realtime;
+    ARTRealtime *_realtime;
 }
 @end
 
 @implementation ARTRealtimeInitTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     if (_realtime) {
@@ -41,14 +37,13 @@
     [super tearDown];
 }
 
--(void) getBaseOptions:(void (^)(ARTClientOptions * options)) cb {
+- (void)getBaseOptions:(void (^)(ARTClientOptions *options)) cb {
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO callback:cb];
 }
 
-
--(void)testInitWithOptions {
-    [ARTTestUtil testRealtime:^(ARTRealtime * realtime) {
+- (void)testInitWithOptions {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"initWithOptions"];
+    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
@@ -63,11 +58,11 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testInitWithHost {
-    [self getBaseOptions:^(ARTClientOptions * options) {
+- (void)testInitWithHost {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithHost"];
+    [self getBaseOptions:^(ARTClientOptions *options) {
         options.environment = @"test";
-        ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
@@ -82,11 +77,11 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testInitWithPort {
-    [self getBaseOptions:^(ARTClientOptions * options) {
+- (void)testInitWithPort {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithPort"];
+    [self getBaseOptions:^(ARTClientOptions *options) {
         options.tlsPort = 9998;
-        ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
@@ -101,7 +96,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout]+[ARTDefault connectTimeout] handler:nil];
 }
 
--(void) testInitWithKey {
+- (void)testInitWithKey {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithKey"];
     [self getBaseOptions:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithKey:options.key];
@@ -113,7 +108,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testInitAutoConnectDefault {
+- (void)testInitAutoConnectDefault {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -127,11 +122,11 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testInitAutoConnectFalse {
+- (void)testInitAutoConnectFalse {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.autoConnect = false;
-        ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;

--- a/Tests/ARTRealtimeInitTest.m
+++ b/Tests/ARTRealtimeInitTest.m
@@ -47,8 +47,8 @@
 
 
 -(void)testInitWithOptions {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"initWithOptions"];
     [ARTTestUtil testRealtime:^(ARTRealtime * realtime) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"initWithOptions"];
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
@@ -64,8 +64,8 @@
 }
 
 -(void)testInitWithHost {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithHost"];
     [self getBaseOptions:^(ARTClientOptions * options) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithHost"];
         options.environment = @"test";
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
@@ -83,8 +83,8 @@
 }
 
 -(void)testInitWithPort {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithPort"];
     [self getBaseOptions:^(ARTClientOptions * options) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithPort"];
         options.tlsPort = 9998;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime;
@@ -102,7 +102,7 @@
 }
 
 -(void) testInitWithKey {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithKey"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithKey"];
     [self getBaseOptions:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithKey:options.key];
         if (_realtime.connection.state == ARTRealtimeConnecting) {
@@ -114,7 +114,7 @@
 }
 
 -(void) testInitAutoConnectDefault {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -128,7 +128,7 @@
 }
 
 -(void) testInitAutoConnectFalse {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.autoConnect = false;
         ARTRealtime * realtime = [[ARTRealtime alloc] initWithOptions:options];

--- a/Tests/ARTRealtimeMessageTest.m
+++ b/Tests/ARTRealtimeMessageTest.m
@@ -23,16 +23,13 @@
 #import "ARTNSArray+ARTFunctional.h"
 
 @interface ARTRealtimeMessageTest : XCTestCase {
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtime2;
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtime2;
 }
+
 @end
 
 @implementation ARTRealtimeMessageTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     [super tearDown];
@@ -111,9 +108,9 @@
     NSString *channelName = @"testSingleEcho";
     
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRealtime * realtime1 = [[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime1 = [[ARTRealtime alloc] initWithOptions:options];
         _realtime = realtime1;
-        ARTRealtime * realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+        ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = realtime2;
 
         ARTRealtimeChannel *channel = [realtime1.channels get:channelName];
@@ -164,11 +161,11 @@
 }
 
 - (void)testEchoMessagesDefault {
-    NSString * channelName = @"channel";
-    NSString * message1 = @"message1";
-    NSString * message2 = @"message2";
+    NSString *channelName = @"channel";
+    NSString *message1 = @"message1";
+    NSString *message2 = @"message2";
+
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesDefault"];
-    
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -187,7 +184,7 @@
         }];
         [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            ARTRealtimeChannel * channel2 = [_realtime2.channels get:channelName];
+            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
             [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
@@ -197,10 +194,10 @@
 }
 
 - (void)testEchoMessagesFalse {
-    NSString * channelName = @"channel";
-    NSString * message1 = @"message1";
-    NSString * message2 = @"message2";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesFalse"];
+    NSString *channelName = @"channel";
+    NSString *message1 = @"message1";
+    NSString *message2 = @"message2";
     
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.echoMessages = false;
@@ -214,7 +211,7 @@
         }];
         [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            ARTRealtimeChannel * channel2 = [_realtime2.channels get:channelName];
+            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
             [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
@@ -240,12 +237,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
 - (void)testMessageQueue {
-    NSString * connectingMessage = @"connectingMessage";
-    NSString * disconnectedMessage = @"disconnectedMessage";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testMessageQueue"];
-
+    NSString *connectingMessage = @"connectingMessage";
+    NSString *disconnectedMessage = @"disconnectedMessage";
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.autoConnect = false;
     [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
@@ -291,7 +286,7 @@
 
 
 - (void)testConnectionIdsInMessage {
-    NSString * channelName = @"channelName";
+    NSString *channelName = @"channelName";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectionIdsInMessage"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -322,7 +317,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testPublishImmediate {
+- (void)testPublishImmediate {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishImmediate"];
     
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
@@ -349,12 +344,12 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testPublishArray {
+- (void)testPublishArray {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        NSArray * messages = [@[@"test1", @"test2", @"test3"] artMap:^id(id data) {
+        NSArray *messages = [@[@"test1", @"test2", @"test3"] artMap:^id(id data) {
             return [[ARTMessage alloc] initWithName:nil data:data];
         }];
         [channel publish:messages callback:^(ARTErrorInfo *errorInfo) {
@@ -378,7 +373,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testPublishWithName {
+- (void)testPublishWithName {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishWithName"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -397,10 +392,10 @@
 
 
 - (void)testSubscribeToName {
-    NSString * channelName = @"channel";
-    NSString * messageName =@"messageName";
-    NSString * messageContent = @"content";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToName"];
+    NSString *channelName = @"channel";
+    NSString *messageName =@"messageName";
+    NSString *messageContent = @"content";
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];

--- a/Tests/ARTRealtimeMessageTest.m
+++ b/Tests/ARTRealtimeMessageTest.m
@@ -53,7 +53,7 @@
 - (void)multipleSendName:(NSString *)name count:(int)count delay:(int)delay {
     __block int numReceived = 0;
     
-    XCTestExpectation *e = [self expectationWithDescription:@"waitExp"];
+    __weak XCTestExpectation *e = [self expectationWithDescription:@"waitExp"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         [e fulfill];
@@ -62,7 +62,7 @@
 
     [_realtime close];
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"multiple_send"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"multiple_send"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:name];
@@ -89,7 +89,7 @@
 }
 
 - (void)testSingleSendText {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendText"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendText"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"testSingleSendText"];
@@ -105,9 +105,9 @@
 }
 
 - (void)testSingleSendEchoText {
-    XCTestExpectation *exp1 = [self expectationWithDescription:@"testSingleSendEchoText1"];
-    XCTestExpectation *exp2 = [self expectationWithDescription:@"testSingleSendEchoText2"];
-    XCTestExpectation *exp3 = [self expectationWithDescription:@"testSingleSendEchoText3"];
+    __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testSingleSendEchoText1"];
+    __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testSingleSendEchoText2"];
+    __weak XCTestExpectation *exp3 = [self expectationWithDescription:@"testSingleSendEchoText3"];
     NSString *channelName = @"testSingleEcho";
     
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
@@ -164,10 +164,10 @@
 }
 
 - (void)testEchoMessagesDefault {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesDefault"];
     NSString * channelName = @"channel";
     NSString * message1 = @"message1";
     NSString * message2 = @"message2";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesDefault"];
     
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -197,10 +197,10 @@
 }
 
 - (void)testEchoMessagesFalse {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesFalse"];
     NSString * channelName = @"channel";
     NSString * message1 = @"message1";
     NSString * message2 = @"message2";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesFalse"];
     
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.echoMessages = false;
@@ -224,7 +224,7 @@
 }
 
 - (void)testSubscribeAttaches {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendText"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendText"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"testSubscribeAttaches"];
@@ -242,9 +242,9 @@
 
 
 - (void)testMessageQueue {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testMessageQueue"];
     NSString * connectingMessage = @"connectingMessage";
     NSString * disconnectedMessage = @"disconnectedMessage";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testMessageQueue"];
 
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.autoConnect = false;
@@ -291,8 +291,8 @@
 
 
 - (void)testConnectionIdsInMessage {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testConnectionIdsInMessage"];
     NSString * channelName = @"channelName";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectionIdsInMessage"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -323,7 +323,7 @@
 }
 
 -(void) testPublishImmediate {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPublishImmediate"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishImmediate"];
     
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
@@ -350,7 +350,7 @@
 }
 
 -(void) testPublishArray {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
@@ -379,7 +379,7 @@
 }
 
 -(void) testPublishWithName {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPublishWithName"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishWithName"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
@@ -397,10 +397,10 @@
 
 
 - (void)testSubscribeToName {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToName"];
     NSString * channelName = @"channel";
     NSString * messageName =@"messageName";
     NSString * messageContent = @"content";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToName"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];

--- a/Tests/ARTRealtimePresenceHistoryTest.m
+++ b/Tests/ARTRealtimePresenceHistoryTest.m
@@ -99,7 +99,7 @@
 }
 
 -(void) runTestLimit:(int)limit forwards:(bool)forwards callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error))cb {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -138,7 +138,7 @@
 
 - (void)testPresenceHistory {
     NSString * presenceEnter = @"client_has_entered";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testSimpleText"];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -171,7 +171,7 @@
     NSString * presenceEnter1 = @"client_has_entered";
     NSString * presenceEnter2 = @"client_has_entered2";
     NSString * presenceUpdate= @"client_has_updated";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testSimpleText"];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -225,7 +225,7 @@
     NSString * presenceUpdate= @"client_has_updated";
     NSString * channelName = @"testSecondChannel";
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendEchoText"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendEchoText"];
     [self withRealtimeClientId:^(ARTRealtime *realtime1) {
         ARTRealtimeChannel *channel = [realtime1.channels get:channelName];
        
@@ -280,7 +280,7 @@
     NSString * presenceEnter1 = @"client_has_entered";
     NSString * presenceEnter2 = @"client_has_entered2";
     NSString * presenceUpdate= @"client_has_updated";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testWaitTextBackward"];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -405,7 +405,7 @@
 -(void) runTestTimeForwards:(bool) forwards limit:(int) limit callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error)) cb {
     __block long long timeOffset= 0;
     
-    XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
+    __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
     [self withRealtimeClientId:^(ARTRealtime  *realtime) {
         [realtime time:^(NSDate *time, NSError *error) {
             XCTAssert(!error);
@@ -426,7 +426,7 @@
                 [channel attach];
             }
         }];
-        XCTestExpectation *firstBatchExpectation= [self expectationWithDescription:@"firstBatchExpectation"];
+        __weak XCTestExpectation *firstBatchExpectation= [self expectationWithDescription:@"firstBatchExpectation"];
         
         int firstBatchTotal = [self firstBatchSize];
         int secondBatchTotal = [self secondBatchSize];
@@ -459,7 +459,7 @@
         sleep([ARTTestUtil bigSleep]);
         long long start = [ARTTestUtil nowMilli] + timeOffset;
 
-        XCTestExpectation * secondBatchExpectation= [self expectationWithDescription:@"secondBatchExpectation"];
+        __weak XCTestExpectation *secondBatchExpectation= [self expectationWithDescription:@"secondBatchExpectation"];
         __block int numReceived=0;
         for(int i=0;i < secondBatchTotal; i++) {
             NSString * str = [NSString stringWithFormat:@"second_updates%d", i];
@@ -479,7 +479,7 @@
 
 
         numReceived = 0;
-        XCTestExpectation *thirdBatchExpectation = [self expectationWithDescription:@"thirdBatchExpectation"];
+        __weak XCTestExpectation *thirdBatchExpectation = [self expectationWithDescription:@"thirdBatchExpectation"];
         for(int i=0;i < thirdBatchTotal; i++) {
             NSString * str = [NSString stringWithFormat:@"third_updates%d", i];
             [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
@@ -499,7 +499,7 @@
         query.limit = limit;
         query.direction = forwards ? ARTQueryDirectionForwards : ARTQueryDirectionBackwards;
 
-        XCTestExpectation *historyExpecation = [self expectationWithDescription:@"historyExpecation"];
+        __weak XCTestExpectation *historyExpecation = [self expectationWithDescription:@"historyExpecation"];
         [channel.presence history:query callback:^(ARTPaginatedResult *result, NSError *error) {
             cb(result, error);
             [historyExpecation fulfill];
@@ -542,7 +542,7 @@
 }
 
 - (void)testFromAttach {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -604,7 +604,7 @@
     NSString * presenceEnter3 = @"enter3";
     
     NSString * channelName = @"chanName";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];

--- a/Tests/ARTRealtimePresenceHistoryTest.m
+++ b/Tests/ARTRealtimePresenceHistoryTest.m
@@ -22,19 +22,15 @@
 #import "ARTDataQuery.h"
 #import "ARTRealtime+Private.h"
 
-@interface ARTRealtimePresenceHistoryTest : XCTestCase
-{
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtime2;
-    ARTRealtime * _realtime3;
+@interface ARTRealtimePresenceHistoryTest : XCTestCase {
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtime2;
+    ARTRealtime *_realtime3;
 }
+
 @end
 
 @implementation ARTRealtimePresenceHistoryTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     if (_realtime) {
@@ -57,13 +53,14 @@
     _realtime3 = nil;
     [super tearDown];
 }
--(NSString *) getClientId {
+
+- (NSString *)getClientId {
     return @"theClientId";
 }
 
 - (void)withRealtimeClientId:(void (^)(ARTRealtime *realtime))cb {
     if (!_realtime) {
-        ARTClientOptions * options = [ARTTestUtil clientOptions];
+        ARTClientOptions *options = [ARTTestUtil clientOptions];
         options.clientId = [self getClientId];
         [ARTTestUtil setupApp:options callback:^(ARTClientOptions *options) {
             if (options) {
@@ -82,23 +79,23 @@
     cb(_realtime2);
 }
 
--(NSString *) enter1Str {
+- (NSString *)enter1Str {
     return @"client_entered1";
 }
 
--(NSString *) enter2Str {
+- (NSString *)enter2Str {
     return @"client_entered2";
 }
 
--(NSString *) updateStr {
+- (NSString *)updateStr {
     return @"client_updated";
 }
 
--(NSString *) channelName {
+- (NSString *)channelName {
     return @"persisted:runTestChannelName";
 }
 
--(void) runTestLimit:(int)limit forwards:(bool)forwards callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error))cb {
+- (void)runTestLimit:(int)limit forwards:(bool)forwards callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error))cb {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
@@ -135,9 +132,8 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
 - (void)testPresenceHistory {
-    NSString * presenceEnter = @"client_has_entered";
+    NSString *presenceEnter = @"client_has_entered";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testSimpleText"];
@@ -168,9 +164,10 @@
 }
 
 - (void)testForward {
-    NSString * presenceEnter1 = @"client_has_entered";
-    NSString * presenceEnter2 = @"client_has_entered2";
-    NSString * presenceUpdate= @"client_has_updated";
+    NSString *presenceEnter1 = @"client_has_entered";
+    NSString *presenceEnter2 = @"client_has_entered2";
+    NSString *presenceUpdate= @"client_has_updated";
+
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testSimpleText"];
@@ -219,17 +216,15 @@
 }
 
 - (void)testSecondChannel {
-
-    NSString * presenceEnter1 = @"client_has_entered";
-    NSString * presenceEnter2 = @"client_has_entered2";
-    NSString * presenceUpdate= @"client_has_updated";
-    NSString * channelName = @"testSecondChannel";
+    NSString *presenceEnter1 = @"client_has_entered";
+    NSString *presenceEnter2 = @"client_has_entered2";
+    NSString *presenceUpdate= @"client_has_updated";
+    NSString *channelName = @"testSecondChannel";
 
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendEchoText"];
     [self withRealtimeClientId:^(ARTRealtime *realtime1) {
         ARTRealtimeChannel *channel = [realtime1.channels get:channelName];
-       
-    
+
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached)
             {
@@ -274,12 +269,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
-
 - (void)testWaitTextBackward {
-    NSString * presenceEnter1 = @"client_has_entered";
-    NSString * presenceEnter2 = @"client_has_entered2";
-    NSString * presenceUpdate= @"client_has_updated";
+    NSString *presenceEnter1 = @"client_has_entered";
+    NSString *presenceEnter2 = @"client_has_entered2";
+    NSString *presenceUpdate= @"client_has_updated";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testWaitTextBackward"];
@@ -328,8 +321,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testLimitForward
-{
+- (void)testLimitForward {
     [self runTestLimit:2 forwards:true callback:^(ARTPaginatedResult *result, NSError *error) {
         XCTAssert(!error);
         NSArray *messages = [result items];
@@ -355,8 +347,6 @@
         }];
     }];
 }
-
-
 
 - (void)testLimitBackward {
     [self runTestLimit:2 forwards:false callback:^(ARTPaginatedResult *result, NSError *error) {
@@ -385,24 +375,19 @@
     }];
 }
 
-
-
--(int) firstBatchSize
-{
+- (int)firstBatchSize {
     return 2;
 }
--(int) secondBatchSize
-{
+- (int)secondBatchSize {
     return 3;
 }
--(int) thirdBatchSize
-{
+
+- (int)thirdBatchSize {
     return 4;
 }
 
-
 // TODO: consider using a pattern similar to ARTTestUtil testPublish.
--(void) runTestTimeForwards:(bool) forwards limit:(int) limit callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error)) cb {
+- (void)runTestTimeForwards:(bool) forwards limit:(int) limit callback:(void (^)(ARTPaginatedResult *__art_nullable result, NSError *__art_nullable error)) cb {
     __block long long timeOffset= 0;
     
     __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
@@ -440,7 +425,7 @@
                     __block int numReceived=0;
                     for(int i=0;i < firstBatchTotal; i++)
                     {
-                        NSString * str = [NSString stringWithFormat:@"update%d", i];
+                        NSString *str = [NSString stringWithFormat:@"update%d", i];
                         [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
                             XCTAssertNil(errorInfo);
                             sleep([ARTTestUtil smallSleep]);
@@ -462,7 +447,7 @@
         __weak XCTestExpectation *secondBatchExpectation= [self expectationWithDescription:@"secondBatchExpectation"];
         __block int numReceived=0;
         for(int i=0;i < secondBatchTotal; i++) {
-            NSString * str = [NSString stringWithFormat:@"second_updates%d", i];
+            NSString *str = [NSString stringWithFormat:@"second_updates%d", i];
             [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
                 sleep([ARTTestUtil smallSleep]);
@@ -481,7 +466,7 @@
         numReceived = 0;
         __weak XCTestExpectation *thirdBatchExpectation = [self expectationWithDescription:@"thirdBatchExpectation"];
         for(int i=0;i < thirdBatchTotal; i++) {
-            NSString * str = [NSString stringWithFormat:@"third_updates%d", i];
+            NSString *str = [NSString stringWithFormat:@"third_updates%d", i];
             [channel.presence update:str callback:^(ARTErrorInfo *errorInfo) {
                 sleep([ARTTestUtil smallSleep]);
                 XCTAssertNil(errorInfo);
@@ -516,8 +501,8 @@
         XCTAssertTrue(page != nil);
         XCTAssertEqual([page count], [self secondBatchSize]);
         for(int i=0;i < [page count]; i++) {
-            NSString * goalStr = [NSString stringWithFormat:@"second_updates%d",i];
-            ARTPresenceMessage * m = [page objectAtIndex:i];
+            NSString *goalStr = [NSString stringWithFormat:@"second_updates%d",i];
+            ARTPresenceMessage *m = [page objectAtIndex:i];
             XCTAssertEqual(ARTPresenceUpdate, m.action);
             XCTAssertEqualObjects(goalStr, [m data]);
         }
@@ -528,13 +513,13 @@
     [self runTestTimeForwards:false limit:100 callback:^(ARTPaginatedResult *result, NSError *error) {
         XCTAssert(!error);
         XCTAssertFalse([result hasNext]);
-        NSArray * page = [result items];
+        NSArray *page = [result items];
         XCTAssertTrue(page != nil);
         XCTAssertEqual([page count], [self secondBatchSize]);
         int topSize = [self secondBatchSize];
         for(int i=0;i < [page count]; i++) {
-            NSString * goalStr = [NSString stringWithFormat:@"second_updates%d",topSize - i -1];
-            ARTPresenceMessage * m = [page objectAtIndex:i];
+            NSString *goalStr = [NSString stringWithFormat:@"second_updates%d",topSize - i -1];
+            ARTPresenceMessage *m = [page objectAtIndex:i];
             XCTAssertEqual(ARTPresenceUpdate, m.action);
             XCTAssertEqualObjects(goalStr, [m data]);
         }
@@ -560,7 +545,7 @@
                         [channel.presence update:[self updateStr] callback:^(ARTErrorInfo *errorInfo2) {
                             XCTAssertNil(errorInfo2);
                             [self withRealtimeClientId2:^(ARTRealtime *realtime2) {
-                                ARTRealtimeChannel * channel2 = [realtime2.channels get:[self channelName]];
+                                ARTRealtimeChannel *channel2 = [realtime2.channels get:[self channelName]];
                                 [channel2 on:^(ARTErrorInfo *errorInfo) {
                                     if(channel2.state == ARTRealtimeChannelAttached) {
                                         ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
@@ -599,24 +584,24 @@
 }
 
 - (void)testPresenceHistoryMultipleClients {
-    NSString * presenceEnter1 = @"enter1";
-    NSString * presenceEnter2 = @"enter2";
-    NSString * presenceEnter3 = @"enter3";
+    NSString *presenceEnter1 = @"enter1";
+    NSString *presenceEnter2 = @"enter2";
+    NSString *presenceEnter3 = @"enter3";
     
-    NSString * channelName = @"chanName";
+    NSString *channelName = @"chanName";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         _realtime3 = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel * c1 =[_realtime.channels get:channelName];
+        ARTRealtimeChannel *c1 =[_realtime.channels get:channelName];
         [c1.presence enter:presenceEnter1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            ARTRealtimeChannel * c2 =[_realtime2.channels get:channelName];
+            ARTRealtimeChannel *c2 =[_realtime2.channels get:channelName];
             [c2.presence enter:presenceEnter2 callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                ARTRealtimeChannel * c3 =[_realtime3.channels get:channelName];
+                ARTRealtimeChannel *c3 =[_realtime3.channels get:channelName];
                 [c3.presence enter:presenceEnter3 callback:^(ARTErrorInfo *errorInfo) {
                     XCTAssertNil(errorInfo);
                     [c1.presence history:[[ARTRealtimeHistoryQuery alloc] init] callback:^(ARTPaginatedResult *result, NSError *error) {

--- a/Tests/ARTRealtimePresenceTest.m
+++ b/Tests/ARTRealtimePresenceTest.m
@@ -24,21 +24,16 @@
 #import "ARTLog.h"
 #import "ARTCrypto.h"
 
-@interface ARTRealtimePresenceTest : XCTestCase
-{
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtime2;
-    ARTClientOptions * _options;
-    ARTRest * _rest;
+@interface ARTRealtimePresenceTest : XCTestCase {
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtime2;
+    ARTClientOptions *_options;
+    ARTRest *_rest;
 }
+
 @end
 
 @implementation ARTRealtimePresenceTest
-
-- (void)setUp {
-    [super setUp];
-
-}
 
 - (void)tearDown {
     if (_realtime) {
@@ -56,11 +51,11 @@
     [super tearDown];
 }
 
--(NSString *) getClientId {
+- (NSString *)getClientId {
     return @"theClientId";
 }
 
--(NSString *) getSecondClientId {
+- (NSString *)getSecondClientId {
     return @"secondClientId";
 }
 
@@ -133,13 +128,13 @@
 }
 
 - (void)testEnterSimple {
-    NSString * channelName = @"presTest";
+    NSString *channelName = @"presTest";
     __weak XCTestExpectation *dummyExpectation = [self expectationWithDescription:@"testEnterSimple"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         [dummyExpectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-    NSString * presenceEnter = @"client_has_entered";
+    NSString *presenceEnter = @"client_has_entered";
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         __weak XCTestExpectation *expectConnected = [self expectationWithDescription:@"expectConnected"];
 
@@ -176,7 +171,7 @@
     }];
 }
 
-- (void) testEnterAttachesTheChannel {
+- (void)testEnterAttachesTheChannel {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAttachesTheChannel"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
@@ -192,11 +187,11 @@
 }
 
 - (void)testSubscribeConnects {
-    NSString * channelName = @"presBeforeAttachTest";
+    NSString *channelName = @"presBeforeAttachTest";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
         }];
         
         [channel on:^(ARTErrorInfo *errorInfo) {
@@ -209,7 +204,7 @@
 }
 
 - (void)testUpdateConnects {
-    NSString * channelName = @"presBeforeAttachTest";
+    NSString *channelName = @"presBeforeAttachTest";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
@@ -226,12 +221,12 @@
 }
 
 - (void)testEnterBeforeConnect {
-    NSString * channelName = @"testEnterBeforeConnect";
-    NSString * presenceEnter = @"client_has_entered";
+    NSString *channelName = @"testEnterBeforeConnect";
+    NSString *presenceEnter = @"client_has_entered";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             XCTAssertEqualObjects([message data], presenceEnter);
             [expectation fulfill];
         }];
@@ -255,13 +250,13 @@
 }
 
 - (void)testEnterLeaveSimple {
-    NSString * channelName = @"testEnterLeaveSimple";
-    NSString * presenceEnter = @"client_has_entered";
-    NSString * presenceLeave = @"byebye";
+    NSString *channelName = @"testEnterLeaveSimple";
+    NSString *presenceEnter = @"client_has_entered";
+    NSString *presenceLeave = @"byebye";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
@@ -292,14 +287,14 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterEnter {
-    NSString * channelName = @"testEnterLeaveSimple";
-    NSString * presenceEnter = @"client_has_entered";
-    NSString * secondEnter = @"secondEnter";
+- (void)testEnterEnter {
+    NSString *channelName = @"testEnterLeaveSimple";
+    NSString *presenceEnter = @"client_has_entered";
+    NSString *secondEnter = @"secondEnter";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
                 [channel.presence enter:secondEnter callback:^(ARTErrorInfo *errorInfo) {
@@ -328,15 +323,15 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterUpdateSimple
+- (void)testEnterUpdateSimple
 {
-    NSString * channelName = @"testEnterLeaveSimple";
-    NSString * presenceEnter = @"client_has_entered";
-    NSString * update = @"updateMessage";
+    NSString *channelName = @"testEnterLeaveSimple";
+    NSString *presenceEnter = @"client_has_entered";
+    NSString *update = @"updateMessage";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
                 [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
@@ -365,14 +360,13 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testUpdateNull
-{
-    NSString * channelName = @"testEnterLeaveSimple";
-    NSString * presenceEnter = @"client_has_entered";
+- (void)testUpdateNull {
+    NSString *channelName = @"testEnterLeaveSimple";
+    NSString *presenceEnter = @"client_has_entered";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
                 [channel.presence update:nil callback:^(ARTErrorInfo *errorInfo) {
@@ -401,14 +395,14 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterLeaveWithoutData {
-    NSString * channelName = @"testEnterLeaveSimple";
-    NSString * presenceEnter = @"client_has_entered";
+- (void)testEnterLeaveWithoutData {
+    NSString *channelName = @"testEnterLeaveSimple";
+    NSString *presenceEnter = @"client_has_entered";
 
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], presenceEnter);
                 [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
@@ -439,12 +433,12 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testUpdateNoEnter {
-    NSString * update = @"update_message";
+- (void)testUpdateNoEnter {
+    NSString *update = @"update_message";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testUpdateNoEnter"];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], update);
                 [expectation fulfill];
@@ -470,10 +464,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterAndGet {
-    NSString * enter = @"enter";
-    NSString * enter2 = @"enter2";
-    NSString * channelName = @"channelName";
+- (void)testEnterAndGet {
+    NSString *enter = @"enter";
+    NSString *enter2 = @"enter2";
+    NSString *channelName = @"channelName";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
@@ -506,11 +500,11 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterNoClientId {
+- (void)testEnterNoClientId {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterNoClientId"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
-        ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo){
             XCTAssertNotNil(errorInfo);
             [exp fulfill];
@@ -519,10 +513,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterOnDetached {
+- (void)testEnterOnDetached {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
                 [channel detach];
@@ -539,10 +533,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testEnterOnFailed {
+- (void)testEnterOnFailed {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
                 [channel setFailed:[ARTStatus state:ARTStateError]];
@@ -561,9 +555,9 @@
 
 //TODO wortk out why presence with clientId doesnt work
 /*
--(void) testFilterPresenceByClientId {
-    NSString * channelName = @"channelName";
+- (void)testFilterPresenceByClientId {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSingleSendEchoText"];
+    NSString *channelName = @"channelName";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -592,14 +586,13 @@
 }
  */
 
--(void) testLeaveAndGet
-{
-    NSString * enter = @"enter";
-    NSString * leave = @"bye";
+- (void)testLeaveAndGet {
+    NSString *enter = @"enter";
+    NSString *leave = @"bye";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter)  {
                 XCTAssertEqualObjects([message data], enter);
                 [channel.presence leave:leave callback:^(ARTErrorInfo *errorInfo) {
@@ -633,13 +626,12 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testLeaveNoData
-{
-    NSString * enter = @"enter";
+- (void)testLeaveNoData {
+    NSString *enter = @"enter";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterLeaveNoData"];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter) {
                 XCTAssertEqualObjects([message data], enter);
                 [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
@@ -670,14 +662,12 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
--(void) testLeaveNoMessage
-{
-    NSString * enter = @"enter";
+- (void)testLeaveNoMessage {
+    NSString *enter = @"enter";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter)  {
                 XCTAssertEqualObjects([message data], enter);
                 [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
@@ -697,13 +687,13 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testLeaveWithMessage {
-    NSString * enter = @"enter";
-    NSString * leave = @"bye";
+- (void)testLeaveWithMessage {
+    NSString *enter = @"enter";
+    NSString *leave = @"bye";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             if(message.action == ARTPresenceEnter)  {
                 XCTAssertEqualObjects([message data], enter);
                 [channel.presence leave:leave callback:^(ARTErrorInfo *errorInfo) {
@@ -723,10 +713,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testLeaveOnDetached {
+- (void)testLeaveOnDetached {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
                 [channel detach];
@@ -741,10 +731,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testLeaveOnFailed {
+- (void)testLeaveOnFailed {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
             if(channel.state == ARTRealtimeChannelAttached) {
                 [channel setFailed:[ARTStatus state:ARTStateError]];
@@ -760,9 +750,9 @@
 }
 
 - (void)testEnterFailsOnError {
-    NSString * channelName = @"presBeforeAttachTest";
-    NSString * presenceEnter = @"client_has_entered";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterBeforeAttach"];
+    NSString *channelName = @"presBeforeAttachTest";
+    NSString *presenceEnter = @"client_has_entered";
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -780,10 +770,10 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testGetFailsOnDetachedOrFailed {
+- (void)testGetFailsOnDetachedOrFailed {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel * channel = [realtime.channels get:@"channel"];
+        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
         __block bool hasDisconnected = false;
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
@@ -821,9 +811,9 @@
                     XCTAssert(!error);
                     NSArray *messages = [result items];
                     XCTAssertEqual(2, messages.count);
-                    ARTPresenceMessage * m0 = [messages objectAtIndex:0];
+                    ARTPresenceMessage *m0 = [messages objectAtIndex:0];
                     XCTAssertEqualObjects(m0.clientId, clientId);
-                    ARTPresenceMessage * m1 = [messages objectAtIndex:1];
+                    ARTPresenceMessage *m1 = [messages objectAtIndex:1];
                     XCTAssertEqualObjects(m1.clientId, clientId2);
                     [exp fulfill];
                 }];
@@ -853,9 +843,9 @@
 }
 
 - (void)testWithNoClientIdUpdateLeaveEnterAnotherClient {
-    NSString * otherClientId = @"otherClientId";
-    NSString * data = @"data";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testWithNoClientIdUpdateLeaveEnterAnotherClient"];
+    NSString *otherClientId = @"otherClientId";
+    NSString *data = @"data";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = nil;
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -871,7 +861,7 @@
         }];
         
         __block int messageCount =0;
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel.presence subscribe:^(ARTPresenceMessage *message) {
             XCTAssertEqualObjects(otherClientId, message.clientId);
             if(messageCount ==0) {
                 XCTAssertEqual(message.action, ARTPresenceEnter);
@@ -911,7 +901,7 @@
             ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
             __block int numReceived = 0;
 
-            [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus * s) {
+            [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus *s) {
                 if (c == ARTRealtimeChannelAttached) {
                     //channel2 enters itself
                     [channel2.presence enterClient:@"channel2Enter" data:@"joins" callback:^(ARTErrorInfo *errorInfo) {
@@ -936,7 +926,7 @@
                     }];
                 }
             }];
-            [channel2.presence subscribe:^(ARTPresenceMessage * message) {
+            [channel2.presence subscribe:^(ARTPresenceMessage *message) {
                 numReceived++;
                 if (numReceived == count +1) {//count + channel1
                     channel2SawAllPresences = true;
@@ -956,7 +946,6 @@
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-
         [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             [options setClientId: [self getSecondClientId]];
@@ -966,11 +955,10 @@
             [channel2.presence get:^(ARTPaginatedResult *result, NSError *error) {
                 XCTAssert(!error);
                 XCTAssertFalse([channel2.presence isSyncComplete]);
-
                 [ARTTestUtil delay:1.0 block:^{
                     XCTAssertTrue([channel2.presence isSyncComplete]);
-                    ARTPresenceMap * map = channel2.presenceMap;
-                    ARTPresenceMessage * m =[map getClient:[self getClientId]];
+                    ARTPresenceMap *map = channel2.presenceMap;
+                    ARTPresenceMessage *m =[map getClient:[self getClientId]];
                     XCTAssertFalse(m == nil);
                     XCTAssertEqual(m.action, ARTPresencePresent);
                     XCTAssertEqualObjects([m data], @"hi");
@@ -983,17 +971,16 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
 //TODO work out why wait_for_sync doesnt work
 /*
--(void) testPresenceMapWaitOnSync {
-    NSString * channelName = @"channelName";
+- (void)testPresenceMapWaitOnSync {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
+    NSString *channelName = @"channelName";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence subscribeToPresence:^(ARTPresenceMessage * message) {
+        [channel.presence subscribeToPresence:^(ARTPresenceMessage *message) {
         }];
         [channel.presence publishPresenceEnter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
@@ -1003,8 +990,8 @@
             ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
             [channel2.presence getWithParams:@{@"wait_for_sync": @"true"} callback:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
                 XCTAssertNil(errorInfo);
-                ARTPresenceMap * map = channel2.presenceMap;
-                ARTPresenceMessage * m =[map getClient:[self getClientId]];
+                ARTPresenceMap *map = channel2.presenceMap;
+                ARTPresenceMessage *m =[map getClient:[self getClientId]];
                 XCTAssertFalse(m == nil);
                 XCTAssertEqual(m.action, ArtPresenceMessagePresent);
                 XCTAssertEqualObjects([m data], @"hi");
@@ -1017,10 +1004,9 @@
 }
 */
 
-
--(void) testLeaveBeforeEnterThrows {
-    NSString * channelName = @"channelName";
+- (void)testLeaveBeforeEnterThrows {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLeaveBeforeEnterThrows"];
+    NSString *channelName = @"channelName";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1039,10 +1025,10 @@
 }
 
 - (void)testSubscribeToAction {
-    NSString * channelName = @"presBeforeAttachTest";
-    NSString * enter1 = @"enter1";
-    NSString * update1 = @"update1";
-    NSString * leave1 = @"leave1";
+    NSString *channelName = @"presBeforeAttachTest";
+    NSString *enter1 = @"enter1";
+    NSString *update1 = @"update1";
+    NSString *leave1 = @"leave1";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToAction"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
@@ -1050,15 +1036,15 @@
         __block bool gotUpdate = false;
         __block bool gotEnter = false;
         __block bool gotLeave = false;
-        ARTEventListener *leaveSub = [channel.presence subscribe:ARTPresenceLeave callback:^(ARTPresenceMessage * message) {
+        ARTEventListener *leaveSub = [channel.presence subscribe:ARTPresenceLeave callback:^(ARTPresenceMessage *message) {
             XCTAssertEqualObjects([message data], leave1);
             gotLeave = true;
         }];
-        ARTEventListener *updateSub=[channel.presence subscribe:ARTPresenceUpdate callback:^(ARTPresenceMessage * message) {
+        ARTEventListener *updateSub=[channel.presence subscribe:ARTPresenceUpdate callback:^(ARTPresenceMessage *message) {
             XCTAssertEqualObjects([message data], update1);
             gotUpdate = true;
         }];
-        ARTEventListener *enterSub =[channel.presence subscribe:ARTPresenceEnter callback:^(ARTPresenceMessage * message) {
+        ARTEventListener *enterSub =[channel.presence subscribe:ARTPresenceEnter callback:^(ARTPresenceMessage *message) {
             XCTAssertEqualObjects([message data], enter1);
             gotEnter = true;
         }];
@@ -1111,7 +1097,7 @@
                     __block bool hasFailed = false;
 
                     ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
-                    [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus * s) {
+                    [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus *s) {
                         if(c == ARTRealtimeChannelAttached) {
                             //channel2 enters itself
                             [channel2.presence enterClient:@"channel2Enter" data:@"joins" callback:^(ARTErrorInfo *errorInfo) {
@@ -1155,9 +1141,9 @@
 */
 
 - (void)testPresenceNoSideEffects {
-    NSString * channelName = @"channelName";
-    NSString * client1 = @"client1";
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceNoSideEffects"];
+    NSString *channelName = @"channelName";
+    NSString *client1 = @"client1";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1194,14 +1180,14 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testPresenceWithData {
-    NSString * channelName = @"channelName";
+- (void)testPresenceWithData {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceWithData"];
+    NSString *channelName = @"channelName";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+        NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
         [channel.presence enter:dataPayload callback:^(ARTErrorInfo *errorInfo) {
              XCTAssertNil(errorInfo);
             [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
@@ -1220,10 +1206,10 @@
 }
 
 - (void)testPresenceWithDataOnLeave {
-    NSString * channelName = @"channelName";
-    NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
     __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testPresenceWithDataOnLeave1"];
     __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testPresenceWithDataOnLeave2"];
+    NSString *channelName = @"channelName";
+    NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1233,7 +1219,7 @@
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
         ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
 
-        [channel2.presence subscribe:^(ARTPresenceMessage * message) {
+        [channel2.presence subscribe:^(ARTPresenceMessage *message) {
             if (message.action == ARTPresenceLeave) {
                 XCTAssertEqualObjects([message data], dataPayload);
                 [exp1 fulfill];

--- a/Tests/ARTRealtimePresenceTest.m
+++ b/Tests/ARTRealtimePresenceTest.m
@@ -88,9 +88,9 @@
 }
 
 - (void)testTwoConnections {
-    XCTestExpectation *expectation1 = [self expectationWithDescription:@"testTwoConnections1"];
-    XCTestExpectation *expectation2 = [self expectationWithDescription:@"testTwoConnections2"];
-    XCTestExpectation *expectation3 = [self expectationWithDescription:@"testTwoConnections3"];
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"testTwoConnections1"];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"testTwoConnections2"];
+    __weak XCTestExpectation *expectation3 = [self expectationWithDescription:@"testTwoConnections3"];
     NSString *channelName = @"testSingleEcho";
     [self withRealtimeClientId:^(ARTRealtime *realtime1) {
         [self withRealtimeClientId2:^(ARTRealtime *realtime2) {
@@ -134,14 +134,14 @@
 
 - (void)testEnterSimple {
     NSString * channelName = @"presTest";
-    XCTestExpectation *dummyExpectation = [self expectationWithDescription:@"testEnterSimple"];
+    __weak XCTestExpectation *dummyExpectation = [self expectationWithDescription:@"testEnterSimple"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         [dummyExpectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
     NSString * presenceEnter = @"client_has_entered";
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        XCTestExpectation *expectConnected = [self expectationWithDescription:@"expectConnected"];
+        __weak XCTestExpectation *expectConnected = [self expectationWithDescription:@"expectConnected"];
 
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
             ARTRealtimeConnectionState state = stateChange.current;
@@ -154,7 +154,7 @@
         ARTRealtimeChannel *channel2 = [realtime.channels get:channelName];
         [channel2 attach];
         [channel attach];
-        XCTestExpectation *expectChannel2Connected = [self expectationWithDescription:@"presence message"];
+        __weak XCTestExpectation *expectChannel2Connected = [self expectationWithDescription:@"presence message"];
 
         [channel2 on:^(ARTErrorInfo *errorInfo) {
             if(channel2.state == ARTRealtimeChannelAttached) {
@@ -163,7 +163,7 @@
         }];
 
         [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-        XCTestExpectation *expectPresenceMessage = [self expectationWithDescription:@"presence message"];
+        __weak XCTestExpectation *expectPresenceMessage = [self expectationWithDescription:@"presence message"];
 
         [channel2.presence subscribe:^(ARTPresenceMessage *message) {
             [expectPresenceMessage fulfill];
@@ -177,7 +177,7 @@
 }
 
 - (void) testEnterAttachesTheChannel {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAttachesTheChannel"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAttachesTheChannel"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
         XCTAssertEqual(channel.state, ARTRealtimeChannelInitialized);
@@ -193,7 +193,7 @@
 
 - (void)testSubscribeConnects {
     NSString * channelName = @"presBeforeAttachTest";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -210,7 +210,7 @@
 
 - (void)testUpdateConnects {
     NSString * channelName = @"presBeforeAttachTest";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence update:@"update"  callback:^(ARTErrorInfo *errorInfo) {
@@ -228,7 +228,7 @@
 - (void)testEnterBeforeConnect {
     NSString * channelName = @"testEnterBeforeConnect";
     NSString * presenceEnter = @"client_has_entered";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -258,7 +258,7 @@
     NSString * channelName = @"testEnterLeaveSimple";
     NSString * presenceEnter = @"client_has_entered";
     NSString * presenceLeave = @"byebye";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -296,7 +296,7 @@
     NSString * channelName = @"testEnterLeaveSimple";
     NSString * presenceEnter = @"client_has_entered";
     NSString * secondEnter = @"secondEnter";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -333,7 +333,7 @@
     NSString * channelName = @"testEnterLeaveSimple";
     NSString * presenceEnter = @"client_has_entered";
     NSString * update = @"updateMessage";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -369,7 +369,7 @@
 {
     NSString * channelName = @"testEnterLeaveSimple";
     NSString * presenceEnter = @"client_has_entered";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -405,7 +405,7 @@
     NSString * channelName = @"testEnterLeaveSimple";
     NSString * presenceEnter = @"client_has_entered";
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -441,7 +441,7 @@
 
 -(void) testUpdateNoEnter {
     NSString * update = @"update_message";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testUpdateNoEnter"];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -474,7 +474,7 @@
     NSString * enter = @"enter";
     NSString * enter2 = @"enter2";
     NSString * channelName = @"channelName";
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -507,7 +507,7 @@
 }
 
 -(void) testEnterNoClientId {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterNoClientId"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterNoClientId"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
@@ -520,7 +520,7 @@
 }
 
 -(void) testEnterOnDetached {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
@@ -540,7 +540,7 @@
 }
 
 -(void) testEnterOnFailed {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
@@ -562,8 +562,8 @@
 //TODO wortk out why presence with clientId doesnt work
 /*
 -(void) testFilterPresenceByClientId {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSingleSendEchoText"];
     NSString * channelName = @"channelName";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSingleSendEchoText"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -596,7 +596,7 @@
 {
     NSString * enter = @"enter";
     NSString * leave = @"bye";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -636,7 +636,7 @@
 -(void) testLeaveNoData
 {
     NSString * enter = @"enter";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterLeaveNoData"];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -674,7 +674,7 @@
 -(void) testLeaveNoMessage
 {
     NSString * enter = @"enter";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -700,7 +700,7 @@
 -(void) testLeaveWithMessage {
     NSString * enter = @"enter";
     NSString * leave = @"bye";
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
         [channel.presence subscribe:^(ARTPresenceMessage * message) {
@@ -724,7 +724,7 @@
 }
 
 -(void) testLeaveOnDetached {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
@@ -742,7 +742,7 @@
 }
 
 -(void) testLeaveOnFailed {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"testEnterNoClientId"];
         [channel on:^(ARTErrorInfo *errorInfo) {
@@ -760,9 +760,9 @@
 }
 
 - (void)testEnterFailsOnError {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterBeforeAttach"];
     NSString * channelName = @"presBeforeAttachTest";
     NSString * presenceEnter = @"client_has_entered";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterBeforeAttach"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -781,7 +781,7 @@
 }
 
 -(void) testGetFailsOnDetachedOrFailed {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel * channel = [realtime.channels get:@"channel"];
         __block bool hasDisconnected = false;
@@ -809,7 +809,7 @@
     NSString *clientId = @"otherClientId";
     NSString *clientId2 = @"yetAnotherClientId";
 
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClient"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClient"];
     [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
         _realtime = realtime;
         ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
@@ -834,7 +834,7 @@
 }
 
 - (void)testEnterClientIdFailsOnError {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClientIdFailsOnError"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClientIdFailsOnError"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
         [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
@@ -853,9 +853,9 @@
 }
 
 - (void)testWithNoClientIdUpdateLeaveEnterAnotherClient {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testWithNoClientIdUpdateLeaveEnterAnotherClient"];
     NSString * otherClientId = @"otherClientId";
     NSString * data = @"data";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testWithNoClientIdUpdateLeaveEnterAnotherClient"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = nil;
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -896,7 +896,7 @@
 - (void)test250ClientsEnter {
     NSString *channelName = @"channelName";
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"setupChannel2"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"setupChannel2"];
     ARTClientOptions *options =[ARTTestUtil clientOptions];
     options.clientId = @"client_string";
 
@@ -950,8 +950,8 @@
 */
 
 - (void)testPresenceMap {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
     NSString * channelName = @"channelName";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -987,8 +987,8 @@
 //TODO work out why wait_for_sync doesnt work
 /*
 -(void) testPresenceMapWaitOnSync {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
     NSString * channelName = @"channelName";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1019,8 +1019,8 @@
 
 
 -(void) testLeaveBeforeEnterThrows {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testLeaveBeforeEnterThrows"];
     NSString * channelName = @"channelName";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLeaveBeforeEnterThrows"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1043,7 +1043,7 @@
     NSString * enter1 = @"enter1";
     NSString * update1 = @"update1";
     NSString * leave1 = @"leave1";
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToAction"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToAction"];
     [self withRealtimeClientId:^(ARTRealtime *realtime) {
         ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         
@@ -1091,7 +1091,7 @@
 - (void)testSyncResumes {
     NSString *channelName = @"channelName";
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"enterAll"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"enterAll"];
     ARTClientOptions *options = [ARTTestUtil clientOptions];
     options.clientId = @"client_string";
 
@@ -1155,9 +1155,9 @@
 */
 
 - (void)testPresenceNoSideEffects {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceNoSideEffects"];
     NSString * channelName = @"channelName";
     NSString * client1 = @"client1";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceNoSideEffects"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1195,8 +1195,8 @@
 }
 
 -(void) testPresenceWithData {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceWithData"];
     NSString * channelName = @"channelName";
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceWithData"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
@@ -1220,10 +1220,10 @@
 }
 
 - (void)testPresenceWithDataOnLeave {
-    XCTestExpectation *exp1 = [self expectationWithDescription:@"testPresenceWithDataOnLeave1"];
-    XCTestExpectation *exp2 = [self expectationWithDescription:@"testPresenceWithDataOnLeave2"];
     NSString * channelName = @"channelName";
     NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+    __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testPresenceWithDataOnLeave1"];
+    __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testPresenceWithDataOnLeave2"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = [self getClientId];
         _realtime = [[ARTRealtime alloc] initWithOptions:options];

--- a/Tests/ARTRealtimeRecoverTest.m
+++ b/Tests/ARTRealtimeRecoverTest.m
@@ -18,18 +18,15 @@
 #import "ARTEventEmitter.h"
 
 @interface ARTRealtimeRecoverTest : XCTestCase {
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtimeRecover;
-    ARTRealtime * _realtimeNonRecovered;
-    ARTClientOptions * _options;
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtimeRecover;
+    ARTRealtime *_realtimeNonRecovered;
+    ARTClientOptions *_options;
 }
+
 @end
 
 @implementation ARTRealtimeRecoverTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     if (_realtime) {
@@ -62,9 +59,9 @@
 }
 
 - (void)testRecoverDisconnected {
-    NSString * channelName = @"chanName";
-    NSString * c1Message = @"c1 says hi";
-    NSString * c2Message= @"c2 says hi";
+    NSString *channelName = @"chanName";
+    NSString *c1Message = @"c1 says hi";
+    NSString *c2Message= @"c2 says hi";
 
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {

--- a/Tests/ARTRealtimeRecoverTest.m
+++ b/Tests/ARTRealtimeRecoverTest.m
@@ -66,7 +66,7 @@
     NSString * c1Message = @"c1 says hi";
     NSString * c2Message= @"c2 says hi";
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
 
@@ -120,7 +120,7 @@
 }
 
 - (void)testRecoverFails {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testRecoverDisconnected"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.recover = @"bad_recovery_key:1234";
         _realtimeRecover = [[ARTRealtime alloc] initWithOptions:options];

--- a/Tests/ARTRealtimeResumeTest.m
+++ b/Tests/ARTRealtimeResumeTest.m
@@ -49,12 +49,12 @@
 }
 
 -(void) testSimpleDisconnected {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
     NSString * channelName = @"resumeChannel";
     NSString * message1 = @"message1";
     NSString * message2 = @"message2";
     NSString * message3 = @"message3";
     NSString * message4 = @"message4";
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];

--- a/Tests/ARTRealtimeResumeTest.m
+++ b/Tests/ARTRealtimeResumeTest.m
@@ -19,18 +19,14 @@
 #import "ARTTestUtil.h"
 #import "ARTRealtime+Private.h"
 
-@interface ARTRealtimeResumeTest : XCTestCase
-{
-    ARTRealtime * _realtime;
-    ARTRealtime * _realtime2;
+@interface ARTRealtimeResumeTest : XCTestCase {
+    ARTRealtime *_realtime;
+    ARTRealtime *_realtime2;
 }
+
 @end
 
 @implementation ARTRealtimeResumeTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     if (_realtime) {
@@ -48,13 +44,13 @@
     [super tearDown];
 }
 
--(void) testSimpleDisconnected {
-    NSString * channelName = @"resumeChannel";
-    NSString * message1 = @"message1";
-    NSString * message2 = @"message2";
-    NSString * message3 = @"message3";
-    NSString * message4 = @"message4";
+- (void)testSimpleDisconnected {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
+    NSString *channelName = @"resumeChannel";
+    NSString *message1 = @"message1";
+    NSString *message2 = @"message2";
+    NSString *message3 = @"message3";
+    NSString *message4 = @"message4";
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         _realtime = [[ARTRealtime alloc] initWithOptions:options];
         _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
@@ -76,8 +72,8 @@
                 }];
             }
         }];
-        [channel subscribe:^(ARTMessage * message) {
-            NSString * msg = [message data];
+        [channel subscribe:^(ARTMessage *message) {
+            NSString *msg = [message data];
             if([msg isEqualToString:message2]) {
                 //disconnect connection1
                 [_realtime onError:[ARTTestUtil newErrorProtocolMessage]];

--- a/Tests/ARTRestCapabilityTest.m
+++ b/Tests/ARTRestCapabilityTest.m
@@ -66,8 +66,8 @@
 }
 
 - (void)testPublishRestricted {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
     [self withRestRestrictCap:^(ARTRest * rest) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
         ARTRestChannel *channel = [rest.channels get:@"canpublish:test"];
         [channel publish:nil data:@"publish" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);

--- a/Tests/ARTRestCapabilityTest.m
+++ b/Tests/ARTRestCapabilityTest.m
@@ -29,10 +29,6 @@
 
 @implementation ARTRestCapabilityTest
 
-- (void)setUp {
-    [super setUp];
-}
-
 - (void)tearDown {
     _rest = nil;
     [super tearDown];
@@ -40,7 +36,7 @@
 
 - (void)withRestRestrictCap:(void (^)(ARTRest *rest))cb {
     if (!_rest) {
-        ARTClientOptions * theOptions = [ARTTestUtil clientOptions];
+        ARTClientOptions *theOptions = [ARTTestUtil clientOptions];
         [ARTTestUtil setupApp:theOptions withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
             if (options) {
                 options.clientId = @"client_string";
@@ -66,8 +62,8 @@
 }
 
 - (void)testPublishRestricted {
-    [self withRestRestrictCap:^(ARTRest * rest) {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
+    [self withRestRestrictCap:^(ARTRest *rest) {
         ARTRestChannel *channel = [rest.channels get:@"canpublish:test"];
         [channel publish:nil data:@"publish" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);

--- a/Tests/ARTRestChannelHistoryTest.m
+++ b/Tests/ARTRestChannelHistoryTest.m
@@ -18,18 +18,14 @@
 #import "ARTDataQuery.h"
 #import "ARTPaginatedResult.h"
 
-@interface ARTRestChannelHistoryTest : XCTestCase
-{
+@interface ARTRestChannelHistoryTest : XCTestCase {
     ARTRest *_rest;
     ARTRest *_rest2;
 }
+
 @end
 
 @implementation ARTRestChannelHistoryTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     [super tearDown];
@@ -87,9 +83,9 @@
                                 XCTAssertTrue(page != nil);
                                 XCTAssertEqual([page count], secondBatchTotal);
                                 for (int i=0; i < [page count]; i++) {
-                                    NSString * pattern = [secondBatch stringByAppendingString:@"%d"];
-                                    NSString * goalStr = [NSString stringWithFormat:pattern, secondBatchTotal -1 -i];
-                                    ARTMessage * m = [page objectAtIndex:i];
+                                    NSString *pattern = [secondBatch stringByAppendingString:@"%d"];
+                                    NSString *goalStr = [NSString stringWithFormat:pattern, secondBatchTotal -1 -i];
+                                    ARTMessage *m = [page objectAtIndex:i];
                                     XCTAssertEqualObjects(goalStr, [m data]);
                                 }
                                 [firstExpectation fulfill];
@@ -201,28 +197,28 @@
 
                 [result next:^(ARTPaginatedResult *result2, NSError *error) {
                     XCTAssert(!error);
-                    NSArray * page = [result2 items];
+                    NSArray *page = [result2 items];
                     XCTAssertEqual([page count], 2);
-                    //ARTMessage * firstMessage = [page objectAtIndex:0];
-                    //ARTMessage * secondMessage =[page objectAtIndex:1];
+                    //ARTMessage *firstMessage = [page objectAtIndex:0];
+                    //ARTMessage *secondMessage =[page objectAtIndex:1];
                     //XCTAssertEqualObjects(@"testString2", [firstMessage data]);
                     //XCTAssertEqualObjects(@"testString3", [secondMessage data]);
 
                     [result2 next:^(ARTPaginatedResult *result3, NSError *error) {
                         XCTAssert(!error);
                         XCTAssertFalse([result3 hasNext]);
-                        NSArray * page = [result3 items];
+                        NSArray *page = [result3 items];
                         XCTAssertEqual([page count], 1);
-                        //ARTMessage * firstMessage = [page objectAtIndex:0];
+                        //ARTMessage *firstMessage = [page objectAtIndex:0];
                         //XCTAssertEqualObjects(@"testString4", [firstMessage data]);
 
                         [result3 first:^(ARTPaginatedResult *result4, NSError *error) {
                             XCTAssert(!error);
                             XCTAssertTrue([result4 hasNext]);
-                            NSArray * page = [result4 items];
+                            NSArray *page = [result4 items];
                             XCTAssertEqual([page count], 2);
-                            //ARTMessage * firstMessage = [page objectAtIndex:0];
-                            //ARTMessage * secondMessage =[page objectAtIndex:1];
+                            //ARTMessage *firstMessage = [page objectAtIndex:0];
+                            //ARTMessage *secondMessage =[page objectAtIndex:1];
                             //XCTAssertEqualObjects(@"testString0", [firstMessage data]);
                             //XCTAssertEqualObjects(@"testString1", [secondMessage data]);
                             [firstExpectation fulfill];
@@ -255,19 +251,19 @@
             [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                 XCTAssert(!error);
                 XCTAssertTrue([result hasNext]);
-                NSArray * page = [result items];
+                NSArray *page = [result items];
                 XCTAssertEqual([page count], 2);
-                ARTMessage * firstMessage = [page objectAtIndex:0];
-                ARTMessage * secondMessage =[page objectAtIndex:1];
+                ARTMessage *firstMessage = [page objectAtIndex:0];
+                ARTMessage *secondMessage =[page objectAtIndex:1];
                 XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                 XCTAssertEqualObjects(@"testString3", [secondMessage data]);
 
                 [result next:^(ARTPaginatedResult *result2, NSError *error) {
                     XCTAssert(!error);
-                    NSArray * page = [result2 items];
+                    NSArray *page = [result2 items];
                     XCTAssertEqual([page count], 2);
-                    ARTMessage * firstMessage = [page objectAtIndex:0];
-                    ARTMessage * secondMessage =[page objectAtIndex:1];
+                    ARTMessage *firstMessage = [page objectAtIndex:0];
+                    ARTMessage *secondMessage =[page objectAtIndex:1];
 
                     XCTAssertEqualObjects(@"testString2", [firstMessage data]);
                     XCTAssertEqualObjects(@"testString1", [secondMessage data]);
@@ -275,18 +271,18 @@
                     [result2 next:^(ARTPaginatedResult *result3, NSError *error) {
                         XCTAssert(!error);
                         XCTAssertFalse([result3 hasNext]);
-                        NSArray * page = [result3 items];
+                        NSArray *page = [result3 items];
                         XCTAssertEqual([page count], 1);
-                        ARTMessage * firstMessage = [page objectAtIndex:0];
+                        ARTMessage *firstMessage = [page objectAtIndex:0];
                         XCTAssertEqualObjects(@"testString0", [firstMessage data]);
 
                         [result3 first:^(ARTPaginatedResult *result4, NSError *error) {
                             XCTAssert(!error);
                             XCTAssertTrue([result4 hasNext]);
-                            NSArray * page = [result4 items];
+                            NSArray *page = [result4 items];
                             XCTAssertEqual([page count], 2);
-                            ARTMessage * firstMessage = [page objectAtIndex:0];
-                            ARTMessage * secondMessage =[page objectAtIndex:1];
+                            ARTMessage *firstMessage = [page objectAtIndex:0];
+                            ARTMessage *secondMessage =[page objectAtIndex:1];
                             XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                             XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                             [firstExpectation fulfill];
@@ -318,10 +314,10 @@
             [channel history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                 XCTAssert(!error);
                 XCTAssertTrue([result hasNext]);
-                NSArray * page = [result items];
+                NSArray *page = [result items];
                 XCTAssertEqual([page count], 2);
-                ARTMessage * firstMessage = [page objectAtIndex:0];
-                ARTMessage * secondMessage =[page objectAtIndex:1];
+                ARTMessage *firstMessage = [page objectAtIndex:0];
+                ARTMessage *secondMessage =[page objectAtIndex:1];
                 XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                 XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                 [firstExpectation fulfill];
@@ -331,7 +327,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testHistoryTwoClients {
+- (void)testHistoryTwoClients {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [expectation fulfill];
@@ -357,10 +353,10 @@
             [channelTwo history:query callback:^(ARTPaginatedResult *result, NSError *error) {
                 XCTAssert(!error);
                 XCTAssertTrue([result hasNext]);
-                NSArray * page = [result items];
+                NSArray *page = [result items];
                 XCTAssertEqual([page count], 2);
-                ARTMessage * firstMessage = [page objectAtIndex:0];
-                ARTMessage * secondMessage =[page objectAtIndex:1];
+                ARTMessage *firstMessage = [page objectAtIndex:0];
+                ARTMessage *secondMessage =[page objectAtIndex:1];
                 XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                 XCTAssertEqualObjects(@"testString3", [secondMessage data]);
                 [firstExpectation fulfill];

--- a/Tests/ARTRestChannelHistoryTest.m
+++ b/Tests/ARTRestChannelHistoryTest.m
@@ -40,7 +40,7 @@
 - (void)testTimeBackwards {
     __block long long timeOffset = 0;
     
-    XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
+    __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         [rest time:^(NSDate *time, NSError *error) {
@@ -53,7 +53,7 @@
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
     
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"firstExpectation"];
+    __weak XCTestExpectation *firstExpectation = [self expectationWithDescription:@"firstExpectation"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"testTimeBackwards"];
@@ -106,7 +106,7 @@
 - (void)testTimeForwards {
     __block long long timeOffset = 0;
     
-    XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
+    __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         [rest time:^(NSDate *time, NSError *error) {
@@ -119,7 +119,7 @@
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"getTime"];
+    __weak XCTestExpectation *firstExpectation = [self expectationWithDescription:@"getTime"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"test_history_time_forwards"];
@@ -172,13 +172,13 @@
 }
 
 - (void)testHistoryForwardPagination {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryForwardPagination"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryForwardPagination"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
     
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
+    __weak XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testHistoryForwardPagination"];
@@ -236,13 +236,13 @@
 }
 
 - (void)testHistoryBackwardPagination {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
+    __weak XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testHistoryBackwardPagination"];
@@ -300,13 +300,13 @@
 }
 
 - (void)testHistoryBackwardDefault {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
+    __weak XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testHistoryBackwardDefault"];
@@ -332,14 +332,14 @@
 }
 
 -(void) testHistoryTwoClients {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"e"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
     NSString *channelName = @"testHistoryTwoClients";
-    XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
+    __weak XCTestExpectation *firstExpectation = [self expectationWithDescription:@"send_second_batch"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
@@ -371,7 +371,7 @@
 }
 
 - (void)testHistoryLimit {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channelOne = [rest.channels get:@"name"];
@@ -390,7 +390,7 @@
 }
 
 - (void)testHistoryLimitIgnoringError {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channelOne = [rest.channels get:@"name"];

--- a/Tests/ARTRestChannelPublishTest.m
+++ b/Tests/ARTRestChannelPublishTest.m
@@ -22,13 +22,10 @@
 @interface ARTRestChannelPublishTest : XCTestCase {
     ARTRest *_rest;
 }
+
 @end
 
 @implementation ARTRestChannelPublishTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     [super tearDown];
@@ -36,10 +33,9 @@
 }
 
 - (void)testTypesByText {
-
-    NSString * message1 = @"message1";
-    NSString * message2 = @"message2";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
+    NSString *message1 = @"message1";
+    NSString *message2 = @"message2";
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testTypesByText"];
@@ -65,7 +61,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testPublishArray {
+- (void)testPublishArray {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;

--- a/Tests/ARTRestChannelPublishTest.m
+++ b/Tests/ARTRestChannelPublishTest.m
@@ -37,9 +37,9 @@
 
 - (void)testTypesByText {
 
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     NSString * message1 = @"message1";
     NSString * message2 = @"message2";
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testTypesByText"];
@@ -66,7 +66,7 @@
 }
 
 -(void) testPublishArray {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"channel"];
@@ -98,7 +98,7 @@
 }
 
 - (void)testPublishUnJsonableType {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTChannel *channel = [rest.channels get:@"testTypesByText"];

--- a/Tests/ARTRestCryptoTest.m
+++ b/Tests/ARTRestCryptoTest.m
@@ -28,34 +28,30 @@
 
 @implementation ARTRestCryptoTest
 
-- (void)setUp {    
-    [super setUp];
-}
-
 - (void)tearDown {
     _rest = nil;
     [super tearDown];
 }
 
--(void) testSendBinary {
+- (void)testSendBinary {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest =rest;
-        ARTChannel * c = [rest.channels get:@"test"];
+        ARTChannel *c = [rest.channels get:@"test"];
         XCTAssert(c);
-        NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-        NSString * stringPayload = @"someString";
+        NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+        NSString *stringPayload = @"someString";
         [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
                 XCTAssert(!error);
                 [c history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
-                    NSArray * page = [result items];
+                    NSArray *page = [result items];
                     XCTAssertTrue(page != nil);
                     XCTAssertEqual([page count], 2);
-                    ARTMessage * stringMessage = [page objectAtIndex:0];
-                    ARTMessage * dataMessage = [page objectAtIndex:1];
+                    ARTMessage *stringMessage = [page objectAtIndex:0];
+                    ARTMessage *dataMessage = [page objectAtIndex:1];
                     XCTAssertEqualObjects([dataMessage data], dataPayload);
                     XCTAssertEqualObjects([stringMessage data], stringPayload);
                     [exp fulfill];
@@ -66,32 +62,32 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void) testSendEncodedMessage {
+- (void)testSendEncodedMessage {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest =rest;
         
-        NSData * ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
     
-        NSData * keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+        NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
         ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
         ARTChannelOptions *channelOptions = [[ARTChannelOptions alloc] initWithCipher:params];
 
         ARTRestChannel *c = [rest.channels get:@"test" options:channelOptions];
         XCTAssert(c);
-        NSData * dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-        NSString * stringPayload = @"someString";
+        NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+        NSString *stringPayload = @"someString";
         [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
                 XCTAssert(!error);
                 [c history:^(ARTPaginatedResult *result, NSError *error) {
                     XCTAssert(!error);
-                    NSArray * page = [result items];
+                    NSArray *page = [result items];
                     XCTAssertTrue(page != nil);
                     XCTAssertEqual([page count], 2);
-                    ARTMessage * stringMessage = [page objectAtIndex:0];
-                    ARTMessage * dataMessage = [page objectAtIndex:1];
+                    ARTMessage *stringMessage = [page objectAtIndex:0];
+                    ARTMessage *dataMessage = [page objectAtIndex:1];
                     XCTAssertEqualObjects([dataMessage data], dataPayload);
                     XCTAssertEqualObjects([stringMessage data], stringPayload);
                     [exp fulfill];
@@ -102,48 +98,4 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
-
-/*
-- (void)testPublishText256 {
-    XCTFail(@"TODO write test");
-}
-
-
-
-
-- (void)testPublishKeyMismatch {
-    XCTFail(@"TODO write test");
-}
-
-
-- (void)testEncrypedUnHandled {
-    XCTFail(@"TODO write test");
-}
-
-
- - (void)testSendUnencrypted {
- XCTFail(@"TODO write test");
- }
- */
-
-/*
- //msgpack not implemented
-- (void)testBinaryAndText {
-    XCTFail(@"TODO write test");
-}
-
-- (void)testBinary256 {
-    XCTFail(@"TODO write test");
-}
-
-- (void)testTextAndBinary {
-    XCTFail(@"TODO write test");
-}
-
-- (void)testPublishBinary {
-    XCTFail(@"TODO write test");
-}
-
-*/
 @end

--- a/Tests/ARTRestCryptoTest.m
+++ b/Tests/ARTRestCryptoTest.m
@@ -38,7 +38,7 @@
 }
 
 -(void) testSendBinary {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest =rest;
         ARTChannel * c = [rest.channels get:@"test"];
@@ -67,7 +67,7 @@
 }
 
 -(void) testSendEncodedMessage {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest =rest;
         

--- a/Tests/ARTRestInitTest.m
+++ b/Tests/ARTRestInitTest.m
@@ -21,24 +21,20 @@
 #import "ARTChannel.h"
 #import "ARTChannels.h"
 
-
 @interface ARTRestInitTest : XCTestCase {
     ARTRest *_rest;
 }
+
 @end
 
 @implementation ARTRestInitTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     _rest = nil;
     [super tearDown];
 }
 
--(void)testInternetIsUp {
+- (void)testInternetIsUp {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInternetIsUp"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [rest internetIsUp:^(bool isUp) {
@@ -49,7 +45,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testInitWithKey {
+- (void)testInitWithKey {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKey"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         @try {
@@ -70,18 +66,18 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testInitWithNoKey {
-    NSString * key = @"";
+- (void)testInitWithNoKey {
+    NSString *key = @"";
     XCTAssertThrows([[ARTRest alloc] initWithKey:key]);
 }
 
--(void)testInitWithKeyBad {
+- (void)testInitWithKeyBad {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKeyBad"];
     @try {
         [ARTClientOptions setDefaultEnvironment:@"sandbox"];
-        ARTRest * rest = [[ARTRest alloc] initWithKey:@"badkey:secret"];
+        ARTRest *rest = [[ARTRest alloc] initWithKey:@"badkey:secret"];
         _rest = rest;
-        ARTChannel * c = [rest.channels get:@"test"];
+        ARTChannel *c = [rest.channels get:@"test"];
         XCTAssert(c);
         [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
             XCTAssert(error);
@@ -95,30 +91,13 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testInitWithOptions {
+- (void)testInitWithOptions {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
+        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
-       ARTChannel * c = [rest.channels get:@"test"];
-       XCTAssert(c);
-       [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
-           XCTAssert(!error);
-           [exp fulfill];
-       }];
-   }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-
--(void)testInitWithOptionsEnvironment {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTClientOptions *envOptions = [[ARTClientOptions alloc] init];
-        envOptions.key = options.key;
-        envOptions.environment = @"sandbox";
-        ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTChannel * c = [rest.channels get:@"test"];
+        ARTChannel *c = [rest.channels get:@"test"];
+        XCTAssert(c);
         [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
             [exp fulfill];
@@ -127,16 +106,33 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testGetAuth {
+- (void)testInitWithOptionsEnvironment {
     __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
+        ARTClientOptions *envOptions = [[ARTClientOptions alloc] init];
+        envOptions.key = options.key;
+        envOptions.environment = @"sandbox";
+        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
-        ARTChannel * c = [rest.channels get:@"test"];
+        ARTChannel *c = [rest.channels get:@"test"];
+        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
+            XCTAssert(!error);
+            [exp fulfill];
+        }];
+    }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+}
+
+- (void)testGetAuth {
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
+        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+        _rest = rest;
+        ARTChannel *c = [rest.channels get:@"test"];
         XCTAssert(c);
         [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
-            ARTAuth * auth = rest.auth;
+            ARTAuth *auth = rest.auth;
             XCTAssert(auth);
             ARTAuthOptions *authOptions = auth.options;
             XCTAssertEqual(authOptions.key, options.key);
@@ -147,7 +143,7 @@
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
--(void)testInitWithOptionsBad {
+- (void)testInitWithOptionsBad {
     XCTAssertThrows([[ARTClientOptions alloc] initWithKey:@"bad"]);
     XCTAssertThrows([[ARTRest alloc] initWithOptions:[[ARTClientOptions alloc] init]]);
 }

--- a/Tests/ARTRestInitTest.m
+++ b/Tests/ARTRestInitTest.m
@@ -39,7 +39,7 @@
 }
 
 -(void)testInternetIsUp {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testInternetIsUp"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInternetIsUp"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         [rest internetIsUp:^(bool isUp) {
             XCTAssertTrue(isUp);
@@ -50,7 +50,7 @@
 }
 
 -(void)testInitWithKey {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKey"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKey"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         @try {
             [ARTClientOptions setDefaultEnvironment:@"sandbox"];
@@ -76,7 +76,7 @@
 }
 
 -(void)testInitWithKeyBad {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKeyBad"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKeyBad"];
     @try {
         [ARTClientOptions setDefaultEnvironment:@"sandbox"];
         ARTRest * rest = [[ARTRest alloc] initWithKey:@"badkey:secret"];
@@ -96,7 +96,7 @@
 }
 
 -(void)testInitWithOptions {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
@@ -111,7 +111,7 @@
 }
 
 -(void)testInitWithOptionsEnvironment {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTClientOptions *envOptions = [[ARTClientOptions alloc] init];
         envOptions.key = options.key;
@@ -128,7 +128,7 @@
 }
 
 -(void)testGetAuth {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
@@ -153,7 +153,7 @@
 }
 
 - (void)testRestTime {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testRestTime"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testRestTime"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         [rest time:^(NSDate *date, NSError *error) {

--- a/Tests/ARTRestPresenceTest.m
+++ b/Tests/ARTRestPresenceTest.m
@@ -23,13 +23,10 @@
 @interface ARTRestPresenceTest : XCTestCase {
     ARTRest *_rest;
 }
+
 @end
 
 @implementation ARTRestPresenceTest
-
-- (void)setUp {
-    [super setUp];
-}
 
 - (void)tearDown {
     _rest = nil;
@@ -105,7 +102,7 @@
             XCTAssert(!error);
             NSArray *presence = [result items];
             XCTAssertEqual(6, [presence count]);
-            ARTPresenceMessage * m = [presence objectAtIndex:[presence count] -1];
+            ARTPresenceMessage *m = [presence objectAtIndex:[presence count] -1];
             XCTAssertEqualObjects(@"true", [m data]);
             [expectation fulfill];
         } error:nil];
@@ -124,7 +121,7 @@
             XCTAssert(!error);
             NSArray *presence = [result items];
             XCTAssertEqual(6, [presence count]);
-            ARTPresenceMessage * m = [presence objectAtIndex:0];
+            ARTPresenceMessage *m = [presence objectAtIndex:0];
             XCTAssertEqualObjects(@"true", [m data]);
             [expectation fulfill];
         } error:nil];

--- a/Tests/ARTRestPresenceTest.m
+++ b/Tests/ARTRestPresenceTest.m
@@ -37,7 +37,7 @@
 }
 
 - (void)testPresence {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
@@ -82,7 +82,7 @@
 }
 
 - (void)testHistory {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
@@ -97,7 +97,7 @@
 }
 
 - (void)testHistoryDefaultBackwards {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
@@ -114,7 +114,7 @@
 }
 
 - (void)testHistoryDirection {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
@@ -133,7 +133,7 @@
 }
 
 - (void)testPresenceLimit {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channelOne = [rest.channels get:@"name"];
@@ -150,7 +150,7 @@
 }
 
 - (void)testPresenceLimitIgnoringError {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
     [ARTTestUtil testRest:^(ARTRest *rest) {
         _rest = rest;
         ARTRestChannel *channelOne = [rest.channels get:@"name"];

--- a/Tests/ARTRestTokenTest.m
+++ b/Tests/ARTRestTokenTest.m
@@ -30,10 +30,6 @@
 
 @implementation ARTRestTokenTest
 
-- (void)setUp {
-    [super setUp];
-}
-
 - (void)tearDown {
     _rest = nil;
     _rest2 = nil;
@@ -45,9 +41,9 @@
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
-        ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
+        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
-        ARTAuth * auth = rest.auth;
+        ARTAuth *auth = rest.auth;
         XCTAssertEqual(auth.method, ARTAuthMethodToken);
         ARTRestChannel *c = [rest.channels get:@"getChannel"];
         [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
@@ -64,11 +60,11 @@
         options.useTokenAuth = true;
         options.clientId = @"testToken";
         options.token = @"this_is_a_bad_token";
-        ARTRest * rest = [[ARTRest alloc] initWithOptions:options];
+        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
         _rest = rest;
-        ARTAuth * auth = rest.auth;
+        ARTAuth *auth = rest.auth;
         XCTAssertEqual(auth.method, ARTAuthMethodToken);
-        ARTChannel * c= [rest.channels get:@"getChannel"];
+        ARTChannel *c= [rest.channels get:@"getChannel"];
         [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
             XCTAssert(error);
             [expectation fulfill];
@@ -113,11 +109,11 @@
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
-        ARTRest * firstRest = [[ARTRest alloc] initWithOptions:options];
+        ARTRest *firstRest = [[ARTRest alloc] initWithOptions:options];
         _rest = firstRest;
-        ARTAuth * auth = firstRest.auth;
+        ARTAuth *auth = firstRest.auth;
         //options.authCallback = [auth getTheAuthCb]; //?!
-        ARTRest * secondRest = [[ARTRest alloc] initWithOptions:options];
+        ARTRest *secondRest = [[ARTRest alloc] initWithOptions:options];
         _rest2 = secondRest;
         XCTAssertEqual(auth.method, ARTAuthMethodToken);
         ARTChannel *c = [secondRest.channels get:@"getChannel"];

--- a/Tests/ARTRestTokenTest.m
+++ b/Tests/ARTRestTokenTest.m
@@ -41,7 +41,7 @@
 }
 
 - (void)testTokenSimple {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testRestTimeBadHost"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testRestTimeBadHost"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
@@ -59,7 +59,7 @@
 }
 
 - (void)testInitWithBadToken {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";
@@ -78,7 +78,7 @@
 }
 
 -(void)testAuthURLForcesToken {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testClientIdForcesToken"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testClientIdForcesToken"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.authUrl = [NSURL URLWithString:@"some_url"];
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
@@ -91,7 +91,7 @@
 }
 
 -(void)testTTLDefaultOneHour {
-    XCTestExpectation *exp = [self expectationWithDescription:@"testTTLDefaultOneHour"];
+    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testTTLDefaultOneHour"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.clientId = @"clientIdThatForcesToken";
         ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
@@ -109,7 +109,7 @@
 }
 
 - (void)testInitWithBorrowedAuthCb {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
     [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
         options.useTokenAuth = true;
         options.clientId = @"testToken";

--- a/Tests/ARTTestUtil.h
+++ b/Tests/ARTTestUtil.h
@@ -43,22 +43,10 @@ typedef NS_ENUM(NSUInteger, TestAlteration) {
 
 typedef void (^ARTRestConstructorCb)(ARTRest *rest);
 typedef void (^ARTRealtimeConstructorCb)(ARTRealtime *realtime);
-typedef void (^ARTRealtimeTestCallback)(ARTRealtime *realtime, ARTRealtimeConnectionState state, XCTestExpectation *expectation);
 
 + (void)testRest:(ARTRestConstructorCb)cb;
-
 + (void)testRealtime:(ARTClientOptions *)options callback:(ARTRealtimeConstructorCb)cb;
-
-// FIXME: try to unify testRealtime, testRealtimeV2 and others that are private
 + (void)testRealtime:(ARTRealtimeConstructorCb)cb;
-
-/**
- New RealtimeClient instance
-
- Creates implicitly a XCTestExpectation.
- The callback is called only if the RealtimeClient gets connected.
- */
-+ (void)testRealtimeV2:(XCTestCase *)testCase withDebug:(BOOL)debug callback:(ARTRealtimeTestCallback)callback;
 
 + (void)repeat:(int)count i:(int)i delay:(NSTimeInterval)delay block:(void (^)(int))block;
 + (void)repeat:(int)count delay:(NSTimeInterval)delay block:(void (^)(int))block ;

--- a/Tests/ARTTestUtil.m
+++ b/Tests/ARTTestUtil.m
@@ -193,7 +193,7 @@
 + (void)publishRealtimeMessages:(NSString *)prefix count:(int)count channel:(ARTRealtimeChannel *)channel completion:(void (^)())completion {
     __block int numReceived = 0;
     __block __weak void (^weakCb)(ARTErrorInfo *__art_nullable error);
-    NSString * pattern = [prefix stringByAppendingString:@"%d"];
+    NSString *pattern = [prefix stringByAppendingString:@"%d"];
     void (^cb)(ARTErrorInfo *__art_nullable error);
     
     weakCb = cb = ^(ARTErrorInfo *errorInfo) {

--- a/Tests/ARTTestUtil.m
+++ b/Tests/ARTTestUtil.m
@@ -248,32 +248,6 @@
     }];
 }
 
-+ (void)testRealtimeV2:(XCTestCase *)testCase withDebug:(BOOL)debug callback:(ARTRealtimeTestCallback)callback {
-    XCTestExpectation *expectation = [testCase expectationWithDescription:@"testRealtime"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:debug callback:^(ARTClientOptions *options) {
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
-            if (state == ARTRealtimeFailed) {
-                // FIXME: XCTFail not working outside a XCTestCase method!
-                if (errorInfo) {
-                    //XCTFail(@"%@", errorInfo);
-                    NSLog(@"Realtime connection failed: %@", errorInfo);
-                }
-                else {
-                    //XCTFail();
-                    NSLog(@"Realtime connection failed");
-                }
-                [expectation fulfill];
-            }
-            else
-                callback(realtime, state, expectation);
-        }];
-    }];
-    [testCase waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-
 + (ARTProtocolMessage *)newErrorProtocolMessage {
     ARTProtocolMessage* protocolMessage = [[ARTProtocolMessage alloc] init];
     protocolMessage.action = ARTProtocolMessageError;


### PR DESCRIPTION
I declared each expectation variable as `__weak` to avoid API violations. The expectation will be released when the timeout expires. So if the task takes longer than the timeout, the expectation variable will be nil when the task completion handler is called. Thus the `fulfill` method will be called on nil, doing nothing.