### PR TITLE
Legacy tests: Sandbox ClientOptions

### DIFF
--- a/Tests/ARTRealtimeAttachTest.m
+++ b/Tests/ARTRealtimeAttachTest.m
@@ -20,10 +20,7 @@
 #import "ARTTokenParams.h"
 #import "ARTTokenDetails.h"
 
-@interface ARTRealtimeAttachTest : XCTestCase {
-    ARTRealtime *_realtime;
-}
-
+@interface ARTRealtimeAttachTest : XCTestCase
 @end
 
 @implementation ARTRealtimeAttachTest
@@ -33,377 +30,361 @@
 }
 
 - (void)tearDown {
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
     [super tearDown];
 }
 
 - (void)testAttachOnce {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attachOnce"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
 
-                __block bool hasAttached = false;
-                [channel on:^(ARTErrorInfo *errorInfo) {
-                    if(channel.state == ARTRealtimeChannelAttaching) {
-                        XCTAssertNil(errorInfo);
-                        [channel attach];
+            __block bool hasAttached = false;
+            [channel on:^(ARTErrorInfo *errorInfo) {
+                if(channel.state == ARTRealtimeChannelAttaching) {
+                    XCTAssertNil(errorInfo);
+                    [channel attach];
+                }
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    XCTAssertNil(errorInfo);
+                    [channel attach];
+                    
+                    if(!hasAttached) {
+                        hasAttached = true;
+                        [channel detach];
                     }
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        XCTAssertNil(errorInfo);
-                        [channel attach];
-                        
-                        if(!hasAttached) {
-                            hasAttached = true;
-                            [channel detach];
-                        }
-                        else {
-                            XCTFail(@"duplicate call to attach shouldnt happen");
-                        }
+                    else {
+                        XCTFail(@"duplicate call to attach shouldnt happen");
                     }
-                    if (channel.state == ARTRealtimeChannelDetached) {
-                        [expectation fulfill];
-                    }
-                }];
-                [channel attach];
-            }
-        }];
+                }
+                if (channel.state == ARTRealtimeChannelDetached) {
+                    [expectation fulfill];
+                }
+            }];
+            [channel attach];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-
 }
 
 - (void)testSkipsFromDetachingToAttaching {
-    __weak XCTestExpectation * expectation = [self expectationWithDescription:@"detaching_to_attaching"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"detaching_to_attaching"];
-        [channel attach];
-        __block bool detachedReached = false;
-        
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                if(!detachedReached) {
-                    [channel detach];
-                }
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"detaching_to_attaching"];
+    [channel attach];
+    __block bool detachedReached = false;
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            if(!detachedReached) {
+                [channel detach];
             }
-            else if(channel.state == ARTRealtimeChannelDetaching) {
-                detachedReached = true;
-                [channel attach];
+        }
+        else if(channel.state == ARTRealtimeChannelDetaching) {
+            detachedReached = true;
+            [channel attach];
+        }
+        else if(channel.state == ARTRealtimeChannelDetached) {
+            XCTFail(@"Should not have reached detached state");
+        }
+        else if(channel.state == ARTRealtimeChannelAttaching) {
+            if(detachedReached) {
+                [channel off];
+                [expectation fulfill];
             }
-            else if(channel.state == ARTRealtimeChannelDetached) {
-                XCTFail(@"Should not have reached detached state");
-            }
-            else if(channel.state == ARTRealtimeChannelAttaching) {
-                if(detachedReached) {
-                    [channel off];
-                    [expectation fulfill];
-                }
-            }
-        }];
+        }
     }];
-    
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachMultipleChannels {
-    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"test_attach_multiple1"];
-    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"test_attach_multiple2"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel1 = [realtime.channels get:@"test_attach_multiple1"];
-        [channel1 attach];
-        ARTRealtimeChannel *channel2 = [realtime.channels get:@"test_attach_multiple2"];
-        [channel2 attach];
-
-        [channel1 on:^(ARTErrorInfo *errorInfo) {
-            if (channel1.state == ARTRealtimeChannelAttached) {
-                [expectation1 fulfill];
-            }
-        }];
-        [channel2 on:^(ARTErrorInfo *errorInfo) {
-            if (channel2.state == ARTRealtimeChannelAttached) {
-                [expectation2 fulfill];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel1 = [realtime.channels get:@"test_attach_multiple1"];
+    [channel1 attach];
+    ARTRealtimeChannel *channel2 = [realtime.channels get:@"test_attach_multiple2"];
+    [channel2 attach];
+    [channel1 on:^(ARTErrorInfo *errorInfo) {
+        if (channel1.state == ARTRealtimeChannelAttached) {
+            [expectation1 fulfill];
+        }
     }];
-    
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        if (channel2.state == ARTRealtimeChannelAttached) {
+            [expectation2 fulfill];
+        }
+    }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-
 - (void)testDetach {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
-                [channel on:^(ARTErrorInfo *errorInfo) {
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        [channel detach];
-                    }
-                    else if(channel.state == ARTRealtimeChannelDetached) {
-                        [expectation fulfill];
-                    }
-                }];
-                [channel attach];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
+            [channel on:^(ARTErrorInfo *errorInfo) {
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    [channel detach];
+                }
+                else if(channel.state == ARTRealtimeChannelDetached) {
+                    [expectation fulfill];
+                }
+            }];
+            [channel attach];
+        }
     }];
-    
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testDetaching {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"detach"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        __block BOOL detachingHit = NO;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
-                [channel on:^(ARTErrorInfo *errorInfo) {
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        [channel detach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block BOOL detachingHit = NO;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"detach"];
+            [channel on:^(ARTErrorInfo *errorInfo) {
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    [channel detach];
+                }
+                else if(channel.state == ARTRealtimeChannelDetaching) {
+                    detachingHit = YES;
+                }
+                else if(channel.state == ARTRealtimeChannelDetached) {
+                    if(detachingHit) {
+                        [expectation fulfill];
                     }
-                    else if(channel.state == ARTRealtimeChannelDetaching) {
-                        detachingHit = YES;
+                    else {
+                        XCTFail(@"Detaching state not emitted prior to detached");
                     }
-                    else if(channel.state == ARTRealtimeChannelDetached) {
-                        if(detachingHit) {
-                            [expectation fulfill];
-                        }
-                        else {
-                            XCTFail(@"Detaching state not emitted prior to detached");
-                        }
-                    }
-                }];
-                [channel attach];
-            }
-        }];
+                }
+            }];
+            [channel attach];
+        }
     }];
-    
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSkipsFromAttachingToDetaching {
-    __weak XCTestExpectation * expectation = [self expectationWithDescription:@"attaching_to_detaching"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"attaching_to_detaching"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                XCTFail(@"Should not have made it to attached");
-            }
-            else if( channel.state == ARTRealtimeChannelAttaching) {
-                [channel detach];
-            }
-            else if(channel.state == ARTRealtimeChannelDetaching) {
-                [channel off];
-                [expectation fulfill];
-            }
-            else if(channel.state == ARTRealtimeChannelDetached) {
-                XCTFail(@"Should not have made it to detached");
-                
-            }
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"attaching_to_detaching"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            XCTFail(@"Should not have made it to attached");
+        }
+        else if( channel.state == ARTRealtimeChannelAttaching) {
+            [channel detach];
+        }
+        else if(channel.state == ARTRealtimeChannelDetaching) {
+            [channel off];
+            [expectation fulfill];
+        }
+        else if(channel.state == ARTRealtimeChannelDetached) {
+            XCTFail(@"Should not have made it to detached");
+            
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 -(void)testDetachingIgnoresDetach {
-    __weak XCTestExpectation * expectation = [self expectationWithDescription:@"testDetachingIgnoresDetach"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"testDetachingIgnoresDetach"];
-                [channel on:^(ARTErrorInfo *errorInfo) {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"testDetachingIgnoresDetach"];
+            [channel on:^(ARTErrorInfo *errorInfo) {
 
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        [channel detach];
-                    }
-                    if( channel.state == ARTRealtimeChannelDetaching) {
-                        [channel detach];
-                    }
-                    if(channel.state == ARTRealtimeChannelDetached) {
-                        [expectation fulfill];
-                    }
-                }];
-                [channel attach];
-            }
-        }];
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    [channel detach];
+                }
+                if( channel.state == ARTRealtimeChannelDetaching) {
+                    [channel detach];
+                }
+                if(channel.state == ARTRealtimeChannelDetached) {
+                    [expectation fulfill];
+                }
+            }];
+            [channel attach];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachFailsOnFailedConnection {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testAttachFailsOnFailedConnection"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-                __block bool hasFailed = false;
-                [channel on:^(ARTErrorInfo *errorInfo) {
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        if(!hasFailed) {
-                            XCTAssertNil(errorInfo);
-                            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                        }
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
+            __block bool hasFailed = false;
+            [channel on:^(ARTErrorInfo *errorInfo) {
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    if(!hasFailed) {
+                        XCTAssertNil(errorInfo);
+                        [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
                     }
-                    else if(channel.state == ARTRealtimeChannelFailed) {
+                }
+                else if(channel.state == ARTRealtimeChannelFailed) {
+                    XCTAssertNotNil(errorInfo);
+                    [channel attach:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNotNil(errorInfo);
-                        [channel attach:^(ARTErrorInfo *errorInfo) {
-                            XCTAssertNotNil(errorInfo);
-                            [expectation fulfill];
-                        }];
-                    }
-                }];
-                [channel attach];
-                [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-                    ARTRealtimeConnectionState state = stateChange.current;
-                    if(state == ARTRealtimeFailed) {
-                        hasFailed = true;
-                        [channel attach];
-                    }
-                }];
-            }
-        }];
+                        [expectation fulfill];
+                    }];
+                }
+            }];
+            [channel attach];
+            [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+                ARTRealtimeConnectionState state = stateChange.current;
+                if(state == ARTRealtimeFailed) {
+                    hasFailed = true;
+                    [channel attach];
+                }
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachRestricted {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
-
-        ARTRealtime *realtime =[[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-
-        ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state != ARTRealtimeChannelAttaching) {
-                XCTAssertEqual(channel.state, ARTRealtimeChannelFailed);
-                [expectation fulfill];
-                [channel off];
-            }
-        }];
-        [channel attach];
+    __weak XCTestExpectation *startup = [self expectationWithDescription:[NSString stringWithFormat:@"%s-ClientOptions", __FUNCTION__]];
+    __block ARTClientOptions *options;
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *_options) {
+        options = _options;
+        [startup fulfill];
     }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state != ARTRealtimeChannelAttaching) {
+            XCTAssertEqual(channel.state, ARTRealtimeChannelFailed);
+            [expectation fulfill];
+            [channel off];
+        }
+    }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachingChannelFails {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachingChannelFails"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
-        [channel1 on:^(ARTErrorInfo *errorInfo) {
-            if (channel1.state == ARTRealtimeChannelAttaching) {
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-            }
-            else {
-                XCTAssertEqual(ARTRealtimeChannelFailed, channel1.state);
-                [exp fulfill];
-            }
-        }];
-        [channel1 attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
+    [channel1 on:^(ARTErrorInfo *errorInfo) {
+        if (channel1.state == ARTRealtimeChannelAttaching) {
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+        }
+        else {
+            XCTAssertEqual(ARTRealtimeChannelFailed, channel1.state);
+            [expectation fulfill];
+        }
     }];
+    [channel1 attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachedChannelFails {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachedChannelFails"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
-        [channel1 on:^(ARTErrorInfo *errorInfo) {
-            if (channel1.state == ARTRealtimeChannelAttached) {
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-            }
-            else if(channel1.state != ARTRealtimeChannelAttaching) {
-                XCTAssertEqual(ARTRealtimeChannelFailed, channel1.state);
-                [exp fulfill];
-            }
-        }];
-        [channel1 attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
+    [channel1 on:^(ARTErrorInfo *errorInfo) {
+        if (channel1.state == ARTRealtimeChannelAttached) {
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+        }
+        else if(channel1.state != ARTRealtimeChannelAttaching) {
+            XCTAssertEqual(ARTRealtimeChannelFailed, channel1.state);
+            [expectation fulfill];
+        }
     }];
+    [channel1 attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testChannelClosesOnClose {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testChannelClosesOnClose"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
-        [channel1 on:^(ARTErrorInfo *errorInfo) {
-            if (channel1.state == ARTRealtimeChannelAttached) {
-                [realtime close];
-            }
-            else if(channel1.state != ARTRealtimeChannelAttaching) {
-                XCTAssertEqual(ARTRealtimeChannelDetached, channel1.state);
-                [exp fulfill];
-            }
-        }];
-        [channel1 attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel1 = [realtime.channels get:@"channel"];
+    [channel1 on:^(ARTErrorInfo *errorInfo) {
+        if (channel1.state == ARTRealtimeChannelAttached) {
+            [realtime close];
+        }
+        else if(channel1.state != ARTRealtimeChannelAttaching) {
+            XCTAssertEqual(ARTRealtimeChannelDetached, channel1.state);
+            [expectation fulfill];
+        }
     }];
+    [channel1 attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testPresenceEnterRestricted {
-    __weak XCTestExpectation *expect = [self expectationWithDescription:@"testSimpleDisconnected"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
-        // Connection
-        options.clientId = @"some_client_id";
-        options.autoConnect = false;
+    __weak XCTestExpectation *startup = [self expectationWithDescription:[NSString stringWithFormat:@"%s-ClientOptions", __FUNCTION__]];
+    __block ARTClientOptions *options;
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *_options) {
+        options = _options;
+        [startup fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    // Connection
+    options.clientId = @"some_client_id";
+    options.autoConnect = false;
 
-        // FIXME: there is setupApp, testRealtime, testRest, ... try to unify them and then use this code
-        ARTTokenParams *tokenParams = [[ARTTokenParams alloc] initWithClientId:options.clientId];
-        tokenParams.capability = @"{\"canpublish:*\":[\"publish\"],\"canpublish:andpresence\":[\"presence\",\"publish\"],\"cansubscribe:*\":[\"subscribe\"]}";
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
 
-        [realtime.auth authorise:tokenParams options:options callback:^(ARTTokenDetails *tokenDetails, NSError *error) {
-            options.token = tokenDetails.token;
-            [realtime connect];
-        }];
+    // FIXME: there is setupApp, testRealtime, testRest, ... try to unify them and then use this code
+    ARTTokenParams *tokenParams = [[ARTTokenParams alloc] initWithClientId:options.clientId];
+    tokenParams.capability = @"{\"canpublish:*\":[\"publish\"],\"canpublish:andpresence\":[\"presence\",\"publish\"],\"cansubscribe:*\":[\"subscribe\"]}";
 
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
-                [channel.presence enter:@"not_allowed_here" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNotNil(errorInfo);
-                    [expect fulfill];
-                }];
+    [realtime.auth authorise:tokenParams options:options callback:^(ARTTokenDetails *tokenDetails, NSError *error) {
+        options.token = tokenDetails.token;
+        [realtime connect];
+    }];
+
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        ARTErrorInfo *errorInfo = stateChange.reason;
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"some_unpermitted_channel"];
+            [channel.presence enter:@"not_allowed_here" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNotNil(errorInfo);
+                [expectation fulfill];
+            }];
+        }
+        else if (state == ARTRealtimeFailed) {
+            if (errorInfo) {
+                XCTFail(@"%@", errorInfo);
             }
-            else if (state == ARTRealtimeFailed) {
-                if (errorInfo) {
-                    XCTFail(@"%@", errorInfo);
-                }
-                else {
-                    XCTFail();
-                }
-                [expect fulfill];
+            else {
+                XCTFail();
             }
-        }];
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }

--- a/Tests/ARTRealtimeChannelHistoryTest.m
+++ b/Tests/ARTRealtimeChannelHistoryTest.m
@@ -17,10 +17,7 @@
 #import "ARTDataQuery.h"
 #import "ARTTestUtil.h"
 
-@interface ARTRealtimeChannelHistoryTest : XCTestCase {
-    ARTRealtime *_realtime;
-    ARTRealtime *_realtime2;
-}
+@interface ARTRealtimeChannelHistoryTest : XCTestCase
 
 @end
 
@@ -32,57 +29,45 @@
 
 - (void)tearDown {
     [super tearDown];
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.connection close];
-    }
-    _realtime = nil;
-    if (_realtime2) {
-        [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2.connection close];
-    }
-    _realtime2 = nil;
 }
 
 - (void)testHistory {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistory"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            ARTErrorInfo *errorInfo = stateChange.reason;
-            if (state == ARTRealtimeFailed) {
-                if (errorInfo) {
-                    XCTFail(@"Realtime connection failed: %@", errorInfo);
-                }
-                else {
-                    XCTFail(@"Realtime connection failed");
-                }
-                [expectation fulfill];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        ARTErrorInfo *errorInfo = stateChange.reason;
+        if (state == ARTRealtimeFailed) {
+            if (errorInfo) {
+                XCTFail(@"Realtime connection failed: %@", errorInfo);
             }
             else {
-                if (state == ARTRealtimeConnected) {
-                    ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testHistory"];
-                    [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+                XCTFail(@"Realtime connection failed");
+            }
+            [expectation fulfill];
+        }
+        else {
+            if (state == ARTRealtimeConnected) {
+                ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testHistory"];
+                [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+                    XCTAssertNil(errorInfo);
+                    [channel publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
-                            XCTAssertNil(errorInfo);
-                            [channel history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                                XCTAssert(!error);
-                                NSArray *messages = [result items];
-                                XCTAssertEqual(2, messages.count);
-                                ARTMessage *m0 = messages[0];
-                                ARTMessage *m1 = messages[1];
-                                XCTAssertEqualObjects(@"testString2", [m0 data]);
-                                XCTAssertEqualObjects(@"testString", [m1 data]);
-                                [expectation fulfill];
-                            }];
+                        [channel history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                            XCTAssert(!error);
+                            NSArray *messages = [result items];
+                            XCTAssertEqual(2, messages.count);
+                            ARTMessage *m0 = messages[0];
+                            ARTMessage *m1 = messages[1];
+                            XCTAssertEqualObjects(@"testString2", [m0 data]);
+                            XCTAssertEqualObjects(@"testString", [m1 data]);
+                            [expectation fulfill];
                         }];
                     }];
-                }
+                }];
             }
-        }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
@@ -115,38 +100,37 @@
 }
 
 - (void)testHistoryBothChannels {
-    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"historyBothChanels1"];
-    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"historyBothChanels2"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        NSString *both = @"historyBoth";
-        ARTRealtimeChannel *channel1 = [realtime.channels get:both];
-        ARTRealtimeChannel *channel2 = [realtime.channels get:both];
-        [channel1 publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    NSString *both = @"historyBoth";
+    ARTRealtimeChannel *channel1 = [realtime.channels get:both];
+    ARTRealtimeChannel *channel2 = [realtime.channels get:both];
+    [channel1 publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel2 publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel2 publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [channel1 history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    NSArray *messages = [result items];
-                    XCTAssertEqual(2, messages.count);
-                    ARTMessage *m0 = messages[0];
-                    ARTMessage *m1 = messages[1];
-                    XCTAssertEqualObjects(@"testString2", [m0 data]);
-                    XCTAssertEqualObjects(@"testString", [m1 data]);
-                    [expectation1 fulfill];
-                    
-                }];
-                [channel2 history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    NSArray *messages = [result items];
-                    XCTAssertEqual(2, messages.count);
-                    ARTMessage *m0 = messages[0];
-                    ARTMessage *m1 = messages[1];
-                    XCTAssertEqualObjects(@"testString2", [m0 data]);
-                    XCTAssertEqualObjects(@"testString", [m1 data]);
-                    [expectation2 fulfill];
-                }];
+            [channel1 history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                NSArray *messages = [result items];
+                XCTAssertEqual(2, messages.count);
+                ARTMessage *m0 = messages[0];
+                ARTMessage *m1 = messages[1];
+                XCTAssertEqualObjects(@"testString2", [m0 data]);
+                XCTAssertEqualObjects(@"testString", [m1 data]);
+                [expectation1 fulfill];
+                
+            }];
+            [channel2 history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                NSArray *messages = [result items];
+                XCTAssertEqual(2, messages.count);
+                ARTMessage *m0 = messages[0];
+                ARTMessage *m1 = messages[1];
+                XCTAssertEqualObjects(@"testString2", [m0 data]);
+                XCTAssertEqualObjects(@"testString", [m1 data]);
+                [expectation2 fulfill];
             }];
         }];
     }];
