### PR TITLE
Encode JSON message data as string.

### DIFF
--- a/Source/ARTDataEncoder.m
+++ b/Source/ARTDataEncoder.m
@@ -90,6 +90,8 @@
             return [[ARTDataEncoderOutput alloc] initWithData:encoded encoding:encoding errorInfo:errorInfo];
         }
         encoding = [NSString artAddEncoding:[self cipherEncoding] toString:encoding];
+    } else if (jsonEncoded) {
+        encoded = [[NSString alloc] initWithData:jsonEncoded encoding:NSUTF8StringEncoding];
     }
 
     if (toBase64 != nil) {

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3024,7 +3024,7 @@ class RealtimeClientConnection: QuickSpec {
                             fail("expected NSArray")
                         }
                     case "binary":
-                        expect(message.data as? NSData).to(equal(fixtureMessage["expectedValue"].string!.dataFromHexadecimalString()!))
+                        expect(message.data as? NSData).to(equal(fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()!))
                     default:
                         fail("unhandled: \(fixtureMessage["expectedType"].string!)")
                     }
@@ -3037,7 +3037,7 @@ class RealtimeClientConnection: QuickSpec {
                                 return
                             }
 
-                            let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(channel.name)/messages")!)
+                            let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(channel.name)/messages?limit=1")!)
                             request.HTTPMethod = "GET"
                             request.allHTTPHeaderFields = ["Accept" : "application/json"]
                             client.rest.executeRequest(request, withAuthOption: .On, completion: { _, data, err in

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3010,13 +3010,21 @@ class RealtimeClientConnection: QuickSpec {
 
                     switch fixtureMessage["expectedType"].string! {
                     case "string":
-                        expect(message.data as? NSString).toNot(beNil())
-                    case "object":
-                        expect(message.data as? NSDictionary).toNot(beNil())
-                    case "array":
-                        expect(message.data as? NSArray).toNot(beNil())
+                        expect(message.data as? NSString).to(equal(fixtureMessage["expectedValue"].string!))
+                    case "jsonObject":
+                        if let data = message.data as? NSDictionary {
+                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
+                        } else {
+                            fail("expected NSDictionary")
+                        }              
+                    case "jsonArray":
+                        if let data = message.data as? NSArray {
+                            expect(JSON(data)).to(equal(fixtureMessage["expectedValue"]))
+                        } else {
+                            fail("expected NSArray")
+                        }
                     case "binary":
-                        expect(message.data as? NSData).toNot(beNil())
+                        expect(message.data as? NSData).to(equal(fixtureMessage["expectedValue"].string!.dataFromHexadecimalString()!))
                     default:
                         fail("unhandled: \(fixtureMessage["expectedType"].string!)")
                     }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2965,49 +2965,10 @@ class RealtimeClientConnection: QuickSpec {
                 expect(client.connection.errorReason).to(equal(protoMsg.error))
             }
 
-            // https://github.com/ably/wiki/issues/22
-            it("should encode and decode fixture messages as expected") {
+            context("with fixture messages") {
                 let fixtures = JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))!, options: .MutableContainers)
 
-                let options = AblyTests.commonAppSetup()
-                let client = AblyTests.newRealtime(options)
-                defer { client.close() }
-                let channel = client.channels.get("test")
-                channel.attach()
-
-                expect(channel.state).toEventually(equal(ARTRealtimeChannelState.Attached), timeout: testTimeout)
-                if channel.state != .Attached {
-                    return
-                }
-
-                for (_, fixtureMessage) in fixtures["messages"] {
-                    var receivedMessage: ARTMessage?
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.subscribe { message in
-                            channel.unsubscribe()
-                            receivedMessage = message
-                            done()
-                        }
-
-                        let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(channel.name)/messages")!)
-                        request.HTTPMethod = "POST"
-                        request.HTTPBody = try! fixtureMessage.rawData()
-                        request.allHTTPHeaderFields = [
-                            "Accept" : "application/json",
-                            "Content-Type" : "application/json"
-                        ]
-                        client.rest.executeRequest(request, withAuthOption: .On, completion: { _, _, err in
-                            if let err = err {
-                                fail("\(err)")
-                            }
-                        })
-                    }
-
-                    guard let message = receivedMessage else {
-                        continue
-                    }
-
+                func expectDataToMatch(message: ARTMessage, _ fixtureMessage: JSON) {
                     switch fixtureMessage["expectedType"].string! {
                     case "string":
                         expect(message.data as? NSString).to(equal(fixtureMessage["expectedValue"].string!))
@@ -3028,26 +2989,165 @@ class RealtimeClientConnection: QuickSpec {
                     default:
                         fail("unhandled: \(fixtureMessage["expectedType"].string!)")
                     }
+                }
 
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.publish([message]) { err in
-                            if let err = err {
-                                fail("\(err)")
+                // https://github.com/ably/wiki/issues/22
+                it("should encode and decode fixture messages as expected") {
+                    let options = AblyTests.commonAppSetup()
+                    let client = AblyTests.newRealtime(options)
+                    defer { client.close() }
+                    let channel = client.channels.get("test")
+                    channel.attach()
+
+                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.Attached), timeout: testTimeout)
+                    if channel.state != .Attached {
+                        return
+                    }
+
+                    for (_, fixtureMessage) in fixtures["messages"] {
+                        var receivedMessage: ARTMessage?
+
+                        waitUntil(timeout: testTimeout) { done in
+                            channel.subscribe { message in
+                                channel.unsubscribe()
+                                receivedMessage = message
                                 done()
-                                return
                             }
 
-                            let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(channel.name)/messages?limit=1")!)
+                            let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(channel.name)/messages")!)
+                            request.HTTPMethod = "POST"
+                            request.HTTPBody = try! fixtureMessage.rawData()
+                            request.allHTTPHeaderFields = [
+                                "Accept" : "application/json",
+                                "Content-Type" : "application/json"
+                            ]
+                            client.rest.executeRequest(request, withAuthOption: .On, completion: { _, _, err in
+                                if let err = err {
+                                    fail("\(err)")
+                                }
+                            })
+                        }
+
+                        guard let message = receivedMessage else {
+                            continue
+                        }
+
+                        expectDataToMatch(message, fixtureMessage)
+
+                        waitUntil(timeout: testTimeout) { done in
+                            channel.publish([message]) { err in
+                                if let err = err {
+                                    fail("\(err)")
+                                    done()
+                                    return
+                                }
+
+                                let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(channel.name)/messages?limit=1")!)
+                                request.HTTPMethod = "GET"
+                                request.allHTTPHeaderFields = ["Accept" : "application/json"]
+                                client.rest.executeRequest(request, withAuthOption: .On, completion: { _, data, err in
+                                    if let err = err {
+                                        fail("\(err)")
+                                        done()
+                                        return
+                                    }
+                                    let persistedMessage = JSON(data: data!).array!.first!
+                                    expect(persistedMessage["data"]).to(equal(fixtureMessage["data"]))
+                                    expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
+                                    done()
+                                })
+                            }
+                        }
+                    }
+                }
+
+                let jsonOptions = AblyTests.commonAppSetup()
+                jsonOptions.useBinaryProtocol = false
+                let msgpackOptions = AblyTests.commonAppSetup()
+                msgpackOptions.useBinaryProtocol = true
+
+                it("should send messages through JSON and retrieve equal messages through MsgPack") {
+                    let restPublishClient = ARTRest(options: jsonOptions)
+                    let realtimeSubscribeClient = AblyTests.newRealtime(msgpackOptions)
+                    defer { realtimeSubscribeClient.close() }
+
+                    let realtimeSubscribeChannel = realtimeSubscribeClient.channels.get("test-subscribe")
+                    realtimeSubscribeChannel.attach()
+
+                    expect(realtimeSubscribeChannel.state).toEventually(equal(ARTRealtimeChannelState.Attached), timeout: testTimeout)
+                    if realtimeSubscribeChannel.state != .Attached {
+                        return
+                    }
+
+                    for (_, fixtureMessage) in fixtures["messages"] {
+                        var receivedMessage: ARTMessage?
+
+                        waitUntil(timeout: testTimeout) { done in
+                            realtimeSubscribeChannel.subscribe { message in
+                                realtimeSubscribeChannel.unsubscribe()
+                                receivedMessage = message
+                                done()
+                            }
+
+                            let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(realtimeSubscribeChannel.name)/messages")!)
+                            request.HTTPMethod = "POST"
+                            request.HTTPBody = try! fixtureMessage.rawData()
+                            request.allHTTPHeaderFields = [
+                                "Accept" : "application/json",
+                                "Content-Type" : "application/json"
+                            ]
+                            restPublishClient.executeRequest(request, withAuthOption: .On, completion: { _, _, err in
+                                if let err = err {
+                                    fail("\(err)")
+                                }
+                            })
+                        }
+
+                        guard let message = receivedMessage else {
+                            continue
+                        }
+
+                        expectDataToMatch(message, fixtureMessage)
+                    }
+                }
+
+                it("should send messages through MsgPack and retrieve equal messages through JSON") {
+                    let restPublishClient = ARTRest(options: msgpackOptions)
+                    let restRetrieveClient = ARTRest(options: jsonOptions)
+
+                    let restPublishChannel = restPublishClient.channels.get("test-publish")
+
+                    for (_, fixtureMessage) in fixtures["messages"] {
+                        var data: AnyObject
+                        if fixtureMessage["expectedType"] == "binary" {
+                            data = fixtureMessage["expectedHexValue"].string!.dataFromHexadecimalString()!
+                        } else {
+                            data = fixtureMessage["expectedValue"].object
+                        }
+
+                        waitUntil(timeout: testTimeout) { done in
+                            restPublishChannel.publish("event", data: data) { err in 
+                                if let err = err {
+                                    fail("\(err)")
+                                    done()
+                                    return
+                                }
+                                done()
+                            }
+                        }
+
+                        waitUntil(timeout: testTimeout) { done in
+                            let request = NSMutableURLRequest(URL: NSURL(string: "/channels/\(restPublishChannel.name)/messages?limit=1")!)
                             request.HTTPMethod = "GET"
                             request.allHTTPHeaderFields = ["Accept" : "application/json"]
-                            client.rest.executeRequest(request, withAuthOption: .On, completion: { _, data, err in
+                            restRetrieveClient.executeRequest(request, withAuthOption: .On, completion: { _, data, err in
                                 if let err = err {
                                     fail("\(err)")
                                     done()
                                     return
                                 }
                                 let persistedMessage = JSON(data: data!).array!.first!
-                                expect(persistedMessage["data"]).to(equal(fixtureMessage["data"]))
+                                expect(persistedMessage["data"]).to(equal(persistedMessage["data"]))
                                 expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
                                 done()
                             })

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3011,7 +3011,7 @@ class RealtimeClientConnection: QuickSpec {
                     switch fixtureMessage["expectedType"].string! {
                     case "string":
                         expect(message.data as? NSString).toNot(beNil())
-                    case "map":
+                    case "object":
                         expect(message.data as? NSDictionary).toNot(beNil())
                     case "array":
                         expect(message.data as? NSArray).toNot(beNil())

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -375,8 +375,8 @@ class RestClientChannel: QuickSpec {
                     TestCase(value: text, expected: JSON(["data": text])),
                     TestCase(value: integer, expected: JSON(["data": integer])),
                     TestCase(value: decimal, expected: JSON(["data": decimal])),
-                    TestCase(value: dictionary, expected: JSON(["data": dictionary, "encoding": "json"])),
-                    TestCase(value: array, expected: JSON(["data": array, "encoding": "json"])),
+                    TestCase(value: dictionary, expected: JSON(["data": JSON(dictionary).rawString(0, options: NSJSONWritingOptions.init(rawValue: 0))!, "encoding": "json"])),
+                    TestCase(value: array, expected: JSON(["data": JSON(array).rawString(0, options: NSJSONWritingOptions.init(rawValue: 0))!, "encoding": "json"])),
                     TestCase(value: binaryData, expected: JSON(["data": binaryData.toBase64, "encoding": "base64"])),
                 ]
 
@@ -486,7 +486,8 @@ class RestClientChannel: QuickSpec {
                                 if let request = testHTTPExecutor.requests.last, let http = request.HTTPBody {
                                     // Array
                                     let json = AblyTests.msgpackToJSON(http)
-                                    expect(json["data"].asArray).to(equal(array))
+                                    print(json.rawString())
+                                    expect(JSON(data: json["data"].stringValue.dataUsingEncoding(NSUTF8StringEncoding)!).asArray).to(equal(array))
                                     expect(json["encoding"].string).to(equal("json"))
                                 }
                                 else {
@@ -507,7 +508,7 @@ class RestClientChannel: QuickSpec {
                                 if let request = testHTTPExecutor.requests.last, let http = request.HTTPBody {
                                     // Dictionary
                                     let json = AblyTests.msgpackToJSON(http)
-                                    expect(json["data"].asDictionary).to(equal(dictionary))
+                                    expect(JSON(data: json["data"].stringValue.dataUsingEncoding(NSUTF8StringEncoding)!).asDictionary).to(equal(dictionary))
                                     expect(json["encoding"].string).to(equal("json"))
                                 }
                                 else {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -1079,3 +1079,26 @@ public func allValuesPass<U: CollectionType where U: DictionaryLiteralConvertibl
         return true
     }
 }
+
+// http://stackoverflow.com/a/26502285/818420
+extension String {
+
+    /// Create `NSData` from hexadecimal string representation
+    ///
+    /// This takes a hexadecimal representation and creates a `NSData` object. Note, if the string has any spaces or non-hex characters (e.g. starts with '<' and with a '>'), those are ignored and only hex characters are processed.
+    ///
+    /// - returns: Data represented by this hexadecimal string.
+
+    func dataFromHexadecimalString() -> NSData? {
+        let data = NSMutableData(capacity: characters.count / 2)
+
+        let regex = try! NSRegularExpression(pattern: "[0-9a-f]{1,2}", options: .CaseInsensitive)
+        regex.enumerateMatchesInString(self, options: [], range: NSMakeRange(0, characters.count)) { match, flags, stop in
+            let byteString = (self as NSString).substringWithRange(match!.range)
+            var num = UInt8(byteString, radix: 16)
+            data?.appendBytes(&num, length: 1)
+        }
+
+        return data
+    }
+}


### PR DESCRIPTION
Previously, we were just inlining it:

    "messages": [{"data": {"foo": "bar"}}]

What the JS library expects, and really what [RSL4d3](http://docs.ably.io/client-lib-development-guide/features/#RSL4d3) says:

    "messages": [{"data": "{\"foo\": \"bar\"}"}]

So now we do that.