### PR TITLE
Fix race condition when calling ARTTestUtil.setupApp.

### DIFF
--- a/Tests/ARTTestUtil.m
+++ b/Tests/ARTTestUtil.m
@@ -43,6 +43,13 @@
     static NSDictionary *testApplication;
     static int setupAppCounter = 0;
 
+    if (setupAppCounter > 0 && !testApplication) {
+        // Waiting for previous request to finish to avoid a race condition.
+        while (!testApplication) {
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, false);
+        }
+    }
+
     ARTChannels_getChannelNamePrefix = ^NSString*() {
         return [NSString stringWithFormat:@"test-%d", setupAppCounter];
     };


### PR DESCRIPTION
In the Obj-C test suite, ARTReadmeExamples are being before any other
test that uses setupApp. Because tests in ARTReadmeExamples don't have
any assertions, they are not serialized, ie. we don't really wait for
them to finish before running the next test. This causes each one of
them to create a separate setupApp, and this can cause a race condition
when the first "real" test starts (ARTRealtimeAttachTest.testAttachedChannelFails)
in which a new test app arrives in the middle of its execution, which
causes it to use two separate test channel name prefixes (because the
global ARTChannels_getChannelNamePrefix is reassigned) and failing.
It's a bit tricky and definitely hacky.

This waits for the first test app to be created to avoid creating more
than one, and so that the situation explained above is avoided.