@@ -154,218 +138,209 @@
 }
 
 - (void)testHistoryForward {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryForward"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testHistory"];
-        [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"persisted:testHistory"];
+    [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel publish:nil data:@"testString2" callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                ARTRealtimeHistoryQuery* query = [[ARTRealtimeHistoryQuery alloc] init];
-                query.direction = ARTQueryDirectionForwards;
-                [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    NSArray *messages = [result items];
-                    XCTAssertEqual(2, messages.count);
-                    ARTMessage *m0 = messages[0];
-                    ARTMessage *m1 = messages[1];
-                    XCTAssertEqualObjects(@"testString", [m0 data]);
-                    XCTAssertEqualObjects(@"testString2", [m1 data]);
-                    
-                    [expectation fulfill];
-                } error:nil];
-            }];
+            ARTRealtimeHistoryQuery* query = [[ARTRealtimeHistoryQuery alloc] init];
+            query.direction = ARTQueryDirectionForwards;
+            [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                NSArray *messages = [result items];
+                XCTAssertEqual(2, messages.count);
+                ARTMessage *m0 = messages[0];
+                ARTMessage *m1 = messages[1];
+                XCTAssertEqualObjects(@"testString", [m0 data]);
+                XCTAssertEqualObjects(@"testString2", [m1 data]);
+                
+                [expectation fulfill];
+            } error:nil];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testHistoryForwardPagination {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryForwardPagination"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"realHistChan"];
-        
-        [self publishTestStrings:channel count:5 prefix:@"testString" callback:^(ARTErrorInfo *errorInfo){
-            XCTAssertNil(errorInfo);
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"realHistChan"];
+    
+    [self publishTestStrings:channel count:5 prefix:@"testString" callback:^(ARTErrorInfo *errorInfo){
+        XCTAssertNil(errorInfo);
 
-            ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-            query.limit = 2;
-            query.direction = ARTQueryDirectionForwards;
-            
-            [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+        ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
+        query.limit = 2;
+        query.direction = ARTQueryDirectionForwards;
+        
+        [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+             XCTAssert(!error);
+             XCTAssertTrue([result hasNext]);
+             NSArray *items = [result items];
+             XCTAssertEqual([items count], 2);
+             ARTMessage *firstMessage = [items objectAtIndex:0];
+             ARTMessage *secondMessage =[items objectAtIndex:1];
+             XCTAssertEqualObjects(@"testString0", [firstMessage data]);
+             XCTAssertEqualObjects(@"testString1", [secondMessage data]);
+             [result next:^(ARTPaginatedResult *result2, ARTErrorInfo *error) {
                  XCTAssert(!error);
-                 XCTAssertTrue([result hasNext]);
-                 NSArray *items = [result items];
+                 NSArray *items = [result2 items];
                  XCTAssertEqual([items count], 2);
                  ARTMessage *firstMessage = [items objectAtIndex:0];
                  ARTMessage *secondMessage =[items objectAtIndex:1];
-                 XCTAssertEqualObjects(@"testString0", [firstMessage data]);
-                 XCTAssertEqualObjects(@"testString1", [secondMessage data]);
-                 [result next:^(ARTPaginatedResult *result2, ARTErrorInfo *error) {
+                 XCTAssertEqualObjects(@"testString2", [firstMessage data]);
+                 XCTAssertEqualObjects(@"testString3", [secondMessage data]);
+                 
+                 [result2 next:^(ARTPaginatedResult *result3, ARTErrorInfo *error) {
                      XCTAssert(!error);
-                     NSArray *items = [result2 items];
-                     XCTAssertEqual([items count], 2);
+                     XCTAssertFalse([result3 hasNext]);
+                     NSArray *items = [result3 items];
+                     XCTAssertEqual([items count], 1);
                      ARTMessage *firstMessage = [items objectAtIndex:0];
-                     ARTMessage *secondMessage =[items objectAtIndex:1];
-                     XCTAssertEqualObjects(@"testString2", [firstMessage data]);
-                     XCTAssertEqualObjects(@"testString3", [secondMessage data]);
-                     
-                     [result2 next:^(ARTPaginatedResult *result3, ARTErrorInfo *error) {
-                         XCTAssert(!error);
-                         XCTAssertFalse([result3 hasNext]);
-                         NSArray *items = [result3 items];
-                         XCTAssertEqual([items count], 1);
+                     XCTAssertEqualObjects(@"testString4", [firstMessage data]);
+                     [result3 first:^(ARTPaginatedResult *result4, ARTErrorInfo *error) {
+                         XCTAssertNil(errorInfo);
+                         XCTAssertTrue([result4 hasNext]);
+                         NSArray *items = [result4 items];
+                         XCTAssertEqual([items count], 2);
                          ARTMessage *firstMessage = [items objectAtIndex:0];
-                         XCTAssertEqualObjects(@"testString4", [firstMessage data]);
-                         [result3 first:^(ARTPaginatedResult *result4, ARTErrorInfo *error) {
-                             XCTAssertNil(errorInfo);
-                             XCTAssertTrue([result4 hasNext]);
-                             NSArray *items = [result4 items];
-                             XCTAssertEqual([items count], 2);
-                             ARTMessage *firstMessage = [items objectAtIndex:0];
-                             ARTMessage *secondMessage =[items objectAtIndex:1];
-                             XCTAssertEqualObjects(@"testString0", [firstMessage data]);
-                             XCTAssertEqualObjects(@"testString1", [secondMessage data]);
-                             [expectation fulfill];
-                         }];
+                         ARTMessage *secondMessage =[items objectAtIndex:1];
+                         XCTAssertEqualObjects(@"testString0", [firstMessage data]);
+                         XCTAssertEqualObjects(@"testString1", [secondMessage data]);
+                         [expectation fulfill];
                      }];
                  }];
-             } error:nil];
-        }];
+             }];
+         } error:nil];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testHistoryBackwardPagination {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testHistoryBackwardagination"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"histRealBackChan"];
-        [self publishTestStrings:channel count:5 prefix:@"testString" callback:^(ARTErrorInfo *errorInfo){
-            XCTAssertNil(errorInfo);
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"histRealBackChan"];
+    [self publishTestStrings:channel count:5 prefix:@"testString" callback:^(ARTErrorInfo *errorInfo){
+        XCTAssertNil(errorInfo);
 
-            ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-            query.limit = 2;
-            query.direction = ARTQueryDirectionBackwards;
+        ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
+        query.limit = 2;
+        query.direction = ARTQueryDirectionBackwards;
 
-            [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+        [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+             XCTAssert(!error);
+             XCTAssertTrue([result hasNext]);
+             NSArray *items = [result items];
+             XCTAssertEqual([items count], 2);
+             ARTMessage *firstMessage = [items objectAtIndex:0];
+             ARTMessage *secondMessage =[items objectAtIndex:1];
+             XCTAssertEqualObjects(@"testString4", [firstMessage data]);
+             XCTAssertEqualObjects(@"testString3", [secondMessage data]);
+             [result next:^(ARTPaginatedResult *result2, ARTErrorInfo *error) {
                  XCTAssert(!error);
-                 XCTAssertTrue([result hasNext]);
-                 NSArray *items = [result items];
+                 NSArray *items = [result2 items];
                  XCTAssertEqual([items count], 2);
                  ARTMessage *firstMessage = [items objectAtIndex:0];
                  ARTMessage *secondMessage =[items objectAtIndex:1];
-                 XCTAssertEqualObjects(@"testString4", [firstMessage data]);
-                 XCTAssertEqualObjects(@"testString3", [secondMessage data]);
-                 [result next:^(ARTPaginatedResult *result2, ARTErrorInfo *error) {
+                 
+                 XCTAssertEqualObjects(@"testString2", [firstMessage data]);
+                 XCTAssertEqualObjects(@"testString1", [secondMessage data]);
+                 
+                 [result2 next:^(ARTPaginatedResult *result3, ARTErrorInfo *error) {
                      XCTAssert(!error);
-                     NSArray *items = [result2 items];
-                     XCTAssertEqual([items count], 2);
+                     XCTAssertFalse([result3 hasNext]);
+                     NSArray *items = [result3 items];
+                     XCTAssertEqual([items count], 1);
                      ARTMessage *firstMessage = [items objectAtIndex:0];
-                     ARTMessage *secondMessage =[items objectAtIndex:1];
-                     
-                     XCTAssertEqualObjects(@"testString2", [firstMessage data]);
-                     XCTAssertEqualObjects(@"testString1", [secondMessage data]);
-                     
-                     [result2 next:^(ARTPaginatedResult *result3, ARTErrorInfo *error) {
+                     XCTAssertEqualObjects(@"testString0", [firstMessage data]);
+                     [result3 first:^(ARTPaginatedResult *result4, ARTErrorInfo *error) {
                          XCTAssert(!error);
-                         XCTAssertFalse([result3 hasNext]);
-                         NSArray *items = [result3 items];
-                         XCTAssertEqual([items count], 1);
+                         XCTAssertTrue([result4 hasNext]);
+                         NSArray *items = [result4 items];
+                         XCTAssertEqual([items count], 2);
                          ARTMessage *firstMessage = [items objectAtIndex:0];
-                         XCTAssertEqualObjects(@"testString0", [firstMessage data]);
-                         [result3 first:^(ARTPaginatedResult *result4, ARTErrorInfo *error) {
+                         ARTMessage *secondMessage =[items objectAtIndex:1];
+                         XCTAssertEqualObjects(@"testString4", [firstMessage data]);
+                         XCTAssertEqualObjects(@"testString3", [secondMessage data]);
+                         [result2 first:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
                              XCTAssert(!error);
-                             XCTAssertTrue([result4 hasNext]);
-                             NSArray *items = [result4 items];
+                             XCTAssertTrue([result hasNext]);
+                             NSArray *items = [result items];
                              XCTAssertEqual([items count], 2);
                              ARTMessage *firstMessage = [items objectAtIndex:0];
                              ARTMessage *secondMessage =[items objectAtIndex:1];
                              XCTAssertEqualObjects(@"testString4", [firstMessage data]);
                              XCTAssertEqualObjects(@"testString3", [secondMessage data]);
-                             [result2 first:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                                 XCTAssert(!error);
-                                 XCTAssertTrue([result hasNext]);
-                                 NSArray *items = [result items];
-                                 XCTAssertEqual([items count], 2);
-                                 ARTMessage *firstMessage = [items objectAtIndex:0];
-                                 ARTMessage *secondMessage =[items objectAtIndex:1];
-                                 XCTAssertEqualObjects(@"testString4", [firstMessage data]);
-                                 XCTAssertEqualObjects(@"testString3", [secondMessage data]);
-                                [expectation fulfill];
-                             }];
+                            [expectation fulfill];
                          }];
                      }];
                  }];
-             } error:nil];
-        }];
+             }];
+         } error:nil];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testTimeBackwards {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     __block long long timeOffset = 0;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
 
     __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime time:^(NSDate *time, NSError *error) {
-            XCTAssert(!error);
-            long long serverNow = [time timeIntervalSince1970]*1000;
-            long long appNow =[ARTTestUtil nowMilli];
-            timeOffset = serverNow - appNow;
-            [e fulfill];
-        }];
+    [realtime time:^(NSDate *time, NSError *error) {
+        XCTAssert(!error);
+        long long serverNow = [time timeIntervalSince1970]*1000;
+        long long appNow =[ARTTestUtil nowMilli];
+        timeOffset = serverNow - appNow;
+        [e fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
-    [_realtime.connection close];
-    
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"firstExpectation"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testTimeBackwards"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testTimeBackwards"];
 
-        int firstBatchTotal = 3;
-        int secondBatchTotal = 2;
-        int thirdBatchTotal = 1;
-        __block long long intervalStart = 0, intervalEnd = 0;
+    int firstBatchTotal = 3;
+    int secondBatchTotal = 2;
+    int thirdBatchTotal = 1;
+    __block long long intervalStart = 0, intervalEnd = 0;
 
-        NSString *firstBatch = @"first_batch";
-        NSString *secondBatch = @"second_batch";
-        NSString *thirdBatch = @"third_batch";
+    NSString *firstBatch = @"first_batch";
+    NSString *secondBatch = @"second_batch";
+    NSString *thirdBatch = @"third_batch";
 
-        [ARTTestUtil publishRealtimeMessages:firstBatch count:firstBatchTotal channel:channel completion:^{
-            [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
-                intervalStart += [ARTTestUtil nowMilli] + timeOffset;
+    [ARTTestUtil publishRealtimeMessages:firstBatch count:firstBatchTotal channel:channel completion:^{
+        [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
+            intervalStart += [ARTTestUtil nowMilli] + timeOffset;
 
-                [ARTTestUtil publishRealtimeMessages:secondBatch count:secondBatchTotal channel:channel completion:^{
-                    [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
-                        intervalEnd += [ARTTestUtil nowMilli] + timeOffset;
+            [ARTTestUtil publishRealtimeMessages:secondBatch count:secondBatchTotal channel:channel completion:^{
+                [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
+                    intervalEnd += [ARTTestUtil nowMilli] + timeOffset;
 
-                        [ARTTestUtil publishRealtimeMessages:thirdBatch count:thirdBatchTotal channel:channel completion:^{
-                            ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-                            query.start = [NSDate dateWithTimeIntervalSince1970:intervalStart/1000];
-                            query.end = [NSDate dateWithTimeIntervalSince1970:intervalEnd/1000];
-                            query.direction = ARTQueryDirectionBackwards;
+                    [ARTTestUtil publishRealtimeMessages:thirdBatch count:thirdBatchTotal channel:channel completion:^{
+                        ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
+                        query.start = [NSDate dateWithTimeIntervalSince1970:intervalStart/1000];
+                        query.end = [NSDate dateWithTimeIntervalSince1970:intervalEnd/1000];
+                        query.direction = ARTQueryDirectionBackwards;
 
-                            [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                                XCTAssert(!error);
-                                XCTAssertFalse([result hasNext]);
-                                NSArray *items = [result items];
-                                XCTAssertTrue(items != nil);
-                                XCTAssertEqual([items count], secondBatchTotal);
-                                for(int i=0; i < [items count]; i++) {
-                                    NSString *pattern = [secondBatch stringByAppendingString:@"%d"];
-                                    NSString *goalStr = [NSString stringWithFormat:pattern, secondBatchTotal -1 - i];
-                                    ARTMessage *m = [items objectAtIndex:i];
-                                    XCTAssertEqualObjects(goalStr, [m data]);
-                                }
-                                [expectation fulfill];
-                            } error:nil];
-                        }];
+                        [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                            XCTAssert(!error);
+                            XCTAssertFalse([result hasNext]);
+                            NSArray *items = [result items];
+                            XCTAssertTrue(items != nil);
+                            XCTAssertEqual([items count], secondBatchTotal);
+                            for(int i=0; i < [items count]; i++) {
+                                NSString *pattern = [secondBatch stringByAppendingString:@"%d"];
+                                NSString *goalStr = [NSString stringWithFormat:pattern, secondBatchTotal -1 - i];
+                                ARTMessage *m = [items objectAtIndex:i];
+                                XCTAssertEqualObjects(goalStr, [m data]);
+                            }
+                            [expectation fulfill];
+                        } error:nil];
                     }];
                 }];
             }];
@@ -375,67 +350,61 @@
 }
 
 - (void)testTimeForwards {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     __block long long timeOffset = 0;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
 
     __weak XCTestExpectation *e = [self expectationWithDescription:@"getTime"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime time:^(NSDate *time, NSError *error) {
-            XCTAssert(!error);
-            long long serverNow = [time timeIntervalSince1970]*1000;
-            long long appNow = [ARTTestUtil nowMilli];
-            timeOffset = serverNow - appNow;            
-            [e fulfill];
-        }];
+    [realtime time:^(NSDate *time, NSError *error) {
+        XCTAssert(!error);
+        long long serverNow = [time timeIntervalSince1970]*1000;
+        long long appNow = [ARTTestUtil nowMilli];
+        timeOffset = serverNow - appNow;            
+        [e fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 
-    [_realtime.connection close];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"test_history_time_forwards"];
 
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"firstExpectation"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"test_history_time_forwards"];
+    int firstBatchTotal = 3;
+    int secondBatchTotal = 2;
+    int thirdBatchTotal = 1;
+    __block long long intervalStart = 0, intervalEnd = 0;
 
-        int firstBatchTotal = 3;
-        int secondBatchTotal = 2;
-        int thirdBatchTotal = 1;
-        __block long long intervalStart = 0, intervalEnd = 0;
+    NSString *firstBatch = @"first_batch";
+    NSString *secondBatch = @"second_batch";
+    NSString *thirdBatch =@"third_batch";
 
-        NSString *firstBatch = @"first_batch";
-        NSString *secondBatch = @"second_batch";
-        NSString *thirdBatch =@"third_batch";
+    [ARTTestUtil publishRealtimeMessages:firstBatch count:firstBatchTotal channel:channel completion:^{
+        [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
+            intervalStart += [ARTTestUtil nowMilli] + timeOffset;
 
-        [ARTTestUtil publishRealtimeMessages:firstBatch count:firstBatchTotal channel:channel completion:^{
-            [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
-                intervalStart += [ARTTestUtil nowMilli] + timeOffset;
+            [ARTTestUtil publishRealtimeMessages:secondBatch count:secondBatchTotal channel:channel completion:^{
+                [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
+                    intervalEnd += [ARTTestUtil nowMilli] + timeOffset;
 
-                [ARTTestUtil publishRealtimeMessages:secondBatch count:secondBatchTotal channel:channel completion:^{
-                    [ARTTestUtil delay:[ARTTestUtil bigSleep] block:^{
-                        intervalEnd += [ARTTestUtil nowMilli] + timeOffset;
+                    [ARTTestUtil publishRealtimeMessages:thirdBatch count:thirdBatchTotal channel:channel completion:^{
+                        ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
+                        query.start = [NSDate dateWithTimeIntervalSince1970:intervalStart/1000];
+                        query.end = [NSDate dateWithTimeIntervalSince1970:intervalEnd/1000];
+                        query.direction = ARTQueryDirectionForwards;
 
-                        [ARTTestUtil publishRealtimeMessages:thirdBatch count:thirdBatchTotal channel:channel completion:^{
-                            ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-                            query.start = [NSDate dateWithTimeIntervalSince1970:intervalStart/1000];
-                            query.end = [NSDate dateWithTimeIntervalSince1970:intervalEnd/1000];
-                            query.direction = ARTQueryDirectionForwards;
+                        [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                            XCTAssert(!error);
+                            XCTAssertFalse([result hasNext]);
+                            NSArray *items = [result items];
+                            XCTAssertTrue(items != nil);
+                            XCTAssertEqual([items count], secondBatchTotal);
+                            for (int i=0; i < [items count]; i++) {
+                                NSString *pattern = [secondBatch stringByAppendingString:@"%d"];
+                                NSString *goalStr = [NSString stringWithFormat:pattern, i];
 
-                            [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                                XCTAssert(!error);
-                                XCTAssertFalse([result hasNext]);
-                                NSArray *items = [result items];
-                                XCTAssertTrue(items != nil);
-                                XCTAssertEqual([items count], secondBatchTotal);
-                                for (int i=0; i < [items count]; i++) {
-                                    NSString *pattern = [secondBatch stringByAppendingString:@"%d"];
-                                    NSString *goalStr = [NSString stringWithFormat:pattern, i];
-
-                                    ARTMessage *m = [items objectAtIndex:i];
-                                    XCTAssertEqualObjects(goalStr, [m data]);
-                                }
-                                [expectation fulfill];
-                            } error:nil];
-                        }];
+                                ARTMessage *m = [items objectAtIndex:i];
+                                XCTAssertEqualObjects(goalStr, [m data]);
+                            }
+                            [expectation fulfill];
+                        } error:nil];
                     }];
                 }];
             }];
@@ -445,55 +414,46 @@
 }
 
 - (void)testHistoryFromAttach {
-    __weak XCTestExpectation *e = [self expectationWithDescription:@"waitExp"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        [e fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
 
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
     NSString *channelName = @"test_history_time_forwards";
-    __weak XCTestExpectation *expecation = [self expectationWithDescription:@"send_first_batch"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRealtime *realtime =[[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    
+    int firstBatchTotal =3;
+    //send first batch, which we won't recieve in the history request
+    __block int numReceived =0;
 
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        
-        int firstBatchTotal =3;
-        //send first batch, which we won't recieve in the history request
-        __block int numReceived =0;
+    for (int i=0; i < firstBatchTotal; i++) {
+        NSString *pub = [NSString stringWithFormat:@"test%d", i];
 
-        for (int i=0; i < firstBatchTotal; i++) {
-            NSString *pub = [NSString stringWithFormat:@"test%d", i];
+        [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
+            XCTAssertNil(errorInfo);
+            ++numReceived;
+            if (numReceived == firstBatchTotal) {
+                ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+                ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
 
-            [channel publish:nil data:pub callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                ++numReceived;
-                if (numReceived == firstBatchTotal) {
-                    ARTRealtime *realtime2 =[[ARTRealtime alloc] initWithOptions:options];
-                    _realtime2 = realtime2;
-                    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+                ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
+                query.direction = ARTQueryDirectionBackwards;
 
-                    ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-                    query.direction = ARTQueryDirectionBackwards;
-
-                    [channel2 history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                        XCTAssert(!error);
-                        XCTAssertFalse([result hasNext]);
-                        NSArray *items = [result items];
-                        XCTAssertTrue(items != nil);
-                        XCTAssertEqual([items count], firstBatchTotal);
-                        for(int i=0;i < [items count]; i++) {
-                            NSString *goalStr = [NSString stringWithFormat:@"test%d",firstBatchTotal -1 - i];
-                            ARTMessage *m = [items objectAtIndex:i];
-                            XCTAssertEqualObjects(goalStr, [m data]);
-                        }
-                        [expecation fulfill];
-                    } error:nil];
-                }
-            }];
-        }
-    }];
+                [channel2 history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                    XCTAssert(!error);
+                    XCTAssertFalse([result hasNext]);
+                    NSArray *items = [result items];
+                    XCTAssertTrue(items != nil);
+                    XCTAssertEqual([items count], firstBatchTotal);
+                    for(int i=0;i < [items count]; i++) {
+                        NSString *goalStr = [NSString stringWithFormat:@"test%d",firstBatchTotal -1 - i];
+                        ARTMessage *m = [items objectAtIndex:i];
+                        XCTAssertEqualObjects(goalStr, [m data]);
+                    }
+                    [expectation fulfill];
+                } error:nil];
+            }
+        }];
+    }
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 

--- a/Tests/ARTRealtimeChannelTest.m
+++ b/Tests/ARTRealtimeChannelTest.m
@@ -22,10 +22,8 @@
 #import "ARTCrypto+Private.h"
 #import "ARTChannelOptions.h"
 
-@interface ARTRealtimeChannelTest : XCTestCase {
-    ARTRealtime *_realtime;
-    ARTRealtime *_realtime2;
-}
+@interface ARTRealtimeChannelTest : XCTestCase
+
 @end
 
 @implementation ARTRealtimeChannelTest
@@ -35,327 +33,302 @@
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
-    if (_realtime2) {
-        [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2 resetEventEmitter];
-        [_realtime2 close];
-    }
-    _realtime2 = nil;
     [super tearDown];
 }
 
 - (void)testAttach {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-                [channel on:^(ARTErrorInfo *errorInfo) {
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        [expectation fulfill];
-                    }
-                }];
-                [channel attach];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
+            [channel on:^(ARTErrorInfo *errorInfo) {
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    [expectation fulfill];
+                }
+            }];
+            [channel attach];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachBeforeConnect {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_before_connect"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"attach_before_connect"];
-        [channel attach];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                [expectation fulfill];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"attach_before_connect"];
+    [channel attach];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachDetach {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"attach_detach"];
-        [channel attach];
-        
-        __block BOOL attached = NO;
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                attached = YES;
-                [channel detach];
-            }
-            if (attached && channel.state == ARTRealtimeChannelDetached) {
-                [expectation fulfill];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"attach_detach"];
+    [channel attach];
+    
+    __block BOOL attached = NO;
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attached = YES;
+            [channel detach];
+        }
+        if (attached && channel.state == ARTRealtimeChannelDetached) {
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachDetachAttach {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"attach_detach_attach"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"attach_detach_attach"];
-        [channel attach];
-        __block BOOL attached = false;
-        __block int attachCount = 0;
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                attachCount++;
-                attached = true;
-                if (attachCount == 1) {
-                    [channel detach];
-                }
-                else if (attachCount == 2) {
-                    [expectation fulfill];
-                }
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"attach_detach_attach"];
+    [channel attach];
+    __block BOOL attached = false;
+    __block int attachCount = 0;
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attachCount++;
+            attached = true;
+            if (attachCount == 1) {
+                [channel detach];
             }
-            if (attached && channel.state == ARTRealtimeChannelDetached) {
-                [channel attach];
+            else if (attachCount == 2) {
+                [expectation fulfill];
             }
-        }];
+        }
+        if (attached && channel.state == ARTRealtimeChannelDetached) {
+            [channel attach];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSubscribeUnsubscribe {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"publish"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     NSString *lostMessage = @"lost";
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"test"];
-        ARTEventListener __block *subscription = [channel subscribe:^(ARTMessage *message) {
-            if([[message data] isEqualToString:@"testString"]) {
-                [channel unsubscribe:subscription];
-                [channel publish:nil data:lostMessage callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            else if([[message data] isEqualToString:lostMessage]) {
-                XCTFail(@"unsubscribe failed");
-            }
-        }];
-
-        [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            NSString *finalMessage = @"final";
-            [channel subscribe:^(ARTMessage *message) {
-                if([[message data] isEqualToString:finalMessage]) {
-                    [expectation fulfill];
-                }
-            }];
-            [channel publish:nil data:finalMessage callback:^(ARTErrorInfo *errorInfo) {
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"test"];
+    ARTEventListener __block *subscription = [channel subscribe:^(ARTMessage *message) {
+        if([[message data] isEqualToString:@"testString"]) {
+            [channel unsubscribe:subscription];
+            [channel publish:nil data:lostMessage callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
             }];
+        }
+        else if([[message data] isEqualToString:lostMessage]) {
+            XCTFail(@"unsubscribe failed");
+        }
+    }];
+
+    [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        NSString *finalMessage = @"final";
+        [channel subscribe:^(ARTMessage *message) {
+            if([[message data] isEqualToString:finalMessage]) {
+                [expectation fulfill];
+            }
+        }];
+        [channel publish:nil data:finalMessage callback:^(ARTErrorInfo *errorInfo) {
+            XCTAssertNil(errorInfo);
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSuspendingDetachesChannel {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        __block bool gotCb=false;
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [realtime onSuspended];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
+    __block bool gotCb=false;
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [realtime onSuspended];
+        }
+        else if(channel.state == ARTRealtimeChannelDetached) {
+            if(!gotCb) {
+                [channel publish:nil data:@"will_fail" callback:^(ARTErrorInfo *errorInfo) {
+                    XCTAssertNotNil(errorInfo);
+                    XCTAssertEqual(90001, errorInfo.code);
+                    gotCb = true;
+                    [realtime close];
+                    [expectation fulfill];
+                }];
             }
-            else if(channel.state == ARTRealtimeChannelDetached) {
-                if(!gotCb) {
-                    [channel publish:nil data:@"will_fail" callback:^(ARTErrorInfo *errorInfo) {
-                        XCTAssertNotNil(errorInfo);
-                        XCTAssertEqual(90001, errorInfo.code);
-                        gotCb = true;
-                        [realtime close];
-                        [expectation fulfill];
-                    }];
-                }
-            }
-        }];
-        [channel attach];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testFailingFailsChannel {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSuspendingDetachesChannel"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-            }
-            else if(channel.state == ARTRealtimeChannelFailed) {
-                [channel publish:nil data:@"will_fail" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNotNil(errorInfo);
-                    [expectation fulfill];
-                }];
-            }
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+        }
+        else if(channel.state == ARTRealtimeChannelFailed) {
+            [channel publish:nil data:@"will_fail" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNotNil(errorInfo);
+                [expectation fulfill];
+            }];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testGetChannels {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *c1 = [realtime.channels get:@"channel"];
-        ARTRealtimeChannel *c2 = [realtime.channels get:@"channel2"];
-        ARTRealtimeChannel *c3 = [realtime.channels get:@"channel3"];
-        {
-            NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
-            for (ARTRealtimeChannel *channel in realtime.channels) {
-                [d setValue:channel forKey:channel.name];
-            }
-            XCTAssertEqual([[d allKeys] count], 3);
-            XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
-            XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
-            XCTAssertEqualObjects([d valueForKey:@"channel3"], c3);
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *c1 = [realtime.channels get:@"channel"];
+    ARTRealtimeChannel *c2 = [realtime.channels get:@"channel2"];
+    ARTRealtimeChannel *c3 = [realtime.channels get:@"channel3"];
+
+    NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
+    for (ARTRealtimeChannel *channel in realtime.channels) {
+        [d setValue:channel forKey:channel.name];
+    }
+    XCTAssertEqual([[d allKeys] count], 3);
+    XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
+    XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
+    XCTAssertEqualObjects([d valueForKey:@"channel3"], c3);
+
+    [realtime.channels release:c3.name callback:^(ARTErrorInfo *errorInfo) {
+        NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
+        for (ARTRealtimeChannel *channel in realtime.channels) {
+            [d setValue:channel forKey:channel.name];
         }
-        [realtime.channels release:c3.name callback:^(ARTErrorInfo *errorInfo) {
-            NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
-            for (ARTRealtimeChannel *channel in realtime.channels) {
-                [d setValue:channel forKey:channel.name];
-            }
-            XCTAssertEqual([[d allKeys] count], 2);
-            XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
-            XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
-        }];
-        
-        [exp fulfill];
+        XCTAssertEqual([[d allKeys] count], 2);
+        XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
+        XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
     }];
+    
+    [expectation fulfill];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testGetSameChannelWithParams {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testGetChannels"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     NSString *channelName = @"channel";
     NSString *firstMessage = @"firstMessage";
     NSString *secondMessage = @"secondMessage";
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *c1 = [realtime.channels get:channelName];
-        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
-        
-        NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
-        ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
-        ARTRealtimeChannel *c2 = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
-        [c1 publish:nil data:firstMessage callback:^(ARTErrorInfo *errorInfo) {
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *c1 = [realtime.channels get:channelName];
+    NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+    NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+    ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
+    ARTRealtimeChannel *c2 = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
+    [c1 publish:nil data:firstMessage callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [c2 publish:nil data:secondMessage callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [c2 publish:nil data:secondMessage callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-            }];
         }];
-        __block int messageCount =0;
-        [c1 subscribe:^(ARTMessage *message) {
-            if(messageCount ==0) {
-                XCTAssertEqualObjects([message data], firstMessage);
-            }
-            else if(messageCount ==1) {
-                XCTAssertEqualObjects([message data], secondMessage);
-                [exp fulfill];
-            }
-            messageCount++;
-        }];
+    }];
+    __block int messageCount = 0;
+    [c1 subscribe:^(ARTMessage *message) {
+        if(messageCount == 0) {
+            XCTAssertEqualObjects([message data], firstMessage);
+        }
+        else if (messageCount == 1) {
+            XCTAssertEqualObjects([message data], secondMessage);
+            [expectation fulfill];
+        }
+        messageCount++;
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testAttachFails {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testAttachFails"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel on:^(ARTErrorInfo *errorInfo) {
-                    if (channel.state == ARTRealtimeChannelAttached) {
-                        [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                    }
-                }];
-                [channel attach];
-            }
-            else if(state == ARTRealtimeFailed) {
-                [channel attach:^(ARTErrorInfo *errorInfo) {
-                    XCTAssert(errorInfo);
-                    XCTAssertEqual(errorInfo.code, 90000);
-                    [exp fulfill];
-                }];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"attach"];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel on:^(ARTErrorInfo *errorInfo) {
+                if (channel.state == ARTRealtimeChannelAttached) {
+                    [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+                }
+            }];
+            [channel attach];
+        }
+        else if(state == ARTRealtimeFailed) {
+            [channel attach:^(ARTErrorInfo *errorInfo) {
+                XCTAssert(errorInfo);
+                XCTAssertEqual(errorInfo.code, 90000);
+                [expectation fulfill];
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testClientIdPreserved {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+
     NSString *firstClientId = @"firstClientId";
     NSString *channelName = @"channelName";
 
-    __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testClientIdPreserved1"];
-    __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testClientIdPreserved2"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO callback:^(ARTClientOptions *options) {
-        // First instance
-        options.clientId = firstClientId;
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    // First instance
+    options.clientId = firstClientId;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
 
-        // Second instance
-        options.clientId = @"secondClientId";
-        ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime2 = realtime2;
-        ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+    // Second instance
+    options.clientId = @"secondClientId";
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
 
-        __block NSUInteger attached = 0;
-        // Channel 1
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                attached++;
-            }
-        }];
+    __block NSUInteger attached = 0;
+    // Channel 1
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
 
-        // Channel 2
-        [channel2 on:^(ARTErrorInfo *errorInfo) {
-            if (channel2.state == ARTRealtimeChannelAttached) {
-                attached++;
-            }
-        }];
+    // Channel 2
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        if (channel2.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
 
-        [channel2.presence subscribe:^(ARTPresenceMessage *message) {
-            XCTAssertEqualObjects(message.clientId, firstClientId);
-            [channel2 off];
-            [exp1 fulfill];
-        }];
+    [channel2.presence subscribe:^(ARTPresenceMessage *message) {
+        XCTAssertEqualObjects(message.clientId, firstClientId);
+        [channel2 off];
+        [expectation1 fulfill];
+    }];
 
-        [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
+    [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
 
-        // Enters "firstClientId"
-        [channel.presence enter:@"First Client" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            [exp2 fulfill];
-        }];
+    // Enters "firstClientId"
+    [channel.presence enter:@"First Client" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [expectation2 fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }

--- a/Tests/ARTRealtimeConnectTest.m
+++ b/Tests/ARTRealtimeConnectTest.m
@@ -17,9 +17,8 @@
 #import "ARTEventEmitter.h"
 #import "ARTRealtimeChannel.h"
 
-@interface ARTRealtimeConnectTest : XCTestCase {
-    ARTRealtime *_realtime;
-}
+@interface ARTRealtimeConnectTest : XCTestCase
+
 @end
 
 @implementation ARTRealtimeConnectTest
@@ -31,273 +30,251 @@
 
 - (void)tearDown {
     [super tearDown];
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
 }
 
 - (void)testConnectText {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectText"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [expectation fulfill];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectPing {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectPing"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [realtime.connection ping:^(ARTErrorInfo *error) {
-                    XCTAssertNil(error);
-                    [expectation fulfill];
-                }];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [realtime.connection ping:^(ARTErrorInfo *error) {
+                XCTAssertNil(error);
+                [expectation fulfill];
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectStateChange {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     options.autoConnect = false;
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        __block bool connectingHappened = false;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnecting) {
-                XCTAssertTrue(realtime.connection.id == nil);
-                XCTAssertTrue(realtime.connection.key == nil);
-                connectingHappened = true;
-            }
-            else if(state == ARTRealtimeConnected) {
-                
-                XCTAssertTrue(realtime.connection.id != nil);
-                XCTAssertTrue(realtime.connection.key != nil);
-
-                XCTAssertTrue(connectingHappened);
-                [expectation fulfill];
-            }
-        }];
-        [realtime connect];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block bool connectingHappened = false;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnecting) {
+            XCTAssertTrue(realtime.connection.id == nil);
+            XCTAssertTrue(realtime.connection.key == nil);
+            connectingHappened = true;
+        }
+        else if(state == ARTRealtimeConnected) {
+            XCTAssertTrue(realtime.connection.id != nil);
+            XCTAssertTrue(realtime.connection.key != nil);
+            XCTAssertTrue(connectingHappened);
+            [expectation fulfill];
+        }
     }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectStateChangeClose {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     options.autoConnect = false;
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        __block bool closingHappened = false;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [realtime close];
-            }
-            else if(state == ARTRealtimeClosing) {
-                closingHappened = true;
-            }
-            else if(state == ARTRealtimeClosed) {
-                XCTAssertTrue(closingHappened);
-                XCTAssertEqual([realtime.connection state], state);
-                [expectation fulfill];
-            }
-        }];
-        [realtime connect];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block bool closingHappened = false;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [realtime close];
+        }
+        else if(state == ARTRealtimeClosing) {
+            closingHappened = true;
+        }
+        else if(state == ARTRealtimeClosed) {
+            XCTAssertTrue(closingHappened);
+            XCTAssertEqual([realtime.connection state], state);
+            [expectation fulfill];
+        }
     }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectionSerial {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     options.autoConnect = false;
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-        
-            if(state == ARTRealtimeConnected) {
-                XCTAssertEqual(realtime.connection.serial, -1);
-                ARTRealtimeChannel *c =[realtime.channels get:@"chan"];
-                [c publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertEqual(realtime.connection.serial, 0);
-                    [c publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
-                        XCTAssertEqual(realtime.connection.serial, 1);
-                        [expectation fulfill];
-                    }];
-                    XCTAssertEqual(realtime.connection.serial, 0); //confirms that serial only updates after an ack
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+    
+        if(state == ARTRealtimeConnected) {
+            XCTAssertEqual(realtime.connection.serial, -1);
+            ARTRealtimeChannel *c =[realtime.channels get:@"chan"];
+            [c publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertEqual(realtime.connection.serial, 0);
+                [c publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
+                    XCTAssertEqual(realtime.connection.serial, 1);
+                    [expectation fulfill];
                 }];
-                [c attach];
-            }
-        }];
-        [realtime connect];
+                XCTAssertEqual(realtime.connection.serial, 0); //confirms that serial only updates after an ack
+            }];
+            [c attach];
+        }
     }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectAfterClose {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"test_connect_text"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        __block int connectionCount=0;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-        
-            if (state == ARTRealtimeConnected) {
-                connectionCount++;
-                if(connectionCount ==1) {
-                    [realtime close];
-                }
-                else if( connectionCount ==2) {
-                    [expectation fulfill];
-                }
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block int connectionCount = 0;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+    
+        if (state == ARTRealtimeConnected) {
+            connectionCount++;
+            if(connectionCount == 1) {
+                [realtime close];
             }
-            if( state == ARTRealtimeClosed && connectionCount ==1) {
-                [realtime connect];
+            else if( connectionCount == 2) {
+                [expectation fulfill];
             }
-        }];
+        }
+        if (state == ARTRealtimeClosed && connectionCount == 1) {
+            [realtime connect];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectingFromClosing {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testConnectStateChange"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        __block bool connectHappened = false;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-        
-            if(state == ARTRealtimeConnected) {
-                if(connectHappened) {
-                    [expectation fulfill];
-                }
-                else {
-                    connectHappened = true;
-                    [realtime close];
-                }
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block bool connectHappened = false;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+    
+        if (state == ARTRealtimeConnected) {
+            if (connectHappened) {
+                [expectation fulfill];
             }
-            else if(state == ARTRealtimeClosed) {
-                [realtime connect];
+            else {
+                connectHappened = true;
+                [realtime close];
             }
-        }];
+        }
+        else if (state == ARTRealtimeClosed) {
+            [realtime connect];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectStates {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectStates"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.autoConnect = false;
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-        __block bool gotInitialized =false;
-        __block bool gotConnecting =false;
-        __block bool gotConnected =false;
-        __block bool gotDisconnected =false;
-        __block bool gotSuspended =false;
-        __block bool gotClosing =false;
-        __block bool gotClosed =false;
-        __block bool gotFailed= false;
-        
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.autoConnect = false;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block bool gotInitialized =false;
+    __block bool gotConnecting =false;
+    __block bool gotConnected =false;
+    __block bool gotDisconnected =false;
+    __block bool gotSuspended =false;
+    __block bool gotClosing =false;
+    __block bool gotClosed =false;
+    __block bool gotFailed= false;
+    
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
 
-            if(state == ARTRealtimeConnecting) {
-                gotConnecting = true;
-                if (stateChange.previous == ARTRealtimeInitialized) {
-                    gotInitialized = true;
-                }
+        if(state == ARTRealtimeConnecting) {
+            gotConnecting = true;
+            if (stateChange.previous == ARTRealtimeInitialized) {
+                gotInitialized = true;
             }
-            else if(state == ARTRealtimeConnected) {
-                if(!gotConnected) {
-                    gotConnected = true;
-                    [realtime close];
-                }
-                else {
-                    [realtime onDisconnected];
-                }
+        }
+        else if(state == ARTRealtimeConnected) {
+            if(!gotConnected) {
+                gotConnected = true;
+                [realtime close];
             }
-            else if(state == ARTRealtimeDisconnected) {
-                gotDisconnected = true;
-                [realtime onSuspended];
+            else {
+                [realtime onDisconnected];
             }
-            else if(state == ARTRealtimeSuspended) {
-                gotSuspended = true;
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-            }
-            else if(state == ARTRealtimeClosing) {
-                gotClosing = true;
-                
-            }
-            else if(state == ARTRealtimeClosed) {
-                gotClosed = true;
-                [realtime connect];
-            }
-            else if(state == ARTRealtimeFailed) {
-                gotFailed = true;
-                XCTAssertTrue(gotInitialized);
-                XCTAssertTrue(gotConnecting);
-                XCTAssertTrue(gotConnected);
-                XCTAssertTrue(gotDisconnected);
-                XCTAssertTrue(gotSuspended);
-                XCTAssertTrue(gotClosing);
-                XCTAssertTrue(gotClosed);
-                XCTAssertTrue(gotFailed);
-                XCTAssertTrue([realtime.connection state] == ARTRealtimeFailed);
-                [exp fulfill];
-            }
-        }];
-        [realtime connect];
+        }
+        else if(state == ARTRealtimeDisconnected) {
+            gotDisconnected = true;
+            [realtime onSuspended];
+        }
+        else if(state == ARTRealtimeSuspended) {
+            gotSuspended = true;
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+        }
+        else if(state == ARTRealtimeClosing) {
+            gotClosing = true;
+            
+        }
+        else if(state == ARTRealtimeClosed) {
+            gotClosed = true;
+            [realtime connect];
+        }
+        else if(state == ARTRealtimeFailed) {
+            gotFailed = true;
+            XCTAssertTrue(gotInitialized);
+            XCTAssertTrue(gotConnecting);
+            XCTAssertTrue(gotConnected);
+            XCTAssertTrue(gotDisconnected);
+            XCTAssertTrue(gotSuspended);
+            XCTAssertTrue(gotClosing);
+            XCTAssertTrue(gotClosed);
+            XCTAssertTrue(gotFailed);
+            XCTAssertTrue([realtime.connection state] == ARTRealtimeFailed);
+            [expectation fulfill];
+        }
     }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testConnectPingError {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectPingError"];
-    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     options.autoConnect = false;
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        __block bool hasClosed = false;
-        __block id listener = nil;
-        listener = [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-        
-            if(state == ARTRealtimeConnected) {
-                [realtime close];
-            }
-            if(state == ARTRealtimeClosed) {
-                hasClosed = true;
-                XCTAssertThrows([realtime.connection ping:^(ARTErrorInfo *e) {}]);
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-            }
-            if(state == ARTRealtimeFailed) {
-                XCTAssertTrue(hasClosed);
-                XCTAssertThrows([realtime.connection ping:^(ARTErrorInfo *e) {}]);
-                [exp fulfill];
-                [realtime.connection off:listener];
-            }
-        }];
-        [realtime connect];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    __block bool hasClosed = false;
+    __block id listener = nil;
+    listener = [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+    
+        if(state == ARTRealtimeConnected) {
+            [realtime close];
+        }
+        if(state == ARTRealtimeClosed) {
+            hasClosed = true;
+            XCTAssertThrows([realtime.connection ping:^(ARTErrorInfo *e) {}]);
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+        }
+        if(state == ARTRealtimeFailed) {
+            XCTAssertTrue(hasClosed);
+            XCTAssertThrows([realtime.connection ping:^(ARTErrorInfo *e) {}]);
+            [expectation fulfill];
+            [realtime.connection off:listener];
+        }
     }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 

--- a/Tests/ARTRealtimeCryptoTest.m
+++ b/Tests/ARTRealtimeCryptoTest.m
@@ -19,95 +19,84 @@
 #import "ARTPaginatedResult.h"
 #import "ARTChannelOptions.h"
 
-@interface ARTRealtimeCryptoTest : XCTestCase {
-    ARTRealtime *_realtime;
-}
+@interface ARTRealtimeCryptoTest : XCTestCase
 
 @end
 
 @implementation ARTRealtimeCryptoTest
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime.connection close];
-    }
-    _realtime = nil;
 }
 
 - (void)testSendEncodedMessage {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessage"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
-        NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
-        ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
-        ARTRealtimeChannel *channel = [realtime.channels get:@"test" options:[[ARTChannelOptions alloc] initWithCipher: params]];
-        XCTAssert(channel);
-        NSString *dataStr = @"someDataPayload";
-        NSData *dataPayload = [dataStr  dataUsingEncoding:NSUTF8StringEncoding];
-        NSString *stringPayload = @"someString";
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+    NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+    ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"test" options:[[ARTChannelOptions alloc] initWithCipher: params]];
+    XCTAssert(channel);
+    NSString *dataStr = @"someDataPayload";
+    NSData *dataPayload = [dataStr  dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *stringPayload = @"someString";
 
-        [channel publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
+    [channel publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
-                [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    XCTAssertFalse([result hasNext]);
-                    NSArray *page = [result items];
-                    XCTAssertTrue(page != nil);
-                    XCTAssertEqual([page count], 2);
-                    ARTMessage *stringMessage = [page objectAtIndex:0];
-                    ARTMessage *dataMessage = [page objectAtIndex:1];
-                    XCTAssertEqualObjects([dataMessage data], dataPayload);
-                    XCTAssertEqualObjects([stringMessage data], stringPayload);
-                    [exp fulfill];
-                } error:nil];
-            }];
+            ARTRealtimeHistoryQuery *query = [[ARTRealtimeHistoryQuery alloc] init];
+            [channel history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                XCTAssertFalse([result hasNext]);
+                NSArray *page = [result items];
+                XCTAssertTrue(page != nil);
+                XCTAssertEqual([page count], 2);
+                ARTMessage *stringMessage = [page objectAtIndex:0];
+                ARTMessage *dataMessage = [page objectAtIndex:1];
+                XCTAssertEqualObjects([dataMessage data], dataPayload);
+                XCTAssertEqualObjects([stringMessage data], stringPayload);
+                [expectation fulfill];
+            } error:nil];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSendEncodedMessageOnExistingChannel {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendEncodedMessageOnExistingChannel"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     NSString *channelName = @"channelName";
     NSString *firstMessageText = @"firstMessage";
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel publish:nil data:firstMessageText callback:^(ARTErrorInfo *errorInfo) {
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel publish:nil data:firstMessageText callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+        NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+        ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
+        ARTRealtimeChannel *c = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
+        XCTAssert(c);
+        NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+        NSString *stringPayload = @"someString";
+        [c publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
-            NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
-            ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
-            ARTRealtimeChannel *c = [realtime.channels get:channelName options:[[ARTChannelOptions alloc] initWithCipher:params]];
-            XCTAssert(c);
-            NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-            NSString *stringPayload = @"someString";
-            [c publish:nil data:dataPayload callback:^(ARTErrorInfo *errorInfo) {
+            [c publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [c publish:nil data:stringPayload callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                    [c history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                        XCTAssert(!error);
-                        XCTAssertFalse([result hasNext]);
-                        NSArray *page = [result items];
-                        XCTAssertTrue(page != nil);
-                        XCTAssertEqual([page count], 3);
-                        ARTMessage *stringMessage = [page objectAtIndex:0];
-                        ARTMessage *dataMessage = [page objectAtIndex:1];
-                        ARTMessage *firstMessage = [page objectAtIndex:2];
-                        XCTAssertEqualObjects([dataMessage data], dataPayload);
-                        XCTAssertEqualObjects([stringMessage data], stringPayload);
-                        XCTAssertEqualObjects([firstMessage data], firstMessageText);
-                        [exp fulfill];
-                    }];
+                [c history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                    XCTAssert(!error);
+                    XCTAssertFalse([result hasNext]);
+                    NSArray *page = [result items];
+                    XCTAssertTrue(page != nil);
+                    XCTAssertEqual([page count], 3);
+                    ARTMessage *stringMessage = [page objectAtIndex:0];
+                    ARTMessage *dataMessage = [page objectAtIndex:1];
+                    ARTMessage *firstMessage = [page objectAtIndex:2];
+                    XCTAssertEqualObjects([dataMessage data], dataPayload);
+                    XCTAssertEqualObjects([stringMessage data], stringPayload);
+                    XCTAssertEqualObjects([firstMessage data], firstMessageText);
+                    [expectation fulfill];
                 }];
             }];
         }];

--- a/Tests/ARTRealtimeInitTest.m
+++ b/Tests/ARTRealtimeInitTest.m
@@ -17,125 +17,106 @@
 #import "ARTLog.h"
 #import "ARTEventEmitter.h"
 #import "ARTAuth.h"
+#import "ARTAuth+Private.h"
 #import "ARTRealtime+Private.h"
 #import "ARTDefault.h"
 
-@interface ARTRealtimeInitTest : XCTestCase {
-    ARTRealtime *_realtime;
-}
+@interface ARTRealtimeInitTest : XCTestCase
+
 @end
 
 @implementation ARTRealtimeInitTest
 
 - (void)tearDown {
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
     [super tearDown];
 }
 
-- (void)getBaseOptions:(void (^)(ARTClientOptions *options)) cb {
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] withDebug:NO callback:cb];
-}
-
 - (void)testInitWithOptions {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"initWithOptions"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [expectation fulfill];
-            }
-            else {
-                XCTAssertEqual(state, ARTRealtimeConnecting);
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [expectation fulfill];
+        }
+        else {
+            XCTAssertEqual(state, ARTRealtimeConnecting);
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testInitWithHost {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithHost"];
-    [self getBaseOptions:^(ARTClientOptions *options) {
-        options.environment = @"test";
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeFailed) {
-                [expectation fulfill];
-            }
-            else {
-                XCTAssertEqual(state, ARTRealtimeConnecting);
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.environment = @"test";
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeFailed) {
+            [expectation fulfill];
+        }
+        else {
+            XCTAssertEqual(state, ARTRealtimeConnecting);
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testInitWithPort {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithPort"];
-    [self getBaseOptions:^(ARTClientOptions *options) {
-        options.tlsPort = 9998;
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeFailed) {
-                [expectation fulfill];
-            }
-            else {
-                XCTAssertEqual(state, ARTRealtimeConnecting);
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.tlsPort = 9998;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeFailed) {
+            [expectation fulfill];
+        }
+        else {
+            XCTAssertEqual(state, ARTRealtimeConnecting);
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout]+[ARTDefault connectTimeout] handler:nil];
 }
 
 - (void)testInitWithKey {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithKey"];
-    [self getBaseOptions:^(ARTClientOptions *options) {
-        _realtime = [[ARTRealtime alloc] initWithKey:options.key];
-        if (_realtime.connection.state == ARTRealtimeConnecting) {
-            XCTAssertEqual(_realtime.auth.options.key, options.key);
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithKey:options.key];
+    if (realtime.connection.state == ARTRealtimeConnecting) {
+        XCTAssertEqual(realtime.auth.options.key, options.key);
+        [expectation fulfill];
+    }
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+}
+
+- (void)testInitAutoConnectDefault {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
             [expectation fulfill];
         }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void)testInitAutoConnectDefault {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [expectation fulfill];
-            }
-        }];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-
 - (void)testInitAutoConnectFalse {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitAutoConnectDefault"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.autoConnect = false;
-        ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [expectation fulfill];
-            }
-        }];
-        [realtime connect];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.autoConnect = false;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [expectation fulfill];
+        }
     }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 

--- a/Tests/ARTRealtimeMessageTest.m
+++ b/Tests/ARTRealtimeMessageTest.m
@@ -22,10 +22,7 @@
 #import "ARTLog.h"
 #import "ARTNSArray+ARTFunctional.h"
 
-@interface ARTRealtimeMessageTest : XCTestCase {
-    ARTRealtime *_realtime;
-    ARTRealtime *_realtime2;
-}
+@interface ARTRealtimeMessageTest : XCTestCase
 
 @end
 
@@ -33,123 +30,98 @@
 
 - (void)tearDown {
     [super tearDown];
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
-    if (_realtime2) {
-        [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2 resetEventEmitter];
-        [_realtime2 close];
-    }
-    _realtime2 = nil;
 }
 
 - (void)multipleSendName:(NSString *)name count:(int)count delay:(int)delay {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+
     __block int numReceived = 0;
-    
-    __weak XCTestExpectation *e = [self expectationWithDescription:@"waitExp"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        [e fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:name];
 
-    [_realtime close];
+    [channel attach];
 
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"multiple_send"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:name];
-
-        [channel attach];
-
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                [channel subscribe:^(ARTMessage *message) {
-                    ++numReceived;
-                    if (numReceived == count) {
-                        [expectation fulfill];
-                    }
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            [channel subscribe:^(ARTMessage *message) {
+                ++numReceived;
+                if (numReceived == count) {
+                    [expectation fulfill];
+                }
+            }];
+            [ARTTestUtil repeat:count delay:(delay / 1000.0) block:^(int i) {
+                NSString *msg = [NSString stringWithFormat:@"Test message (_multiple_send) %d", i];
+                [channel publish:@"test_event" data:msg callback:^(ARTErrorInfo *errorInfo) { 
                 }];
-                [ARTTestUtil repeat:count delay:(delay / 1000.0) block:^(int i) {
-                    NSString *msg = [NSString stringWithFormat:@"Test message (_multiple_send) %d", i];
-                    [channel publish:@"test_event" data:msg callback:^(ARTErrorInfo *errorInfo) { 
-                    }];
-                }];
-            }
-        }];
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout]+delay handler:nil];
 }
 
 - (void)testSingleSendText {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendText"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testSingleSendText"];
-        [channel subscribe:^(ARTMessage *message) {
-            XCTAssertEqualObjects([message data], @"testString");
-            [expectation fulfill];
-        }];
-        [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testSingleSendText"];
+    [channel subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], @"testString");
+        [expectation fulfill];
+    }];
+    [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSingleSendEchoText {
-    __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testSingleSendEchoText1"];
-    __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testSingleSendEchoText2"];
-    __weak XCTestExpectation *exp3 = [self expectationWithDescription:@"testSingleSendEchoText3"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    __weak XCTestExpectation *expectation3 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-3", __FUNCTION__]];
     NSString *channelName = @"testSingleEcho";
     
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRealtime *realtime1 = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime = realtime1;
-        ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime2 = realtime2;
+    ARTRealtime *realtime1 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
 
-        ARTRealtimeChannel *channel = [realtime1.channels get:channelName];
-        ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+    ARTRealtimeChannel *channel = [realtime1.channels get:channelName];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
 
-        __block NSUInteger attached = 0;
-        // Channel 1
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                attached++;
-            }
-        }];
-
-        // Channel 2
-        [channel2 on:^(ARTErrorInfo *errorInfo) {
-            if (channel2.state == ARTRealtimeChannelAttached) {
-                attached++;
-            }
-        }];
-
-        [channel subscribe:^(ARTMessage *message) {
-            XCTAssertEqualObjects([message data], @"testStringEcho");
-            [exp1 fulfill];
-        }];
-
-
-        [channel2 subscribe:^(ARTMessage *message) {
-            XCTAssertEqualObjects([message data], @"testStringEcho");
-            [exp2 fulfill];
-        }];
-
-        [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
-
-        [channel2 publish:nil data:@"testStringEcho" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            [exp3 fulfill];
-        }];
+    __block NSUInteger attached = 0;
+    // Channel 1
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
     }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+
+    // Channel 2
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        if (channel2.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
+
+    [channel subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], @"testStringEcho");
+        [expectation1 fulfill];
+    }];
+
+
+    [channel2 subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], @"testStringEcho");
+        [expectation2 fulfill];
+    }];
+
+    [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
+
+    [channel2 publish:nil data:@"testStringEcho" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [expectation3 fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout]+5.0 handler:nil];
 }
 
 - (void)testPublish_10_1000 {
@@ -161,156 +133,154 @@
 }
 
 - (void)testEchoMessagesDefault {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+
     NSString *channelName = @"channel";
     NSString *message1 = @"message1";
     NSString *message2 = @"message2";
 
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesDefault"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-    
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        __block bool gotMessage1 = false;
-        [channel subscribe:^(ARTMessage *message) {
-            if([[message data] isEqualToString:message1]) {
-                gotMessage1 = true;
-            }
-            else {
-                XCTAssertTrue(gotMessage1);
-                XCTAssertEqualObjects([message data], message2);
-                [exp fulfill];
-            }
-        }];
-        [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    __block bool gotMessage1 = false;
+    [channel subscribe:^(ARTMessage *message) {
+        if([[message data] isEqualToString:message1]) {
+            gotMessage1 = true;
+        }
+        else {
+            XCTAssertTrue(gotMessage1);
+            XCTAssertEqualObjects([message data], message2);
+            [expectation fulfill];
+        }
+    }];
+    [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+        [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-            }];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEchoMessagesFalse {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEchoMessagesFalse"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+
     NSString *channelName = @"channel";
     NSString *message1 = @"message1";
     NSString *message2 = @"message2";
-    
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.echoMessages = false;
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel subscribe:^(ARTMessage *message) {
-            //message1 should never arrive
-            XCTAssertEqualObjects([message data], message2);
-            [exp fulfill];
-        }];
-        [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
+
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.echoMessages = false;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel subscribe:^(ARTMessage *message) {
+        //message1 should never arrive
+        XCTAssertEqualObjects([message data], message2);
+        [expectation fulfill];
+    }];
+    [channel publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+        [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-            }];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSubscribeAttaches {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSingleSendText"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testSubscribeAttaches"];
-        [channel subscribe:^(ARTMessage *message) {
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            XCTAssert(!errorInfo);
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [expectation fulfill];
-            }   
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testSubscribeAttaches"];
+    [channel subscribe:^(ARTMessage *message) {
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        XCTAssert(!errorInfo);
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [expectation fulfill];
+        }   
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testMessageQueue {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testMessageQueue"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+
     NSString *connectingMessage = @"connectingMessage";
     NSString *disconnectedMessage = @"disconnectedMessage";
-    ARTClientOptions *options = [ARTTestUtil clientOptions];
+
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     options.autoConnect = false;
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testMessageQueue"];
-        __block int messagesReceived = 0;
-        [channel subscribe:^(ARTMessage *message) {
-            if(messagesReceived ==0) {
-                XCTAssertEqualObjects([message data], connectingMessage);
-            }
-            else if(messagesReceived ==1) {
-                XCTAssertEqualObjects([message data], disconnectedMessage);
-                [exp fulfill];
-            }
-            messagesReceived++;
-        }];
-        __block bool connectingHappened = false;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state ==ARTRealtimeConnecting) {
-                if(connectingHappened) {
-                    [channel attach];
-                }
-                else {
-                    connectingHappened = true;
-                    [channel publish:nil data:connectingMessage callback:^(ARTErrorInfo *errorInfo) {
-                        XCTAssertNil(errorInfo);
-                        [realtime onDisconnected];
-                    }];
-                }
-            }
-            else if(state == ARTRealtimeDisconnected) {
-                [channel publish:nil data:disconnectedMessage callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-                [realtime connect];
-            }
-        }];
-        [realtime connect];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testMessageQueue"];
+    __block int messagesReceived = 0;
+    [channel subscribe:^(ARTMessage *message) {
+        if(messagesReceived ==0) {
+            XCTAssertEqualObjects([message data], connectingMessage);
+        }
+        else if(messagesReceived ==1) {
+            XCTAssertEqualObjects([message data], disconnectedMessage);
+            [expectation fulfill];
+        }
+        messagesReceived++;
     }];
+    __block bool connectingHappened = false;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state ==ARTRealtimeConnecting) {
+            if(connectingHappened) {
+                [channel attach];
+            }
+            else {
+                connectingHappened = true;
+                [channel publish:nil data:connectingMessage callback:^(ARTErrorInfo *errorInfo) {
+                    XCTAssertNil(errorInfo);
+                    [realtime onDisconnected];
+                }];
+            }
+        }
+        else if(state == ARTRealtimeDisconnected) {
+            [channel publish:nil data:disconnectedMessage callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+            [realtime connect];
+        }
+    }];
+    [realtime connect];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 
 - (void)testConnectionIdsInMessage {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channelName";
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testConnectionIdsInMessage"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        XCTAssertFalse([_realtime2.connection.key isEqualToString:_realtime.connection.key]);
-        ARTRealtimeChannel *c1 = [_realtime.channels get:channelName];
-        [c1 publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    XCTAssertFalse([realtime2.connection.key isEqualToString:realtime.connection.key]);
+    ARTRealtimeChannel *c1 = [realtime.channels get:channelName];
+    [c1 publish:nil data:@"message" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        ARTRealtimeChannel *c2 = [realtime2.channels get:channelName];
+        [c2 publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            ARTRealtimeChannel *c2 = [_realtime2.channels get:channelName];
-            [c2 publish:nil data:@"message2" callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [c1 history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    NSArray *messages = [result items];
-                    XCTAssertEqual(2, messages.count);
-                    ARTMessage *m0 = messages[0];
-                    ARTMessage *m1 = messages[1];
-                    XCTAssertEqualObjects(m0.data, @"message2");
-                    XCTAssertEqualObjects(m1.data, @"message");
-                    XCTAssertEqualObjects(m0.connectionId, _realtime2.connection.id);
-                    XCTAssertEqualObjects(m1.connectionId, _realtime.connection.id);
-                    XCTAssertFalse([m0.connectionId isEqualToString:m1.connectionId]);
-                    [exp fulfill];
-                }];
+            [c1 history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                NSArray *messages = [result items];
+                XCTAssertEqual(2, messages.count);
+                ARTMessage *m0 = messages[0];
+                ARTMessage *m1 = messages[1];
+                XCTAssertEqualObjects(m0.data, @"message2");
+                XCTAssertEqualObjects(m1.data, @"message");
+                XCTAssertEqualObjects(m0.connectionId, realtime2.connection.id);
+                XCTAssertEqualObjects(m1.connectionId, realtime.connection.id);
+                XCTAssertFalse([m0.connectionId isEqualToString:m1.connectionId]);
+                [expectation fulfill];
             }];
         }];
     }];
@@ -318,99 +288,94 @@
 }
 
 - (void)testPublishImmediate {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishImmediate"];
-    
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [_realtime.channels get:@"testSingleSendText"];
-        [_realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
-        [channel subscribe:^(ARTMessage *message) {
-            XCTAssertEqualObjects([message data], @"testString");
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testSingleSendText"];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel publish:nil data:@"testString" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+    }];
+    [channel subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], @"testString");
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testPublishArray {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishArray"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        NSArray *messages = [@[@"test1", @"test2", @"test3"] artMap:^id(id data) {
-            return [[ARTMessage alloc] initWithName:nil data:data];
-        }];
-        [channel publish:messages callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
-        __block int messageCount =0;
-        [channel subscribe:^(ARTMessage *message) {
-            if(messageCount ==0) {
-                XCTAssertEqualObjects([message data], @"test1");
-            }
-            else if(messageCount ==1) {
-                XCTAssertEqualObjects([message data], @"test2");
-            }
-            else if(messageCount ==2) {
-                XCTAssertEqualObjects([message data], @"test3");
-                [exp fulfill];
-            }
-            messageCount++;
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
+    NSArray *messages = [@[@"test1", @"test2", @"test3"] artMap:^id(id data) {
+        return [[ARTMessage alloc] initWithName:nil data:data];
+    }];
+    [channel publish:messages callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+    }];
+    __block int messageCount =0;
+    [channel subscribe:^(ARTMessage *message) {
+        if(messageCount ==0) {
+            XCTAssertEqualObjects([message data], @"test1");
+        }
+        else if(messageCount ==1) {
+            XCTAssertEqualObjects([message data], @"test2");
+        }
+        else if(messageCount ==2) {
+            XCTAssertEqualObjects([message data], @"test3");
+            [expectation fulfill];
+        }
+        messageCount++;
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testPublishWithName {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPublishWithName"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        [channel publish:@"messageName" data:@"test" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
-        [channel subscribe:^(ARTMessage *message) {
-            XCTAssertEqualObjects(message.data, @"test");
-            XCTAssertEqualObjects(message.name, @"messageName");
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
+    [channel publish:@"messageName" data:@"test" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+    }];
+    [channel subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects(message.data, @"test");
+        XCTAssertEqualObjects(message.name, @"messageName");
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 
 - (void)testSubscribeToName {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToName"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channel";
     NSString *messageName =@"messageName";
     NSString *messageContent = @"content";
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel subscribe:messageName callback:^(ARTMessage *message) {
-            XCTAssertEqualObjects([message data], messageContent);
-            [exp fulfill];
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel subscribe:messageName callback:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], messageContent);
+        [expectation fulfill];
+    }];
 
-        [channel publish:nil data:@"unnamed_wont_arrive" callback:^(ARTErrorInfo *errorInfo) {
+    [channel publish:nil data:@"unnamed_wont_arrive" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel publish:@"wrongName" data:@"wrong_name_wont_arrive" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel publish:@"wrongName" data:@"wrong_name_wont_arrive" callback:^(ARTErrorInfo *errorInfo) {
+            [channel publish:messageName data:messageContent callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [channel publish:messageName data:messageContent callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
             }];
         }];
     }];

--- a/Tests/ARTRealtimePresenceHistoryTest.m
+++ b/Tests/ARTRealtimePresenceHistoryTest.m
@@ -60,7 +60,7 @@
     ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
     ARTRealtimeChannel *channel = [realtime.channels get:[self channelName]];
     [channel attach];
-    [channel once:ARTRealtimeChannelAttached callback:^(ARTErrorInfo *errorInfo) {
+    [channel once:ARTChannelEventAttached callback:^(ARTErrorInfo *errorInfo) {
         [channel.presence enter:[self enter1Str] callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
             //second enter gets treated as an update.

--- a/Tests/ARTRealtimePresenceTest.m
+++ b/Tests/ARTRealtimePresenceTest.m
@@ -24,30 +24,13 @@
 #import "ARTLog.h"
 #import "ARTCrypto.h"
 
-@interface ARTRealtimePresenceTest : XCTestCase {
-    ARTRealtime *_realtime;
-    ARTRealtime *_realtime2;
-    ARTClientOptions *_options;
-    ARTRest *_rest;
-}
+@interface ARTRealtimePresenceTest : XCTestCase
 
 @end
 
 @implementation ARTRealtimePresenceTest
 
 - (void)tearDown {
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
-    if (_realtime2) {
-        [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2 resetEventEmitter];
-        [_realtime2 close];
-    }
-    _realtime2 = nil;
     [super tearDown];
 }
 
@@ -59,435 +42,423 @@
     return @"secondClientId";
 }
 
-- (void)withRealtimeClientId:(void (^)(ARTRealtime *realtime))cb {
-    if (!_realtime) {
-        ARTClientOptions *options = [ARTTestUtil clientOptions];
-        options.clientId = [self getClientId];
-        [ARTTestUtil setupApp:options callback:^(ARTClientOptions *options) {
-            if (options) {
-                _realtime = [[ARTRealtime alloc] initWithOptions:options];
-                _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-                cb(_realtime);
-            }
-        }];
-        return;
-    }
-    else {
-        cb(_realtime);
-    }
-}
-
-//only for use after withRealtimeClientId.
-- (void)withRealtimeClientId2:(void (^)(ARTRealtime *realtime))cb {
-    cb(_realtime2);
-}
-
 - (void)testTwoConnections {
-    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:@"testTwoConnections1"];
-    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:@"testTwoConnections2"];
-    __weak XCTestExpectation *expectation3 = [self expectationWithDescription:@"testTwoConnections3"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    __weak XCTestExpectation *expectation3 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-3", __FUNCTION__]];
     NSString *channelName = @"testSingleEcho";
-    [self withRealtimeClientId:^(ARTRealtime *realtime1) {
-        [self withRealtimeClientId2:^(ARTRealtime *realtime2) {
-            ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
 
-            __block NSUInteger attached = 0;
-            // Channel 1
-            [channel on:^(ARTErrorInfo *errorInfo) {
-                if (channel.state == ARTRealtimeChannelAttached) {
-                    attached++;
-                }
-            }];
-            // Channel 2
-            [channel2 on:^(ARTErrorInfo *errorInfo) {
-                if (channel.state == ARTRealtimeChannelAttached) {
-                    attached++;
-                }
-            }];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
 
-            [channel subscribe:^(ARTMessage *message) {
-                XCTAssertEqualObjects([message data], @"testStringEcho");
-                [expectation1 fulfill];
-            }];
+    __block NSUInteger attached = 0;
+    // Channel 1
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
+    // Channel 2
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
 
-            [channel2 subscribe:^(ARTMessage *message) {
-                XCTAssertEqualObjects([message data], @"testStringEcho");
-                [expectation2 fulfill];
-            }];
+    [channel subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], @"testStringEcho");
+        [expectation1 fulfill];
+    }];
 
-            [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
+    [channel2 subscribe:^(ARTMessage *message) {
+        XCTAssertEqualObjects([message data], @"testStringEcho");
+        [expectation2 fulfill];
+    }];
 
-            [channel2 publish:nil data:@"testStringEcho" callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [expectation3 fulfill];
-            }];
-        }];
+    [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
+
+    [channel2 publish:nil data:@"testStringEcho" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [expectation3 fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterSimple {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+
     NSString *channelName = @"presTest";
-    __weak XCTestExpectation *dummyExpectation = [self expectationWithDescription:@"testEnterSimple"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        [dummyExpectation fulfill];
+    NSString *presenceEnter = @"client_has_entered";
+
+    __weak XCTestExpectation *expectConnected = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [expectConnected fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-    NSString *presenceEnter = @"client_has_entered";
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        __weak XCTestExpectation *expectConnected = [self expectationWithDescription:@"expectConnected"];
 
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [expectConnected fulfill];
-            }
-        }];
-        [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        ARTRealtimeChannel *channel2 = [realtime.channels get:channelName];
-        [channel2 attach];
-        [channel attach];
-        __weak XCTestExpectation *expectChannel2Connected = [self expectationWithDescription:@"presence message"];
-
-        [channel2 on:^(ARTErrorInfo *errorInfo) {
-            if(channel2.state == ARTRealtimeChannelAttached) {
-                [expectChannel2Connected fulfill];
-            }
-        }];
-
-        [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-        __weak XCTestExpectation *expectPresenceMessage = [self expectationWithDescription:@"presence message"];
-
-        [channel2.presence subscribe:^(ARTPresenceMessage *message) {
-            [expectPresenceMessage fulfill];
-
-        }];
-        [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
-        [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    ARTRealtimeChannel *channel2 = [realtime.channels get:channelName];
+    [channel2 attach];
+    [channel attach];
+    
+    __weak XCTestExpectation *expectChannel2Connected = [self expectationWithDescription:@"presence message"];
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        if(channel2.state == ARTRealtimeChannelAttached) {
+            [expectChannel2Connected fulfill];
+        }
     }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+
+    __weak XCTestExpectation *expectPresenceMessage = [self expectationWithDescription:@"presence message"];
+    [channel2.presence subscribe:^(ARTPresenceMessage *message) {
+        [expectPresenceMessage fulfill];
+
+    }];
+    [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+    }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterAttachesTheChannel {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAttachesTheChannel"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        XCTAssertEqual(channel.state, ARTRealtimeChannelInitialized);
-        [channel.presence enter:@"entered" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            XCTAssertEqual(channel.state, ARTRealtimeChannelAttached);
-            [exp fulfill];
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
+    XCTAssertEqual(channel.state, ARTRealtimeChannelInitialized);
+    [channel.presence enter:@"entered" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        XCTAssertEqual(channel.state, ARTRealtimeChannelAttached);
+        [expectation fulfill];
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSubscribeConnects {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"presBeforeAttachTest";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-        }];
-        
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [expectation fulfill];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+    }];
+    
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testUpdateConnects {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"presBeforeAttachTest";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence update:@"update"  callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [expectation fulfill];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence update:@"update"  callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterBeforeConnect {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"testEnterBeforeConnect";
     NSString *presenceEnter = @"client_has_entered";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            XCTAssertEqualObjects([message data], presenceEnter);
-            [expectation fulfill];
-        }];
-        
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached)
-            {
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        XCTAssertEqualObjects([message data], presenceEnter);
+        [expectation fulfill];
+    }];
+    
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached)
+        {
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterLeaveSimple {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"testEnterLeaveSimple";
     NSString *presenceEnter = @"client_has_entered";
     NSString *presenceLeave = @"byebye";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence leave:presenceLeave callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            if(message.action == ARTPresenceLeave) {
-                XCTAssertEqualObjects([message data], presenceLeave);
-                [expectation fulfill];
-            }
-        }];
-        
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], presenceEnter);
+            [channel.presence leave:presenceLeave callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+        if(message.action == ARTPresenceLeave) {
+            XCTAssertEqualObjects([message data], presenceLeave);
+            [expectation fulfill];
+        }
+    }];
+    
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterEnter {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"testEnterLeaveSimple";
     NSString *presenceEnter = @"client_has_entered";
     NSString *secondEnter = @"secondEnter";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence enter:secondEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            else if(message.action == ARTPresenceUpdate) {
-                XCTAssertEqualObjects([message data], secondEnter);
-                [expectation fulfill];
-            }
-        }];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], presenceEnter);
+            [channel.presence enter:secondEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+        else if(message.action == ARTPresenceUpdate) {
+            XCTAssertEqualObjects([message data], secondEnter);
+            [expectation fulfill];
+        }
+    }];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
-- (void)testEnterUpdateSimple
-{
+- (void)testEnterUpdateSimple {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"testEnterLeaveSimple";
     NSString *presenceEnter = @"client_has_entered";
     NSString *update = @"updateMessage";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            else if(message.action == ARTPresenceUpdate) {
-                XCTAssertEqualObjects([message data], update);
-                [expectation fulfill];
-            }
-        }];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], presenceEnter);
+            [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+        else if(message.action == ARTPresenceUpdate) {
+            XCTAssertEqualObjects([message data], update);
+            [expectation fulfill];
+        }
+    }];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testUpdateNull {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"testEnterLeaveSimple";
     NSString *presenceEnter = @"client_has_entered";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence update:nil callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            else if(message.action == ARTPresenceUpdate) {
-                XCTAssertEqualObjects([message data], nil);
-                [expectation fulfill];
-            }
-        }];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], presenceEnter);
+            [channel.presence update:nil callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+        else if(message.action == ARTPresenceUpdate) {
+            XCTAssertEqualObjects([message data], nil);
+            [expectation fulfill];
+        }
+    }];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterLeaveWithoutData {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+
     NSString *channelName = @"testEnterLeaveSimple";
     NSString *presenceEnter = @"client_has_entered";
 
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], presenceEnter);
-                [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            if(message.action == ARTPresenceLeave) {
-                XCTAssertEqualObjects([message data], presenceEnter);
-                [expectation fulfill];
-            }
-            
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if (message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], presenceEnter);
+            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+        if (message.action == ARTPresenceLeave) {
+            XCTAssertEqualObjects([message data], presenceEnter);
+            [expectation fulfill];
+        }
         
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+    }];
+    
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testUpdateNoEnter {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+
     NSString *update = @"update_message";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testUpdateNoEnter"];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], update);
-                [expectation fulfill];
-            }
-        }];
+
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testUpdateNoEnter"];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], update);
+            [expectation fulfill];
+        }
+    }];
+    
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if (state == ARTRealtimeConnected) {
+            [channel attach];
+        }
+    }];
+    
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
         
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel.presence update:update callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            
-        }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterAndGet {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *enterData = @"online";
     NSString *channelName = @"test";
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        [options setClientId:[self getSecondClientId]];
-        _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-        [channel.presence enter:enterData callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.clientId = [self getClientId];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    [options setClientId:[self getSecondClientId]];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+    [channel.presence enter:enterData callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel2.presence enter:enterData callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel2.presence enter:enterData callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [channel2.presence get:^(NSArray<ARTPresenceMessage *> *members, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    XCTAssertEqual(2, members.count);
-                    XCTAssertEqual(members[0].action, ARTPresencePresent);
-                    XCTAssertEqual(members[1].action, ARTPresenceEnter);
-                    XCTAssertEqualObjects([members[0] data], enterData);
-                    XCTAssertEqualObjects([members[1] data], enterData);
-                    [exp fulfill];
-                }];
+            [channel2.presence get:^(NSArray<ARTPresenceMessage *> *members, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                XCTAssertEqual(2, members.count);
+                XCTAssertEqual(members[0].action, ARTPresencePresent);
+                XCTAssertEqual(members[1].action, ARTPresenceEnter);
+                XCTAssertEqualObjects([members[0] data], enterData);
+                XCTAssertEqualObjects([members[1] data], enterData);
+                [expectation fulfill];
             }];
         }];
     }];
