### PR TITLE
Increase test timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   # Use `travis_wait` when a long running command or compile step regularly takes longer than 10 minutes without producing any output.
   # It writes a short line to the build log every minute for 20 minutes, extending the amount of time your command has to finish.
   # Prefix `travis_wait` with a greater number to extend the wait time.
-  - travis_wait 30 scan --scheme "Ably" --open_report false
+  - travis_wait 35 scan --scheme "Ably" --open_report false

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -39,7 +39,7 @@ func pathForTestResource(resourcePath: String) -> String {
 
 let appSetupJson = JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "test-app-setup.json"))!, options: .MutableContainers)
 
-let testTimeout: NSTimeInterval = 10.0
+let testTimeout: NSTimeInterval = 20.0
 let testResourcesPath = "ably-common/test-resources/"
 
 /// Common test utilities.

--- a/Tests/ARTTestUtil.m
+++ b/Tests/ARTTestUtil.m
@@ -169,7 +169,7 @@
 }
 
 + (float)timeout {
-    return 10.0;
+    return 20.0;
 }
 
 + (void)publishRestMessages:(NSString *)prefix count:(int)count channel:(ARTChannel *)channel completion:(void (^)())completion {


### PR DESCRIPTION
Sadly, 10 seconds seems to be not enough given our current sandbox
performance. See some passing tests almost reaching the 10 s timeout:

```
[17:38:25]: ▸ ✓ RestClient__should_use_Auth_to_manage_authentication (9.815 seconds)
[17:38:34]: ▸ ✓ RestClient__should_request_another_token_after_current_one_is_no_longer_valid (9.421 seconds)
[17:38:39]: ▸ ✓ RestClient__initializer__should_accept_an_API_key (4.559 seconds)
```

Travis can be slower than that.