### PR TITLE
RTP8a, RTL7f: attach first to avoid race condition.

### DIFF
--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -1325,16 +1325,19 @@ class RealtimeClientChannel: QuickSpec {
                     let channel2 = client2.channels.get("test")
 
                     waitUntil(timeout: testTimeout) { done in
-                        channel1.subscribe { message in
-                            expect(message.data as? String).to(equal("message"))
-                            delay(1.0) { done() }
-                        }
+                        channel1.attach { err in
+                            expect(err).to(beNil())
+                            channel1.subscribe { message in
+                                expect(message.data as? String).to(equal("message"))
+                                delay(1.0) { done() }
+                            }
 
-                        channel2.subscribe { message in
-                            fail("Shouldn't receive the message")
-                        }
+                            channel2.subscribe { message in
+                                fail("Shouldn't receive the message")
+                            }
 
-                        channel2.publish(nil, data: "message")
+                            channel2.publish(nil, data: "message")
+                        }
                     }
                 }
 

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -287,12 +287,15 @@ class RealtimeClientPresence: QuickSpec {
                     let channel2 = client2.channels.get("test")
 
                     waitUntil(timeout: testTimeout) { done in
-                        channel1.presence.subscribe(.Enter) { member in
-                            expect(member.clientId).to(equal(options.clientId))
-                            expect(member.data as? NSObject).to(equal("online"))
-                            done()
+                        channel1.attach { err in 
+                            expect(err).to(beNil())
+                            channel1.presence.subscribe(.Enter) { member in
+                                expect(member.clientId).to(equal(options.clientId))
+                                expect(member.data as? NSObject).to(equal("online"))
+                                done()
+                            }
+                            channel2.presence.enter("online")
                         }
-                        channel2.presence.enter("online")
                     }
                 }
 


### PR DESCRIPTION
Before we were subscribing the presence listener and entering in
parallel connections, it was possible that the latter finished
before the former attached, thus missing the event.