@@ -495,308 +466,275 @@
 }
 
 - (void)testEnterNoClientId {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterNoClientId"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
-        [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo){
-            XCTAssertNotNil(errorInfo);
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
+    [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo){
+        XCTAssertNotNil(errorInfo);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterOnDetached {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel detach];
-            }
-            else if(channel.state == ARTRealtimeChannelDetached) {
-                [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNotNil(errorInfo);
-                    [expectation fulfill];
-                }];
-            }
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel detach];
+        }
+        else if(channel.state == ARTRealtimeChannelDetached) {
+            [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNotNil(errorInfo);
+                [expectation fulfill];
+            }];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterOnFailed {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel setFailed:[ARTStatus state:ARTStateError]];
-            }
-            else if(channel.state == ARTRealtimeChannelFailed) {
-                [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNotNil(errorInfo);
-                    [expectation fulfill];
-                }];
-            }
-        }];
-        [channel attach];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-
-//TODO wortk out why presence with clientId doesnt work
-/*
-- (void)testFilterPresenceByClientId {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSingleSendEchoText"];
-    NSString *channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence publishPresenceEnter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            [options setClientId: [self getSecondClientId]];
-            XCTAssertEqual(options.clientId, [self getSecondClientId]);
-           _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            [channel2.presence publishPresenceEnter:@"hi2" callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [channel2.presence getWithParams:@{@"client_id" : [self getSecondClientId]} callback:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
-                    XCTAssertNil(errorInfo);
-                    NSArray *messages = [result currentItems];
-                    XCTAssertEqual(1, messages.count);
-                    ARTPresenceMessage *m0 = messages[0];
-                    XCTAssertEqual(m0.action, ArtPresenceMessagePresent);
-                    XCTAssertEqualObjects(@"hi2", [m0 data]);
-                    [exp fulfill];
-                }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel setFailed:[ARTStatus state:ARTStateError]];
+        }
+        else if(channel.state == ARTRealtimeChannelFailed) {
+            [channel.presence enter:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNotNil(errorInfo);
+                [expectation fulfill];
             }];
-        }];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
- */
 
 - (void)testLeaveAndGet {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *enterData = @"enter";
     NSString *leaveData = @"bye";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
-        [channel.presence subscribe:^(ARTPresenceMessage * message) {
-            if (message.action == ARTPresenceEnter)  {
-                XCTAssertEqualObjects([message data], enterData);
-                [channel.presence leave:leaveData callback:^(ARTErrorInfo *error) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
+    [channel.presence subscribe:^(ARTPresenceMessage * message) {
+        if (message.action == ARTPresenceEnter)  {
+            XCTAssertEqualObjects([message data], enterData);
+            [channel.presence leave:leaveData callback:^(ARTErrorInfo *error) {
+                XCTAssert(!error);
+                [channel.presence get:^(NSArray *members, ARTErrorInfo *error) {
                     XCTAssert(!error);
-                    [channel.presence get:^(NSArray *members, ARTErrorInfo *error) {
-                        XCTAssert(!error);
-                        XCTAssertEqual(0, members.count);
-                        [expectation fulfill];
-                    }];
+                    XCTAssertEqual(0, members.count);
+                    [expectation fulfill];
                 }];
-            }
-        }];
+            }];
+        }
+    }];
 
-        [channel.presence enter:enterData callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
+    [channel.presence enter:enterData callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testLeaveNoData {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *enter = @"enter";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterLeaveNoData"];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter) {
-                XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-            else if(message.action == ARTPresenceLeave) {
-                XCTAssertEqualObjects([message data], enter);
-                [expectation fulfill];
-            }
-        }];
-        
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if (state == ARTRealtimeConnected) {
-                [channel attach];
-            }
-        }];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached)
-            {
-                [channel.presence update:enter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
-            }
-        }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterLeaveNoData"];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter) {
+            XCTAssertEqualObjects([message data], enter);
+            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
+        else if(message.action == ARTPresenceLeave) {
+            XCTAssertEqualObjects([message data], enter);
+            [expectation fulfill];
+        }
+    }];
+    [channel attach];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            [channel.presence update:enter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+            }];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testLeaveNoMessage {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *enter = @"enter";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter)  {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter)  {
+            XCTAssertEqualObjects([message data], enter);
+            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertEqualObjects([message data], enter);
-                }];
-            }
-            if(message.action == ARTPresenceLeave) {
-                XCTAssertEqualObjects([message data], enter);
-                [expectation fulfill];
-            }
-        }];
-        [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
-        [channel attach];
+            }];
+        }
+        if(message.action == ARTPresenceLeave) {
+            XCTAssertEqualObjects([message data], enter);
+            [expectation fulfill];
+        }
     }];
