### PR TITLE
Fix: should attach if the channel is in the FAILED state

### DIFF
--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -544,13 +544,15 @@
             [self.realtime.logger debug:__FILE__ line:__LINE__ message:@"R:%p C:%p already attached", _realtime, self];
             if (callback) callback(nil);
             return;
-        case ARTRealtimeChannelDetaching:
-        case ARTRealtimeChannelFailed: {
-            NSString *msg = @"can't attach when in DETACHING or FAILED state";
+        case ARTRealtimeChannelDetaching: {
+            NSString *msg = @"can't attach when in DETACHING state";
             [self.realtime.logger debug:__FILE__ line:__LINE__ message:@"R:%p C:%p %@", _realtime, self, msg];
             if (callback) callback([ARTErrorInfo createWithCode:90000 message:msg]);
             return;
         }
+        case ARTRealtimeChannelFailed:
+            _errorReason = nil;
+            break;
         default:
             break;
     }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -315,6 +315,11 @@
         [_attachedEventEmitter emit:[NSNull null] with:status.errorInfo];
         [_detachedEventEmitter emit:[NSNull null] with:status.errorInfo];
     }
+    else if (state == ARTRealtimeChannelDetaching) {
+        NSString *msg = @"channel is being DETACHED";
+        [self.realtime.logger debug:__FILE__ line:__LINE__ message:@"R:%p C:%p %@", _realtime, self, msg];
+        [_attachedEventEmitter emit:[NSNull null] with:[ARTErrorInfo createWithCode:90000 message:msg]];
+    }
 
     [self emit:(ARTChannelEvent)state with:status.errorInfo];
 }

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -49,6 +49,16 @@
 
 - (void)get:(ARTRealtimePresenceQuery *)query callback:(void (^)(NSArray<ARTPresenceMessage *> *, ARTErrorInfo *))callback {
     [_channel throwOnDisconnectedOrFailed];
+
+    switch (_channel.state) {
+        case ARTRealtimeChannelFailed:
+        case ARTRealtimeChannelDetached:
+            if (callback) callback(nil, [ARTErrorInfo createWithCode:0 message:@"invalid channel state"]);
+            return;
+        default:
+            break;
+    }
+
     [_channel attach:^(ARTErrorInfo *error) {
         if (error) {
             callback(nil, error);

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -380,13 +380,17 @@ class RealtimeClientChannel: QuickSpec {
                         errorMsg.channel = channel.name
                         client.onError(errorMsg)
                         expect(channel.state).to(equal(ARTRealtimeChannelState.Failed))
+                        expect(channel.errorReason).toNot(beNil())
 
                         waitUntil(timeout: testTimeout) { done in
                             channel.attach { error in
-                                expect(error).toNot(beNil())
+                                expect(error).to(beNil())
                                 done()
                             }
                         }
+
+                        expect(channel.state).to(equal(ARTRealtimeChannelState.Attached))
+                        expect(channel.errorReason).to(beNil())
                     }
                 }
 


### PR DESCRIPTION
#485 

> (RTL4g) If the channel is in the FAILED state, the attach request sets its errorReason to null, and proceeds with a channel attach described in RTL4b, RTL4h and RTL4c

Please only merge if all tests are passing.
This can break other tests like `RTP11b`.