### PR TITLE
Test suites: reuse test app.

### DIFF
--- a/Source/ARTChannels+Private.h
+++ b/Source/ARTChannels+Private.h
@@ -13,6 +13,8 @@
 
 ART_ASSUME_NONNULL_BEGIN
 
+extern NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
+
 @protocol ARTChannelsDelegate <NSObject>
 
 - (id)makeChannel:(NSString *)channel options:(ARTChannelOptions *)options;

--- a/Source/ARTRealtimeChannels.m
+++ b/Source/ARTRealtimeChannels.m
@@ -53,7 +53,10 @@
 }
 
 - (void)release:(NSString *)name callback:(void (^)(ARTErrorInfo * _Nullable))cb {
-    ARTRealtimeChannel *channel = _channels.channels[name];
+    ARTRealtimeChannel *channel;
+    if ([self exists:name]) {
+        channel = [self get:name];
+    }
     if (channel) {
         [channel detach:^(ARTErrorInfo *errorInfo) {
             [channel off];

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -23,7 +23,6 @@ ART_ASSUME_NONNULL_BEGIN
 @property (readonly, strong, nonatomic) NSDictionary *encoders;
 
 @property (nonatomic, strong) id<ARTHTTPExecutor> httpExecutor;
-@property (readonly, nonatomic, assign) Class channelClass;
 
 @property (nonatomic, strong) NSURL *baseUrl;
 

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -56,7 +56,6 @@
         [_logger debug:__FILE__ line:__LINE__ message:@"%p alloc HTTP", _http];
         _httpExecutor = _http;
         _httpExecutor.logger = _logger;
-        _channelClass = [ARTRestChannel class];
 
         id<ARTEncoder> defaultEncoder = [[ARTJsonEncoder alloc] initWithLogger:self.logger];
         _encoders = @{ [defaultEncoder mimeType]: defaultEncoder };

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -775,8 +775,8 @@ class RealtimeClientChannel: QuickSpec {
                     }
 
                     it("upon failure") {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken(capability: "{ \"test\":[\"subscribe\"] }")
+                        let options = AblyTests.commonAppSetup()
+                        options.token = getTestToken(key: options.key, capability: "{ \"\(ARTChannels_getChannelNamePrefix!())-test\":[\"subscribe\"] }")
                         let client = ARTRealtime(options: options)
                         defer { client.close() }
 
@@ -814,8 +814,8 @@ class RealtimeClientChannel: QuickSpec {
                     }
 
                     it("for all messages published") {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken(capability: "{ \"channelToSucceed\":[\"subscribe\", \"publish\"], \"channelToFail\":[\"subscribe\"] }")
+                        let options = AblyTests.commonAppSetup()
+                        options.token = getTestToken(key: options.key, capability: "{ \"\(ARTChannels_getChannelNamePrefix!())-channelToSucceed\":[\"subscribe\", \"publish\"], \"\(ARTChannels_getChannelNamePrefix!())-channelToFail\":[\"subscribe\"] }")
                         let client = ARTRealtime(options: options)
                         defer { client.close() }
 

--- a/Spec/RealtimeClientChannels.swift
+++ b/Spec/RealtimeClientChannels.swift
@@ -49,7 +49,7 @@ class RealtimeClientChannels: QuickSpec {
 
                     expect(client.channels.collection).to(haveCount(0))
                     let channel = client.channels.get("test")
-                    expect(channel.name).to(equal("test"))
+                    expect(channel.name).to(equal("\(ARTChannels_getChannelNamePrefix!())-test"))
 
                     expect(client.channels.collection).to(haveCount(1))
                     expect(client.channels.get("test")).to(beIdenticalTo(channel))

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -544,8 +544,8 @@ class RealtimeClientConnection: QuickSpec {
                     }
 
                     it("message failure") {
-                        let options = AblyTests.clientOptions()
-                        options.token = getTestToken(capability: "{ \"test\":[\"subscribe\"] }")
+                        let options = AblyTests.commonAppSetup()
+                        options.token = getTestToken(key: options.key, capability: "{ \"\(ARTChannels_getChannelNamePrefix!())-test\":[\"subscribe\"] }")
                         options.autoConnect = false
                         let client = ARTRealtime(options: options)
                         client.setTransportClass(TestProxyTransport.self)

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -301,6 +301,10 @@ class RestClientChannel: QuickSpec {
             // RSP3
             context("get") {
                 it("should return presence fixture data") {
+                    let originalARTChannels_getChannelNamePrefix = ARTChannels_getChannelNamePrefix
+                    defer { ARTChannels_getChannelNamePrefix = originalARTChannels_getChannelNamePrefix }
+                    ARTChannels_getChannelNamePrefix = nil // Force that channel name is not changed.
+
                     let key = appSetupJson["cipher"]["key"].string!
                     let cipherParams = ARTCipherParams.init(
                         algorithm: appSetupJson["cipher"]["algorithm"].string!,

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -51,7 +51,7 @@ class RestClientChannels: QuickSpec {
                     // RSN3a
                     it("should return a channel") {
                         let channel = client.channels.get(channelName)
-                        expect(channel).to(beAChannel(named: channelName))
+                        expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName)"))
 
                         let sameChannel = client.channels.get(channelName)
                         expect(sameChannel).to(beIdenticalTo(channel))
@@ -62,7 +62,7 @@ class RestClientChannels: QuickSpec {
                         let options = ARTChannelOptions(cipher: cipherParams)
                         let channel = client.channels.get(channelName, options: options)
 
-                        expect(channel).to(beAChannel(named: channelName))
+                        expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName)"))
                         expect(channel.options).to(beIdenticalTo(options))
                     }
 
@@ -110,7 +110,7 @@ class RestClientChannels: QuickSpec {
                         autoreleasepool {
                             channel = client.channels.get(channelName)
 
-                            expect(channel).to(beAChannel(named: channelName))
+                            expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName)"))
                             client.channels.release(channel.name)
                         }
 

--- a/Spec/RestClientStats.swift
+++ b/Spec/RestClientStats.swift
@@ -12,7 +12,7 @@ import SwiftyJSON
 import Foundation
 
 private func postTestStats(stats: JSON) -> ARTClientOptions {
-    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions);
+    let options = AblyTests.setupOptions(AblyTests.jsonRestOptions, forceNewApp: true);
     
     let keyBase64 = encodeBase64(options.key ?? "")
 

--- a/Tests/ARTRealtimeChannelTest.m
+++ b/Tests/ARTRealtimeChannelTest.m
@@ -21,6 +21,7 @@
 #import "ARTTestUtil.h"
 #import "ARTCrypto+Private.h"
 #import "ARTChannelOptions.h"
+#import "ARTChannels+Private.h"
 
 @interface ARTRealtimeChannelTest : XCTestCase
 
@@ -207,9 +208,13 @@
         [d setValue:channel forKey:channel.name];
     }
     XCTAssertEqual([[d allKeys] count], 3);
-    XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
-    XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
-    XCTAssertEqualObjects([d valueForKey:@"channel3"], c3);
+    NSString *prefix = ARTChannels_getChannelNamePrefix();
+    __block NSString *expectedName = [NSString stringWithFormat:@"%@-channel", prefix];
+    XCTAssertEqualObjects([d valueForKey:expectedName], c1);
+    expectedName = [NSString stringWithFormat:@"%@-channel2", prefix];
+    XCTAssertEqualObjects([d valueForKey:expectedName], c2);
+    expectedName = [NSString stringWithFormat:@"%@-channel3", prefix];
+    XCTAssertEqualObjects([d valueForKey:expectedName], c3);
 
     [realtime.channels release:c3.name callback:^(ARTErrorInfo *errorInfo) {
         NSMutableDictionary *d = [[NSMutableDictionary alloc] init];
@@ -217,8 +222,10 @@
             [d setValue:channel forKey:channel.name];
         }
         XCTAssertEqual([[d allKeys] count], 2);
-        XCTAssertEqualObjects([d valueForKey:@"channel"], c1);
-        XCTAssertEqualObjects([d valueForKey:@"channel2"], c2);
+        expectedName = [NSString stringWithFormat:@"%@-channel", prefix];
+        XCTAssertEqualObjects([d valueForKey:expectedName], c1);
+        expectedName = [NSString stringWithFormat:@"%@-channel2", prefix];
+        XCTAssertEqualObjects([d valueForKey:expectedName], c2);
     }];
     
     [expectation fulfill];

--- a/Tests/ARTRestCapabilityTest.m
+++ b/Tests/ARTRestCapabilityTest.m
@@ -20,6 +20,7 @@
 #import "ARTAuth.h"
 #import "ARTTokenParams.h"
 #import "ARTTokenDetails.h"
+#import "ARTChannels+Private.h"
 
 @interface ARTRestCapabilityTest : XCTestCase {
     ARTRest *_rest;
@@ -34,23 +35,9 @@
     [super tearDown];
 }
 
-- (void)withRestRestrictCap:(void (^)(ARTRest *rest))cb {
-    if (!_rest) {
-        ARTClientOptions *theOptions = [ARTTestUtil clientOptions];
-        [ARTTestUtil setupApp:theOptions withAlteration:TestAlterationRestrictCapability callback:^(ARTClientOptions *options) {
-            if (options) {
-
-            }
-        }];
-        return;
-    }
-    else {
-        cb(_rest);
-    }
-}
-
 - (void)testPublishRestricted {
     ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    ARTChannels_getChannelNamePrefix = nil; // Force that channel name is not changed.
 
     __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     options.clientId = @"client_string";

--- a/Tests/ARTRestPresenceTest.m
+++ b/Tests/ARTRestPresenceTest.m
@@ -19,6 +19,7 @@
 #import "ARTChannels.h"
 #import "ARTDataQuery.h"
 #import "ARTPaginatedResult.h"
+#import "ARTChannels+Private.h"
 
 @interface ARTRestPresenceTest : XCTestCase
 
@@ -32,6 +33,7 @@
 
 - (void)testPresence {
     ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    ARTChannels_getChannelNamePrefix = nil; // Force that channel name is not changed.
 
     __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
@@ -75,6 +77,7 @@
 
 - (void)testHistory {
     ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    ARTChannels_getChannelNamePrefix = nil; // Force that channel name is not changed.
     __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
     ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
@@ -89,6 +92,7 @@
 
 - (void)testHistoryDefaultBackwards {
     ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    ARTChannels_getChannelNamePrefix = nil; // Force that channel name is not changed.
     __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
     ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];
@@ -100,11 +104,13 @@
         XCTAssertEqualObjects(@"true", [m data]);
         [expectation fulfill];
     } error:nil];
+
     [self waitForExpectationsWithTimeout:[ARTTestUtil timeout] handler:nil];
 }
 
 - (void)testHistoryDirection {
     ARTClientOptions *options = [ARTTestUtil newSandboxApp:self withDescription:__FUNCTION__];
+    ARTChannels_getChannelNamePrefix = nil; // Force that channel name is not changed.
     __weak XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __FUNCTION__]];
     ARTRest *rest = [[ARTRest alloc] initWithOptions:options];
     ARTRestChannel *channel = [rest.channels get:@"persisted:presence_fixtures"];


### PR DESCRIPTION
For this, we isolate tests by prepending a prefix to channel names in
different tests (ie. that use different calls to 
TestUtilties.setupOptions.)

This should make #397 unnecessary.