+    [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+    }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testLeaveWithMessage {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *enter = @"enter";
     NSString *leave = @"bye";
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            if(message.action == ARTPresenceEnter)  {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterAndGet"];
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        if(message.action == ARTPresenceEnter)  {
+            XCTAssertEqualObjects([message data], enter);
+            [channel.presence leave:leave callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertEqualObjects([message data], enter);
-                [channel.presence leave:leave callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertEqualObjects([message data], enter);
-                }];
-            }
-            if(message.action == ARTPresenceLeave) {
-                XCTAssertEqualObjects([message data], leave);
-                [expectation fulfill];
-            }
-        }];
-        [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-        }];
-        [channel attach];
+            }];
+        }
+        if(message.action == ARTPresenceLeave) {
+            XCTAssertEqualObjects([message data], leave);
+            [expectation fulfill];
+        }
     }];
+    [channel.presence enter:enter callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+    }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testLeaveOnDetached {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel detach];
-            }
-            else if(channel.state == ARTRealtimeChannelDetached) {
-                XCTAssertThrows([channel.presence leave:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {}]);
-                [expectation fulfill];
-            }
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel detach];
+        }
+        else if(channel.state == ARTRealtimeChannelDetached) {
+            XCTAssertThrows([channel.presence leave:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {}]);
+            [expectation fulfill];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testLeaveOnFailed {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"expectation"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel setFailed:[ARTStatus state:ARTStateError]];
-            }
-            else if(channel.state == ARTRealtimeChannelFailed) {
-                XCTAssertThrows([channel.presence leave:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {}]);
-                [expectation fulfill];
-            }
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"testEnterNoClientId"];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel setFailed:[ARTStatus state:ARTStateError]];
+        }
+        else if(channel.state == ARTRealtimeChannelFailed) {
+            XCTAssertThrows([channel.presence leave:@"thisWillFail" callback:^(ARTErrorInfo *errorInfo) {}]);
+            [expectation fulfill];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterFailsOnError {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterBeforeAttach"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"presBeforeAttachTest";
     NSString *presenceEnter = @"client_has_entered";
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNotNil(errorInfo);
-                    [exp fulfill];
-                }];
-            }
-        }];
-        [channel attach];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+            [channel.presence enter:presenceEnter callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNotNil(errorInfo);
+                [expectation fulfill];
+            }];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testGetFailsOnDetachedOrFailed {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterAndGet"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
-        __block bool hasDisconnected = false;
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [realtime onDisconnected];
-            }
-            else if(state == ARTRealtimeDisconnected) {
-                hasDisconnected = true;
-                XCTAssertThrows([channel.presence get:^(NSArray *result, ARTErrorInfo *error) {}]);
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-            }
-            else if(state == ARTRealtimeFailed) {
-                XCTAssertTrue(hasDisconnected);
-                XCTAssertThrows([channel.presence get:^(NSArray *result, ARTErrorInfo *error) {}]);
-                [exp fulfill];
-            }
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channel"];
+    __block bool hasDisconnected = false;
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [realtime onDisconnected];
+        }
+        else if(state == ARTRealtimeDisconnected) {
+            hasDisconnected = true;
+            XCTAssertThrows([channel.presence get:^(NSArray *result, ARTErrorInfo *error) {}]);
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+        }
+        else if(state == ARTRealtimeFailed) {
+            XCTAssertTrue(hasDisconnected);
+            XCTAssertThrows([channel.presence get:^(NSArray *result, ARTErrorInfo *error) {}]);
+            [expectation fulfill];
+        }
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testEnterClient {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *clientId = @"otherClientId";
     NSString *clientId2 = @"yetAnotherClientId";
-
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClient"];
-    [ARTTestUtil testRealtime:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
-        [channel.presence enterClient:clientId data:nil callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
+    [channel.presence enterClient:clientId data:nil callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel.presence  enterClient:clientId2 data:nil callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence  enterClient:clientId2 data:nil callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [channel.presence get:^(NSArray *members, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    XCTAssertEqual(2, members.count);
-                    ARTPresenceMessage *m0 = [members objectAtIndex:0];
-                    XCTAssertEqualObjects(m0.clientId, clientId2);
-                    ARTPresenceMessage *m1 = [members objectAtIndex:1];
-                    XCTAssertEqualObjects(m1.clientId, clientId);
-                    [exp fulfill];
-                }];
+            [channel.presence get:^(NSArray *members, ARTErrorInfo *error) {
+                XCTAssert(!error);
+                XCTAssertEqual(2, members.count);
+                ARTPresenceMessage *m0 = [members objectAtIndex:0];
+                XCTAssertEqualObjects(m0.clientId, clientId2);
+                ARTPresenceMessage *m1 = [members objectAtIndex:1];
+                XCTAssertEqualObjects(m1.clientId, clientId);
+                [expectation fulfill];
             }];
         }];
     }];
