### PR TITLE
Don't use auth when requesting tokens.

### DIFF
--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -246,7 +246,7 @@
     [request setValue:[encoder mimeType] forHTTPHeaderField:@"Accept"];
     [request setValue:[encoder mimeType] forHTTPHeaderField:@"Content-Type"];
     
-    [_rest executeRequest:request withAuthOption:ARTAuthenticationUseBasic completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
+    [_rest executeRequest:request withAuthOption:ARTAuthenticationOff completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         if (error) {
             callback(nil, error);
         } else {

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -1697,7 +1697,7 @@ class Auth : QuickSpec {
 
                     let options = AblyTests.clientOptions()
                     options.authCallback = { tokenParams, completion in
-                        rest.auth.executeTokenRequest(currentTokenRequest!, callback: completion);
+                        completion(currentTokenRequest!, nil)
                     }
 
                     waitUntil(timeout: testTimeout) { done in


### PR DESCRIPTION
We were using basic authentication when calling /requestToken, which
of course only works if you have a key, which is not supposed to be
the case.

An existing test has been modified to test this.