@@ -804,249 +742,160 @@
 }
 
 - (void)testEnterClientIdFailsOnError {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testEnterClientIdFailsOnError"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
-        [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            ARTRealtimeConnectionState state = stateChange.current;
-            if(state == ARTRealtimeConnected) {
-                [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                [channel.presence  enterClient:@"clientId" data:@"" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNotNil(errorInfo);
-                    [exp fulfill];
-                }];
-            }
-        }];
-        [channel attach];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        ARTRealtimeConnectionState state = stateChange.current;
+        if(state == ARTRealtimeConnected) {
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+            [channel.presence  enterClient:@"clientId" data:@"" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNotNil(errorInfo);
+                [expectation fulfill];
+            }];
+        }
     }];
+    [channel attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testWithNoClientIdUpdateLeaveEnterAnotherClient {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testWithNoClientIdUpdateLeaveEnterAnotherClient"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *otherClientId = @"otherClientId";
     NSString *data = @"data";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = nil;
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:@"channelName"];
-        [channel.presence  enterClient:otherClientId data:@"" callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.clientId = nil;
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:@"channelName"];
+    [channel.presence  enterClient:otherClientId data:@"" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel.presence updateClient:otherClientId data:data callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence updateClient:otherClientId data:data callback:^(ARTErrorInfo *errorInfo) {
+            [channel.presence leaveClient:otherClientId data:@"" callback:^(ARTErrorInfo *errorInfo) {
                 XCTAssertNil(errorInfo);
-                [channel.presence leaveClient:otherClientId data:@"" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                }];
             }];
         }];
-        
-        __block int messageCount =0;
-        [channel.presence subscribe:^(ARTPresenceMessage *message) {
-            XCTAssertEqualObjects(otherClientId, message.clientId);
-            if(messageCount ==0) {
-                XCTAssertEqual(message.action, ARTPresenceEnter);
-                XCTAssertEqualObjects(message.data, @"");
-            }
-            else if(messageCount ==1) {
-                XCTAssertEqual(message.action, ARTPresenceUpdate);
-                XCTAssertEqualObjects(message.data, data);
-            }
-            else if(messageCount ==2) {
-                XCTAssertEqual(message.action, ARTPresenceLeave);
-                XCTAssertEqualObjects(message.data, data);
-                [exp fulfill];
-            }
-            messageCount++;
-        }];
+    }];
+    __block int messageCount = 0;
+    [channel.presence subscribe:^(ARTPresenceMessage *message) {
+        XCTAssertEqualObjects(otherClientId, message.clientId);
+        if(messageCount == 0) {
+            XCTAssertEqual(message.action, ARTPresenceEnter);
+            XCTAssertEqualObjects(message.data, @"");
+        }
+        else if(messageCount == 1) {
+            XCTAssertEqual(message.action, ARTPresenceUpdate);
+            XCTAssertEqualObjects(message.data, data);
+        }
+        else if(messageCount == 2) {
+            XCTAssertEqual(message.action, ARTPresenceLeave);
+            XCTAssertEqualObjects(message.data, data);
+            [expectation fulfill];
+        }
+        messageCount++;
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-
-/*
-- (void)test250ClientsEnter {
-    NSString *channelName = @"channelName";
-
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"setupChannel2"];
-    ARTClientOptions *options =[ARTTestUtil clientOptions];
-    options.clientId = @"client_string";
-
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-        const int count = 250;
-        __block bool channel2SawAllPresences = false;
-
-        [ARTTestUtil testRealtime:^(ARTRealtime *realtime2) {
-            _realtime2 = realtime2;
-            ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
-            __block int numReceived = 0;
-
-            [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus *s) {
-                if (c == ARTRealtimeChannelAttached) {
-                    //channel2 enters itself
-                    [channel2.presence enterClient:@"channel2Enter" data:@"joins" callback:^(ARTErrorInfo *errorInfo) {
-                        XCTAssertNil(errorInfo);
-
-                        [ARTTestUtil bigSleep];
-
-                        //channel enters itself
-                        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
-                            XCTAssertNil(errorInfo);
-                            //channel enters 250 others
-                            [ARTTestUtil publishEnterMessages:@"aClientId" count:count channel:channel completion:^{
-                                [channel.presence get:^(ARTPaginatedResult *result, NSError *error) {
-                                    XCTAssert(!error);
-                                    NSArray *messages = [result items];
-                                    XCTAssertEqual(count+2, messages.count); //count + channel1+ channel2
-                                    XCTAssertTrue(channel2SawAllPresences);
-                                    [expectation fulfill];
-                                }];
-                            }];
-                        }];
-                    }];
-                }
-            }];
-            [channel2.presence subscribe:^(ARTPresenceMessage *message) {
-                numReceived++;
-                if (numReceived == count +1) {//count + channel1
-                    channel2SawAllPresences = true;
-                }
-            }];
-            [channel2 attach];
-        }];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-*/
 
 - (void)testPresenceMap {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channelName";
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            [options setClientId: [self getSecondClientId]];
-            XCTAssertEqual(options.clientId, [self getSecondClientId]);
-            _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            ARTRealtimePresenceQuery *query = [[ARTRealtimePresenceQuery alloc] init];
-            query.waitForSync = false;
-            [channel2.presence get:query callback:^(NSArray *members, ARTErrorInfo *error) {
-                XCTAssert(!error);
-                XCTAssertFalse(channel2.presence.syncComplete);
-                [ARTTestUtil delay:1.0 block:^{
-                    XCTAssertTrue(channel2.presence.syncComplete);
-                    ARTPresenceMap *map = channel2.presenceMap;
-                    ARTPresenceMessage *m = [map.members objectForKey:[self getClientId]];
-                    XCTAssertFalse(m == nil);
-                    XCTAssertEqual(m.action, ARTPresencePresent);
-                    XCTAssertEqualObjects([m data], @"hi");
-                    [exp fulfill];
-                }];
-            }];
-            [channel2 attach];
-        }];
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    options.clientId = [self getClientId];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [expectation1 fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-
-//TODO work out why wait_for_sync doesnt work
-/*
-- (void)testPresenceMapWaitOnSync {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceMap"];
-    NSString *channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence subscribeToPresence:^(ARTPresenceMessage *message) {
-        }];
-        [channel.presence publishPresenceEnter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            [options setClientId: [self getSecondClientId]];
-            XCTAssertEqual(options.clientId, [self getSecondClientId]);
-            _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-            ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-            [channel2.presence getWithParams:@{@"wait_for_sync": @"true"} callback:^(ARTErrorInfo *errorInfo, id<ARTPaginatedResult> result) {
-                XCTAssertNil(errorInfo);
-                ARTPresenceMap *map = channel2.presenceMap;
-                ARTPresenceMessage *m =[map getClient:[self getClientId]];
-                XCTAssertFalse(m == nil);
-                XCTAssertEqual(m.action, ArtPresenceMessagePresent);
-                XCTAssertEqualObjects([m data], @"hi");
-                [exp fulfill];
-            }];
-            [channel2 attach];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    [options setClientId: [self getSecondClientId]];
+    XCTAssertEqual(options.clientId, [self getSecondClientId]);
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+    ARTRealtimePresenceQuery *query = [[ARTRealtimePresenceQuery alloc] init];
+    query.waitForSync = false;
+    [channel2.presence get:query callback:^(NSArray *members, ARTErrorInfo *error) {
+        XCTAssert(!error);
+        XCTAssertFalse(channel2.presence.syncComplete);
+        [ARTTestUtil delay:1.0 block:^{
+            XCTAssertTrue(channel2.presence.syncComplete);
+            ARTPresenceMap *map = channel2.presenceMap;
+            ARTPresenceMessage *m = [map.members objectForKey:[self getClientId]];
+            XCTAssertFalse(m == nil);
+            XCTAssertEqual(m.action, ARTPresencePresent);
+            XCTAssertEqualObjects([m data], @"hi");
+            [expectation2 fulfill];
         }];
     }];
+    [channel2 attach];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-*/
 
 - (void)testLeaveBeforeEnterThrows {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLeaveBeforeEnterThrows"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        XCTAssertThrows([channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {}]); // leave before enter
-        [channel.presence enter:nil callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.clientId = [self getClientId];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    XCTAssertThrows([channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {}]); // leave before enter
+    [channel.presence enter:nil callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) { //leave after enter
             XCTAssertNil(errorInfo);
-            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) { //leave after enter
-                XCTAssertNil(errorInfo);
-                XCTAssertThrows([channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {}]); // leave after leave
-                [exp fulfill];
-            }];
+            XCTAssertThrows([channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {}]); // leave after leave
+            [expectation fulfill];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testSubscribeToAction {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    options.clientId = [self getClientId];
     NSString *channelName = @"presBeforeAttachTest";
     NSString *enter1 = @"enter1";
     NSString *update1 = @"update1";
     NSString *leave1 = @"leave1";
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSubscribeToAction"];
-    [self withRealtimeClientId:^(ARTRealtime *realtime) {
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
         
-        __block bool gotUpdate = false;
-        __block bool gotEnter = false;
-        __block bool gotLeave = false;
-        ARTEventListener *leaveSub = [channel.presence subscribe:ARTPresenceLeave callback:^(ARTPresenceMessage *message) {
-            XCTAssertEqualObjects([message data], leave1);
-            gotLeave = true;
-        }];
-        ARTEventListener *updateSub=[channel.presence subscribe:ARTPresenceUpdate callback:^(ARTPresenceMessage *message) {
-            XCTAssertEqualObjects([message data], update1);
-            gotUpdate = true;
-        }];
-        ARTEventListener *enterSub =[channel.presence subscribe:ARTPresenceEnter callback:^(ARTPresenceMessage *message) {
-            XCTAssertEqualObjects([message data], enter1);
-            gotEnter = true;
-        }];
-        [channel.presence enter:enter1 callback:^(ARTErrorInfo *errorInfo) {
+    __block bool gotUpdate = false;
+    __block bool gotEnter = false;
+    __block bool gotLeave = false;
+    ARTEventListener *leaveSub = [channel.presence subscribe:ARTPresenceLeave callback:^(ARTPresenceMessage *message) {
+        XCTAssertEqualObjects([message data], leave1);
+        gotLeave = true;
+    }];
+    ARTEventListener *updateSub=[channel.presence subscribe:ARTPresenceUpdate callback:^(ARTPresenceMessage *message) {
+        XCTAssertEqualObjects([message data], update1);
+        gotUpdate = true;
+    }];
+    ARTEventListener *enterSub =[channel.presence subscribe:ARTPresenceEnter callback:^(ARTPresenceMessage *message) {
+        XCTAssertEqualObjects([message data], enter1);
+        gotEnter = true;
+    }];
+    [channel.presence enter:enter1 callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel.presence update:update1 callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence update:update1 callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [channel.presence unsubscribe:updateSub];
-                [channel.presence unsubscribe:enterSub];
-                [channel.presence update:@"noone will get this" callback:^(ARTErrorInfo *errorInfo) {
-                    [channel.presence leave:leave1 callback:^(ARTErrorInfo *errorInfo) {
+            [channel.presence unsubscribe:updateSub];
+            [channel.presence unsubscribe:enterSub];
+            [channel.presence update:@"noone will get this" callback:^(ARTErrorInfo *errorInfo) {
+                [channel.presence leave:leave1 callback:^(ARTErrorInfo *errorInfo) {
+                    XCTAssertNil(errorInfo);
+                    [channel.presence enter:@"nor this" callback:^(ARTErrorInfo *errorInfo) {
                         XCTAssertNil(errorInfo);
-                        [channel.presence enter:@"nor this" callback:^(ARTErrorInfo *errorInfo) {
-                            XCTAssertNil(errorInfo);
-                            XCTAssertTrue(gotUpdate);
-                            XCTAssertTrue(gotEnter);
-                            XCTAssertTrue(gotLeave);
-                            [channel.presence unsubscribe:leaveSub];
-                            [exp fulfill];
-                        }];
+                        XCTAssertTrue(gotUpdate);
+                        XCTAssertTrue(gotEnter);
+                        XCTAssertTrue(gotLeave);
+                        [channel.presence unsubscribe:leaveSub];
+                        [expectation fulfill];
                     }];
                 }];
             }];
@@ -1054,105 +903,38 @@
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
-
-/*
-- (void)testSyncResumes {
-    NSString *channelName = @"channelName";
-
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"enterAll"];
-    ARTClientOptions *options = [ARTTestUtil clientOptions];
-    options.clientId = @"client_string";
-
-    [ARTTestUtil testRealtime:options callback:^(ARTRealtime *realtime) {
-        _realtime = realtime;
-        ARTRealtimeChannel *channel = [realtime.channels get:channelName];
-
-        const int count = 120;
-        
-        //channel enters itself
-        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
-            XCTAssertNil(errorInfo);
-            //channel enters all others
-            [ARTTestUtil publishEnterMessages:@"aClientId" count:count channel:channel completion:^{
-                [ARTTestUtil testRealtime:^(ARTRealtime *realtime2) {
-                    _realtime2 = realtime2;
-                    __block bool hasFailed = false;
-
-                    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
-                    [channel2 subscribeToStateChanges:^(ARTRealtimeChannelState c, ARTStatus *s) {
-                        if(c == ARTRealtimeChannelAttached) {
-                            //channel2 enters itself
-                            [channel2.presence enterClient:@"channel2Enter" data:@"joins" callback:^(ARTErrorInfo *errorInfo) {
-                                XCTAssertNil(errorInfo);
-                            }];
-                        }
-                    }];
-
-                    [channel2 attach];
-
-                    __block bool firstSyncMessageReceived = false;
-                    __block bool syncComplete = false;
-
-                    [channel2.presenceMap onSync:^{
-                        if(!firstSyncMessageReceived) {
-                            XCTAssertFalse([channel2.presenceMap isSyncComplete]); //confirm we still have more syncing to do.
-                            firstSyncMessageReceived = true;
-                            [realtime2 onError:[ARTTestUtil newErrorProtocolMessage]];
-                        }
-                        else if([channel2.presenceMap isSyncComplete] && !syncComplete) {
-                            XCTAssertTrue(hasFailed);
-                            [expectation fulfill];
-                            syncComplete = true;
-                        }
-                    }];
-
-                    [realtime2 on:^(ARTConnectionStateChange *stateChange) {
-                        ARTRealtimeConnectionState state = stateChange.current;
-                        ARTErrorInfo *errorInfo = stateChange.reason;
-                        if(state == ARTRealtimeFailed) {
-                            hasFailed = true;
-                            [realtime2 connect];
-                        }
-                    }];
-                }];
-            }];
-        }];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
-}
-*/
 
 - (void)testPresenceNoSideEffects {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceNoSideEffects"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channelName";
     NSString *client1 = @"client1";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    options.clientId = [self getClientId];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence enter:@"hi" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [expectation1 fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    options.clientId = nil;
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+    [channel2.presence enterClient:client1 data:@"data" callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel2.presence updateClient:client1 data:@"data2" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-
-            [ARTTestUtil testRealtime:^(ARTRealtime *realtime2) {
-                _realtime2 = realtime2;
-                ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-                [channel2.presence enterClient:client1 data:@"data" callback:^(ARTErrorInfo *errorInfo) {
-                    XCTAssertNil(errorInfo);
-                    [channel2.presence updateClient:client1 data:@"data2" callback:^(ARTErrorInfo *errorInfo) {
-                        XCTAssertNil(errorInfo);
-                        [channel2.presence leaveClient:client1 data:@"data3" callback:^(ARTErrorInfo *errorInfo) {
-                            XCTAssertNil(errorInfo);
-                            [channel.presence get:^(NSArray<ARTPresenceMessage *> *members, ARTErrorInfo *error) {
-                                XCTAssert(!error);
-                                XCTAssertEqual(1, members.count);
-                                //check channel hasnt changed its own state by changing presence of another clientId
-                                XCTAssertEqual(members[0].action, ARTPresenceEnter);
-                                XCTAssertEqualObjects(members[0].clientId, [self getClientId]);
-                                XCTAssertEqualObjects([members[0] data], @"hi");
-                                [exp fulfill];
-                            }];
-                        }];
-                    }];
+            [channel2.presence leaveClient:client1 data:@"data3" callback:^(ARTErrorInfo *errorInfo) {
+                XCTAssertNil(errorInfo);
+                [channel.presence get:^(NSArray<ARTPresenceMessage *> *members, ARTErrorInfo *error) {
+                    XCTAssert(!error);
+                    XCTAssertEqual(1, members.count);
+                    //check channel hasnt changed its own state by changing presence of another clientId
+                    XCTAssertEqual(members[0].action, ARTPresenceEnter);
+                    XCTAssertEqualObjects(members[0].clientId, [self getClientId]);
+                    XCTAssertEqualObjects([members[0] data], @"hi");
+                    [expectation2 fulfill];
                 }];
             }];
         }];
@@ -1161,75 +943,73 @@
 }
 
 - (void)testPresenceWithData {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testPresenceWithData"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channelName";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        [channel.presence enter:@"someDataPayload" callback:^(ARTErrorInfo *errorInfo) {
-             XCTAssertNil(errorInfo);
-            [channel.presence get:^(NSArray<ARTPresenceMessage *> *members, ARTErrorInfo *error) {
-                XCTAssert(!error);
-                XCTAssertEqual(1, members.count);
-                XCTAssertEqual(members[0].action, ARTPresenceEnter);
-                XCTAssertEqualObjects(members[0].clientId, [self getClientId]);
-                XCTAssertEqualObjects([members[0] data], @"someDataPayload");
-                [exp fulfill];
-            }];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.clientId = [self getClientId];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    [channel.presence enter:@"someDataPayload" callback:^(ARTErrorInfo *errorInfo) {
+         XCTAssertNil(errorInfo);
+        [channel.presence get:^(NSArray<ARTPresenceMessage *> *members, ARTErrorInfo *error) {
+            XCTAssert(!error);
+            XCTAssertEqual(1, members.count);
+            XCTAssertEqual(members[0].action, ARTPresenceEnter);
+            XCTAssertEqualObjects(members[0].clientId, [self getClientId]);
+            XCTAssertEqualObjects([members[0] data], @"someDataPayload");
+            [expectation fulfill];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testPresenceWithDataOnLeave {
-    __weak XCTestExpectation *exp1 = [self expectationWithDescription:@"testPresenceWithDataOnLeave1"];
-    __weak XCTestExpectation *exp2 = [self expectationWithDescription:@"testPresenceWithDataOnLeave2"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
     NSString *channelName = @"channelName";
     NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = [self getClientId];
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
+    __weak XCTestExpectation *expectation1 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-1", __FUNCTION__]];
+    __weak XCTestExpectation *expectation2 = [self expectationWithDescription:[NSString stringWithFormat:@"%s-2", __FUNCTION__]];
+    options.clientId = [self getClientId];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
 
-        options.clientId = @"clientId2";
-        _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
+    options.clientId = @"clientId2";
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
 
-        [channel2.presence subscribe:^(ARTPresenceMessage *message) {
-            if (message.action == ARTPresenceLeave) {
-                XCTAssertEqualObjects([message data], dataPayload);
-                [exp1 fulfill];
-            }
-        }];
+    [channel2.presence subscribe:^(ARTPresenceMessage *message) {
+        if (message.action == ARTPresenceLeave) {
+            XCTAssertEqualObjects([message data], dataPayload);
+            [expectation1 fulfill];
+        }
+    }];
 
-        __block NSUInteger attached = 0;
-        // Channel 1
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if (channel.state == ARTRealtimeChannelAttached) {
-                attached++;
-            }
-        }];
+    __block NSUInteger attached = 0;
+    // Channel 1
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if (channel.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
 
-        // Channel 2
-        [channel2 on:^(ARTErrorInfo *errorInfo) {
-            if (channel2.state == ARTRealtimeChannelAttached) {
-                attached++;
-            }
-        }];
+    // Channel 2
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        if (channel2.state == ARTRealtimeChannelAttached) {
+            attached++;
+        }
+    }];
 
-        [channel2 attach];
-        [channel attach];
+    [channel2 attach];
+    [channel attach];
 
-        [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
+    [ARTTestUtil waitForWithTimeout:&attached list:@[channel, channel2] timeout:1.5];
 
-        // Presence
-        [channel.presence enter:dataPayload callback:^(ARTErrorInfo *errorInfo) {
+    // Presence
+    [channel.presence enter:dataPayload callback:^(ARTErrorInfo *errorInfo) {
+        XCTAssertNil(errorInfo);
+        [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
             XCTAssertNil(errorInfo);
-            [channel.presence leave:@"" callback:^(ARTErrorInfo *errorInfo) {
-                XCTAssertNil(errorInfo);
-                [exp2 fulfill];
-            }];
+            [expectation2 fulfill];
         }];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];

--- a/Tests/ARTRealtimeResumeTest.m
+++ b/Tests/ARTRealtimeResumeTest.m
@@ -19,78 +19,64 @@
 #import "ARTTestUtil.h"
 #import "ARTRealtime+Private.h"
 
-@interface ARTRealtimeResumeTest : XCTestCase {
-    ARTRealtime *_realtime;
-    ARTRealtime *_realtime2;
-}
+@interface ARTRealtimeResumeTest : XCTestCase
 
 @end
 
 @implementation ARTRealtimeResumeTest
 
 - (void)tearDown {
-    if (_realtime) {
-        [ARTTestUtil removeAllChannels:_realtime];
-        [_realtime resetEventEmitter];
-        [_realtime close];
-    }
-    _realtime = nil;
-    if (_realtime2) {
-        [ARTTestUtil removeAllChannels:_realtime2];
-        [_realtime2 resetEventEmitter];
-        [_realtime2 close];
-    }
-    _realtime2 = nil;
     [super tearDown];
 }
 
 - (void)testSimpleDisconnected {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testSimpleDisconnected"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    
     NSString *channelName = @"resumeChannel";
     NSString *message1 = @"message1";
     NSString *message2 = @"message2";
     NSString *message3 = @"message3";
     NSString *message4 = @"message4";
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        _realtime = [[ARTRealtime alloc] initWithOptions:options];
-        _realtime2 = [[ARTRealtime alloc] initWithOptions:options];
-        
-        ARTRealtimeChannel *channel = [_realtime.channels get:channelName];
-        ARTRealtimeChannel *channel2 = [_realtime2.channels get:channelName];
-        [channel on:^(ARTErrorInfo *errorInfo) {
-            if(channel.state == ARTRealtimeChannelAttached) {
-                [channel2 attach];
-            }
-        }];
-        [channel2 on:^(ARTErrorInfo *errorInfo) {
-            //both channels are attached. lets get to work.
-            if(channel2.state == ARTRealtimeChannelAttached) {
-                [channel2 publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
-                    [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
-                        XCTAssertNil(errorInfo);
-                    }];
+
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRealtime *realtime = [[ARTRealtime alloc] initWithOptions:options];
+    ARTRealtime *realtime2 = [[ARTRealtime alloc] initWithOptions:options];
+
+    ARTRealtimeChannel *channel = [realtime.channels get:channelName];
+    ARTRealtimeChannel *channel2 = [realtime2.channels get:channelName];
+    [channel on:^(ARTErrorInfo *errorInfo) {
+        if(channel.state == ARTRealtimeChannelAttached) {
+            [channel2 attach];
+        }
+    }];
+    [channel2 on:^(ARTErrorInfo *errorInfo) {
+        //both channels are attached. lets get to work.
+        if(channel2.state == ARTRealtimeChannelAttached) {
+            [channel2 publish:nil data:message1 callback:^(ARTErrorInfo *errorInfo) {
+                [channel2 publish:nil data:message2 callback:^(ARTErrorInfo *errorInfo) {
+                    XCTAssertNil(errorInfo);
                 }];
-            }
-        }];
-        [channel subscribe:^(ARTMessage *message) {
-            NSString *msg = [message data];
-            if([msg isEqualToString:message2]) {
-                //disconnect connection1
-                [_realtime onError:[ARTTestUtil newErrorProtocolMessage]];
-                [channel2 publish:nil data:message3 callback:^(ARTErrorInfo *errorInfo) {
-                    [channel2 publish:nil data:message4 callback:^(ARTErrorInfo *errorInfo) {
-                        [_realtime connect];
-                    }];
+            }];
+        }
+    }];
+    [channel subscribe:^(ARTMessage *message) {
+        NSString *msg = [message data];
+        if([msg isEqualToString:message2]) {
+            //disconnect connection1
+            [realtime onError:[ARTTestUtil newErrorProtocolMessage]];
+            [channel2 publish:nil data:message3 callback:^(ARTErrorInfo *errorInfo) {
+                [channel2 publish:nil data:message4 callback:^(ARTErrorInfo *errorInfo) {
+                    [realtime connect];
                 }];
-            }
-            if([msg isEqualToString:message4]) {
-                [expectation fulfill];
-            }
-        }];
-        
-        [_realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            [channel attach];
-        }];
+            }];
+        }
+        if([msg isEqualToString:message4]) {
+            [expectation fulfill];
+        }
+    }];
+    
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+        [channel attach];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }

--- a/Tests/ARTRestCryptoTest.m
+++ b/Tests/ARTRestCryptoTest.m
@@ -21,41 +21,38 @@
 #import "ARTDataQuery.h"
 #import "ARTPaginatedResult.h"
 
-@interface ARTRestCryptoTest : XCTestCase {
-    ARTRest *_rest;
-}
+@interface ARTRestCryptoTest : XCTestCase
+
 @end
 
 @implementation ARTRestCryptoTest
 
 - (void)tearDown {
-    _rest = nil;
     [super tearDown];
 }
 
 - (void)testSendBinary {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest =rest;
-        ARTChannel *c = [rest.channels get:@"test"];
-        XCTAssert(c);
-        NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-        NSString *stringPayload = @"someString";
-        [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTChannel *c = [rest.channels get:@"test"];
+    XCTAssert(c);
+    NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *stringPayload = @"someString";
+    [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
-            [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
+            [c history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
                 XCTAssert(!error);
-                [c history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    NSArray *page = [result items];
-                    XCTAssertTrue(page != nil);
-                    XCTAssertEqual([page count], 2);
-                    ARTMessage *stringMessage = [page objectAtIndex:0];
-                    ARTMessage *dataMessage = [page objectAtIndex:1];
-                    XCTAssertEqualObjects([dataMessage data], dataPayload);
-                    XCTAssertEqualObjects([stringMessage data], stringPayload);
-                    [exp fulfill];
-                }];
+                NSArray *page = [result items];
+                XCTAssertTrue(page != nil);
+                XCTAssertEqual([page count], 2);
+                ARTMessage *stringMessage = [page objectAtIndex:0];
+                ARTMessage *dataMessage = [page objectAtIndex:1];
+                XCTAssertEqualObjects([dataMessage data], dataPayload);
+                XCTAssertEqualObjects([stringMessage data], stringPayload);
+                [expectation fulfill];
             }];
         }];
     }];
@@ -63,35 +60,31 @@
 }
 
 - (void)testSendEncodedMessage {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testSendBinary"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest =rest;
-        
-        NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
-    
-        NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
-        ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
-        ARTChannelOptions *channelOptions = [[ARTChannelOptions alloc] initWithCipher:params];
-
-        ARTRestChannel *c = [rest.channels get:@"test" options:channelOptions];
-        XCTAssert(c);
-        NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
-        NSString *stringPayload = @"someString";
-        [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    NSData *ivSpec = [[NSData alloc] initWithBase64EncodedString:@"HO4cYSP8LybPYBPZPHQOtg==" options:0];
+    NSData *keySpec = [[NSData alloc] initWithBase64EncodedString:@"WUP6u0K7MXI5Zeo0VppPwg==" options:0];
+    ARTCipherParams *params =[[ARTCipherParams alloc] initWithAlgorithm:@"aes" key:keySpec iv:ivSpec];
+    ARTChannelOptions *channelOptions = [[ARTChannelOptions alloc] initWithCipher:params];
+    ARTRestChannel *c = [rest.channels get:@"test" options:channelOptions];
+    XCTAssert(c);
+    NSData *dataPayload = [@"someDataPayload"  dataUsingEncoding:NSUTF8StringEncoding];
+    NSString *stringPayload = @"someString";
+    [c publish:nil data:dataPayload callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
             XCTAssert(!error);
-            [c publish:nil data:stringPayload callback:^(ARTErrorInfo *error) {
+            [c history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
                 XCTAssert(!error);
-                [c history:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-                    XCTAssert(!error);
-                    NSArray *page = [result items];
-                    XCTAssertTrue(page != nil);
-                    XCTAssertEqual([page count], 2);
-                    ARTMessage *stringMessage = [page objectAtIndex:0];
-                    ARTMessage *dataMessage = [page objectAtIndex:1];
-                    XCTAssertEqualObjects([dataMessage data], dataPayload);
-                    XCTAssertEqualObjects([stringMessage data], stringPayload);
-                    [exp fulfill];
-                }];
+                NSArray *page = [result items];
+                XCTAssertTrue(page != nil);
+                XCTAssertEqual([page count], 2);
+                ARTMessage *stringMessage = [page objectAtIndex:0];
+                ARTMessage *dataMessage = [page objectAtIndex:1];
+                XCTAssertEqualObjects([dataMessage data], dataPayload);
+                XCTAssertEqualObjects([stringMessage data], stringPayload);
+                [expectation fulfill];
             }];
         }];
     }];

--- a/Tests/ARTRestInitTest.m
+++ b/Tests/ARTRestInitTest.m
@@ -21,48 +21,43 @@
 #import "ARTChannel.h"
 #import "ARTChannels.h"
 
-@interface ARTRestInitTest : XCTestCase {
-    ARTRest *_rest;
-}
+@interface ARTRestInitTest : XCTestCase
 
 @end
 
 @implementation ARTRestInitTest
 
 - (void)tearDown {
-    _rest = nil;
     [super tearDown];
 }
 
 - (void)testInternetIsUp {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInternetIsUp"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        [rest internetIsUp:^(bool isUp) {
-            XCTAssertTrue(isUp);
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    [rest internetIsUp:^(bool isUp) {
+        XCTAssertTrue(isUp);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testInitWithKey {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithKey"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        @try {
-            [ARTClientOptions setDefaultEnvironment:@"sandbox"];
-            ARTRest *rest = [[ARTRest alloc] initWithKey:options.key];
-            _rest = rest;
-            ARTChannel *c = [rest.channels get:@"test"];
-            XCTAssert(c);
-            [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
-                XCTAssertNil(error);
-                [exp fulfill];
-            }];
-        }
-        @finally {
-            [ARTClientOptions setDefaultEnvironment:nil];
-        }
-    }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    @try {
+        [ARTClientOptions setDefaultEnvironment:@"sandbox"];
+        ARTRest *rest = [[ARTRest alloc] initWithKey:options.key];
+        ARTChannel *c = [rest.channels get:@"test"];
+        XCTAssert(c);
+        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
+            XCTAssertNil(error);
+            [expectation fulfill];
+        }];
+    }
+    @finally {
+        [ARTClientOptions setDefaultEnvironment:nil];
+    }
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
@@ -76,7 +71,6 @@
     @try {
         [ARTClientOptions setDefaultEnvironment:@"sandbox"];
         ARTRest *rest = [[ARTRest alloc] initWithKey:@"badkey:secret"];
-        _rest = rest;
         ARTChannel *c = [rest.channels get:@"test"];
         XCTAssert(c);
         [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
@@ -92,53 +86,46 @@
 }
 
 - (void)testInitWithOptions {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTChannel *c = [rest.channels get:@"test"];
-        XCTAssert(c);
-        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
-            XCTAssert(!error);
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTChannel *c = [rest.channels get:@"test"];
+    XCTAssert(c);
+    [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testInitWithOptionsEnvironment {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTClientOptions *envOptions = [[ARTClientOptions alloc] init];
-        envOptions.key = options.key;
-        envOptions.environment = @"sandbox";
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTChannel *c = [rest.channels get:@"test"];
-        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
-            XCTAssert(!error);
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTClientOptions *envOptions = [[ARTClientOptions alloc] init];
+    envOptions.key = options.key;
+    envOptions.environment = @"sandbox";
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:envOptions];
+    ARTChannel *c = [rest.channels get:@"test"];
+    [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testGetAuth {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testInitWithOptions"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTChannel *c = [rest.channels get:@"test"];
-        XCTAssert(c);
-        [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
-            XCTAssert(!error);
-            ARTAuth *auth = rest.auth;
-            XCTAssert(auth);
-            ARTAuthOptions *authOptions = auth.options;
-            XCTAssertEqual(authOptions.key, options.key);
-            [exp fulfill];
-        }];
-
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTChannel *c = [rest.channels get:@"test"];
+    XCTAssert(c);
+    [c publish:nil data:@"message" callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        ARTAuth *auth = rest.auth;
+        XCTAssert(auth);
+        ARTAuthOptions *authOptions = auth.options;
+        XCTAssertEqual(authOptions.key, options.key);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
@@ -149,15 +136,14 @@
 }
 
 - (void)testRestTime {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testRestTime"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        [rest time:^(NSDate *date, NSError *error) {
-            XCTAssert(!error);
-            // Expect local clock and server clock to be synced within 30 seconds
-            XCTAssertEqualWithAccuracy([date timeIntervalSinceNow], 0.0, 30.0);
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    [rest time:^(NSDate *date, NSError *error) {
+        XCTAssert(!error);
+        // Expect local clock and server clock to be synced within 30 seconds
+        XCTAssertEqualWithAccuracy([date timeIntervalSinceNow], 0.0, 30.0);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }

--- a/Tests/ARTRestPresenceTest.m
+++ b/Tests/ARTRestPresenceTest.m
@@ -20,145 +20,132 @@
 #import "ARTDataQuery.h"
 #import "ARTPaginatedResult.h"
 
-@interface ARTRestPresenceTest : XCTestCase {
-    ARTRest *_rest;
-}
+@interface ARTRestPresenceTest : XCTestCase
 
 @end
 
 @implementation ARTRestPresenceTest
 
 - (void)tearDown {
-    _rest = nil;
     [super tearDown];
 }
 
 - (void)testPresence {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
 
-        [channel.presence get:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-            XCTAssert(!error);
-            NSArray *presence = [result items];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
 
-            XCTAssertEqual(6, [presence count]);
-            ARTPresenceMessage *p0 = presence[0];
-//            ARTPresenceMessage *p1 = presence[1];
-//            ARTPresenceMessage *p2 = presence[2];
-            ARTPresenceMessage *p3 = presence[3];
-            ARTPresenceMessage *p4 = presence[4];
-            ARTPresenceMessage *p5 = presence[5];
-            
-            
-            XCTAssertEqualObjects(@"client_bool", p0.clientId);
-            XCTAssertEqualObjects(@"true", [p0 data]);
-            
-            
-            //TODO use ARTTestUtil cipher and check they match up.
-            //XCTAssertEqualObjects(@"client_decoded", p1.clientId);
-            //XCTAssertEqualObjects([p1 data], @"{\"example\":{\"json\":\"Object\"}}");
-            
-            //XCTAssertEqualObjects(@"client_encoded", p2.clientId);
-            //XCTAssertEqualObjects([p2 data], @"HO4cYSP8LybPYBPZPHQOtuD53yrD3YV3NBoTEYBh4U0N1QXHbtkfsDfTspKeLQFt");
-            
-            XCTAssertEqualObjects(@"client_int", p3.clientId);
-            XCTAssertEqualObjects(@"24", [p3 data]);
-            
-            XCTAssertEqualObjects(@"client_json", p4.clientId);
-            XCTAssertEqualObjects(@"{ \"test\": \"This is a JSONObject clientData payload\"}", [p4 data]);
-            
-            XCTAssertEqualObjects(@"client_string", p5.clientId);
-            XCTAssertEqualObjects(@"This is a string clientData payload", [p5 data]);
-            
-            [expectation fulfill];
-        }];
+    [channel.presence get:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+        XCTAssert(!error);
+        NSArray *presence = [result items];
+
+        XCTAssertEqual(6, [presence count]);
+        ARTPresenceMessage *p0 = presence[0];
+        //ARTPresenceMessage *p1 = presence[1];
+        //ARTPresenceMessage *p2 = presence[2];
+        ARTPresenceMessage *p3 = presence[3];
+        ARTPresenceMessage *p4 = presence[4];
+        ARTPresenceMessage *p5 = presence[5];
+
+        XCTAssertEqualObjects(@"client_bool", p0.clientId);
+        XCTAssertEqualObjects(@"true", [p0 data]);
+
+        //TODO use ARTTestUtil cipher and check they match up.
+        //XCTAssertEqualObjects(@"client_decoded", p1.clientId);
+        //XCTAssertEqualObjects([p1 data], @"{\"example\":{\"json\":\"Object\"}}");
+        
+        //XCTAssertEqualObjects(@"client_encoded", p2.clientId);
+        //XCTAssertEqualObjects([p2 data], @"HO4cYSP8LybPYBPZPHQOtuD53yrD3YV3NBoTEYBh4U0N1QXHbtkfsDfTspKeLQFt");
+        
+        XCTAssertEqualObjects(@"client_int", p3.clientId);
+        XCTAssertEqualObjects(@"24", [p3 data]);
+        
+        XCTAssertEqualObjects(@"client_json", p4.clientId);
+        XCTAssertEqualObjects(@"{ \"test\": \"This is a JSONObject clientData payload\"}", [p4 data]);
+        
+        XCTAssertEqualObjects(@"client_string", p5.clientId);
+        XCTAssertEqualObjects(@"This is a string clientData payload", [p5 data]);
+        
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testHistory {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
-        [channel.presence history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-            XCTAssert(!error);
-            NSArray *presence = [result items];
-            XCTAssertEqual(6, [presence count]);
-            [expectation fulfill];
-        } error:nil];
-    }];
-     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
+    [channel.presence history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+        XCTAssert(!error);
+        NSArray *presence = [result items];
+        XCTAssertEqual(6, [presence count]);
+        [expectation fulfill];
+    } error:nil];
+    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testHistoryDefaultBackwards {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
-        [channel.presence history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-            XCTAssert(!error);
-            NSArray *presence = [result items];
-            XCTAssertEqual(6, [presence count]);
-            ARTPresenceMessage *m = [presence objectAtIndex:[presence count] -1];
-            XCTAssertEqualObjects(@"true", [m data]);
-            [expectation fulfill];
-        } error:nil];
-    }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
+    [channel.presence history:[[ARTDataQuery alloc] init] callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+        XCTAssert(!error);
+        NSArray *presence = [result items];
+        XCTAssertEqual(6, [presence count]);
+        ARTPresenceMessage *m = [presence objectAtIndex:[presence count] -1];
+        XCTAssertEqualObjects(@"true", [m data]);
+        [expectation fulfill];
+    } error:nil];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testHistoryDirection {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testPresence"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
-        ARTDataQuery *query = [[ARTDataQuery alloc] init];
-        query.direction = ARTQueryDirectionForwards;
-        [channel.presence history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
-            XCTAssert(!error);
-            NSArray *presence = [result items];
-            XCTAssertEqual(6, [presence count]);
-            ARTPresenceMessage *m = [presence objectAtIndex:0];
-            XCTAssertEqualObjects(@"true", [m data]);
-            [expectation fulfill];
-        } error:nil];
-    }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
+    ARTDataQuery *query = [[ARTDataQuery alloc] init];
+    query.direction = ARTQueryDirectionForwards;
+    [channel.presence history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error) {
+        XCTAssert(!error);
+        NSArray *presence = [result items];
+        XCTAssertEqual(6, [presence count]);
+        ARTPresenceMessage *m = [presence objectAtIndex:0];
+        XCTAssertEqualObjects(@"true", [m data]);
+        [expectation fulfill];
+    } error:nil];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testPresenceLimit {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        ARTRestChannel *channelOne = [rest.channels get:@"name"];
-        ARTDataQuery *query = [[ARTDataQuery alloc] init];
-        query.limit = 1001;
-        NSError *error;
-        BOOL valid = [channelOne.presence history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error){} error:&error];
-        XCTAssertFalse(valid);
-        XCTAssertNotNil(error);
-        XCTAssert(error.code == ARTDataQueryErrorLimit);
-        [exp fulfill];
-    }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTRestChannel *channelOne = [rest.channels get:@"name"];
+    ARTDataQuery *query = [[ARTDataQuery alloc] init];
+    query.limit = 1001;
+    NSError *error;
+    BOOL valid = [channelOne.presence history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error){} error:&error];
+    XCTAssertFalse(valid);
+    XCTAssertNotNil(error);
+    XCTAssert(error.code == ARTDataQueryErrorLimit);
+    [expectation fulfill];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testPresenceLimitIgnoringError {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testLimit"];
-    [ARTTestUtil testRest:^(ARTRest *rest) {
-        _rest = rest;
-        ARTRestChannel *channelOne = [rest.channels get:@"name"];
-        ARTDataQuery *query = [[ARTDataQuery alloc] init];
-        query.limit = 1001;
-        // Forcing an invalid query where the error is ignored and the result should be invalid (the request was canceled)
-        BOOL requested = [channelOne.presence history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error){} error:nil];
-        XCTAssertFalse(requested);
-        [exp fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTRestChannel *channelOne = [rest.channels get:@"name"];
+    ARTDataQuery *query = [[ARTDataQuery alloc] init];
+    query.limit = 1001;
+    // Forcing an invalid query where the error is ignored and the result should be invalid (the request was canceled)
+    BOOL requested = [channelOne.presence history:query callback:^(ARTPaginatedResult *result, ARTErrorInfo *error){} error:nil];
+    XCTAssertFalse(requested);
 }
 
 @end

--- a/Tests/ARTRestTokenTest.m
+++ b/Tests/ARTRestTokenTest.m
@@ -20,107 +20,92 @@
 #import "ARTChannels.h"
 #import "ARTTokenDetails.h"
 #import "ARTAuth.h"
+#import "ARTAuth+Private.h"
 
-@interface ARTRestTokenTest : XCTestCase {
-    ARTRest *_rest;
-    ARTRest *_rest2;
-}
+@interface ARTRestTokenTest : XCTestCase
 
 @end
 
 @implementation ARTRestTokenTest
 
 - (void)tearDown {
-    _rest = nil;
-    _rest2 = nil;
     [super tearDown];
 }
 
 - (void)testTokenSimple {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testRestTimeBadHost"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.useTokenAuth = true;
-        options.clientId = @"testToken";
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTAuth *auth = rest.auth;
-        XCTAssertEqual(auth.method, ARTAuthMethodToken);
-        ARTRestChannel *c = [rest.channels get:@"getChannel"];
-        [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
-            XCTAssert(!error);
-            [expectation fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.useTokenAuth = true;
+    options.clientId = @"testToken";
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTAuth *auth = rest.auth;
+    XCTAssertEqual(auth.method, ARTAuthMethodToken);
+    ARTRestChannel *c = [rest.channels get:@"getChannel"];
+    [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testInitWithBadToken {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.useTokenAuth = true;
-        options.clientId = @"testToken";
-        options.token = @"this_is_a_bad_token";
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTAuth *auth = rest.auth;
-        XCTAssertEqual(auth.method, ARTAuthMethodToken);
-        ARTChannel *c= [rest.channels get:@"getChannel"];
-        [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
-            XCTAssert(error);
-            [expectation fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil clientOptions];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.useTokenAuth = true;
+    options.clientId = @"testToken";
+    options.token = @"this_is_a_bad_token";
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTAuth *auth = rest.auth;
+    XCTAssertEqual(auth.method, ARTAuthMethodToken);
+    ARTChannel *c= [rest.channels get:@"getChannel"];
+    [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
+        XCTAssert(error);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 -(void)testAuthURLForcesToken {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testClientIdForcesToken"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.authUrl = [NSURL URLWithString:@"some_url"];
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTAuth *auth = rest.auth;
-        XCTAssertEqual(auth.method, ARTAuthMethodToken);
-        [exp fulfill];
-    }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.authUrl = [NSURL URLWithString:@"some_url"];
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTAuth *auth = rest.auth;
+    XCTAssertEqual(auth.method, ARTAuthMethodToken);
+    [expectation fulfill];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 -(void)testTTLDefaultOneHour {
-    __weak XCTestExpectation *exp = [self expectationWithDescription:@"testTTLDefaultOneHour"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.clientId = @"clientIdThatForcesToken";
-        ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
-        _rest = rest;
-        ARTAuth *auth = rest.auth;
-        ARTChannel *c = [rest.channels get:@"getChannel"];
-        [c publish:nil data:@"invokeTokenRequest" callback:^(ARTErrorInfo *error) {
-            XCTAssert(!error);
-            NSTimeInterval secs = [auth.tokenDetails.expires timeIntervalSinceDate:auth.tokenDetails.issued];
-            XCTAssertEqual(secs, 3600);
-            [exp fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.clientId = @"clientIdThatForcesToken";
+    ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
+    ARTAuth *auth = rest.auth;
+    ARTChannel *c = [rest.channels get:@"getChannel"];
+    [c publish:nil data:@"invokeTokenRequest" callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        NSTimeInterval secs = [auth.tokenDetails.expires timeIntervalSinceDate:auth.tokenDetails.issued];
+        XCTAssertEqual(secs, 3600);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testInitWithBorrowedAuthCb {
-    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitWithToken"];
-    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *options) {
-        options.useTokenAuth = true;
-        options.clientId = @"testToken";
-        ARTRest *firstRest = [[ARTRest alloc] initWithOptions:options];
-        _rest = firstRest;
-        ARTAuth *auth = firstRest.auth;
-        //options.authCallback = [auth getTheAuthCb]; //?!
-        ARTRest *secondRest = [[ARTRest alloc] initWithOptions:options];
-        _rest2 = secondRest;
-        XCTAssertEqual(auth.method, ARTAuthMethodToken);
-        ARTChannel *c = [secondRest.channels get:@"getChannel"];
-        [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
-            XCTAssert(!error);
-            [expectation fulfill];
-        }];
+    ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
+    options.useTokenAuth = true;
+    options.clientId = @"testToken";
+    ARTRest *firstRest = [[ARTRest alloc] initWithOptions:options];
+    ARTAuth *auth = firstRest.auth;
+    //options.authCallback = [auth getTheAuthCb]; //?!
+    ARTRest *secondRest = [[ARTRest alloc] initWithOptions:options];
+    XCTAssertEqual(auth.method, ARTAuthMethodToken);
+    ARTChannel *c = [secondRest.channels get:@"getChannel"];
+    [c publish:nil data:@"something" callback:^(ARTErrorInfo *error) {
+        XCTAssert(!error);
+        [expectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }

--- a/Tests/ARTTestUtil.h
+++ b/Tests/ARTTestUtil.h
@@ -41,6 +41,8 @@ typedef NS_ENUM(NSUInteger, TestAlteration) {
 
 + (ARTClientOptions *)clientOptions;
 
++ (ARTClientOptions *)newSandboxApp:(XCTestCase *)testCase withDescription:(const char *)description;
+
 typedef void (^ARTRestConstructorCb)(ARTRest *rest);
 typedef void (^ARTRealtimeConstructorCb)(ARTRealtime *realtime);
 

--- a/Tests/ARTTestUtil.m
+++ b/Tests/ARTTestUtil.m
@@ -288,4 +288,15 @@
     }
 }
 
++ (ARTClientOptions *)newSandboxApp:(XCTestCase *)testCase withDescription:(const char *)description {
+    __weak XCTestExpectation *expectation = [testCase expectationWithDescription:[NSString stringWithFormat:@"%s-ClientOptions", description]];
+    __block ARTClientOptions *options;
+    [ARTTestUtil setupApp:[ARTTestUtil clientOptions] callback:^(ARTClientOptions *_options) {
+        options = _options;
+        [expectation fulfill];
+    }];
+    [testCase waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
+    return options;
+}
+
 @end


### PR DESCRIPTION
`XCTestExpectation` was created before the `https://sandbox-rest.ably.io:443/apps` request and the timeout was easily exceeded.