### PR TITLE
Update RSC15a for 0.9

### DIFF
--- a/Ably.podspec
+++ b/Ably.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = "Ably"
-  s.version           = "0.8.7"
+  s.version           = "0.9.0"
   s.summary           = "iOS client for Ably"
   s.description       = <<-DESC
                         iOS client library for ably.io, the realtime messaging service, written in Objective-C and ready for Swift 2.0.

--- a/Examples/Tests/Podfile.lock
+++ b/Examples/Tests/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Ably (0.8.7):
+  - Ably (0.9.0):
     - msgpack (= 0.1.8)
     - SocketRocket (= 0.5.1)
   - msgpack (0.1.8)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can install Ably for iOS through CocoaPods, Carthage or manually.
 Add this line to your application's Podfile:
 
     # For Xcode 7.3 and newer
-    pod 'Ably', '~> 0.8'
+    pod 'Ably', '~> 0.9'
 
 And then install the dependency:
 
@@ -26,13 +26,13 @@ And then install the dependency:
 Add this line to your application's Cartfile:
 
     # For Xcode 7.3 and newer
-    github "ably/ably-ios" ~> 0.8
+    github "ably/ably-ios" ~> 0.9
 
 And then run `carthage update` to build the framework and drag the built Ably.framework into your Xcode project.
 
 ### Manual installation 
 
-1. Get the code from GitHub [from the release page](https://github.com/ably/ably-ios/releases/tag/0.8.0), or clone it to get the latest, unstable and possibly underdocumented version: `git clone git@github.com:ably/ably-ios.git` 
+1. Get the code from GitHub [from the release page](https://github.com/ably/ably-ios/releases/tag/0.9.0), or clone it to get the latest, unstable and possibly underdocumented version: `git clone git@github.com:ably/ably-ios.git` 
 2. Drag the directory `ably-ios/ably-ios` into your project as a group.
 3. Ably depends on [SocketRocket](https://github.com/facebook/SocketRocket) 0.5.1; get it [from the releases page](https://github.com/facebook/SocketRocket/releases/tag/0.5.1) and follow [its manual installation instructions](https://github.com/facebook/SocketRocket#installing-ios).
 4. Ably also depends on [msgpack](https://github.com/rvi/msgpack-objective-C) 0.1.8; get it [from the releases page](https://github.com/rvi/msgpack-objective-C/releases/tag/0.1.8) and link it into your project.

--- a/Source/ARTDefault.h
+++ b/Source/ARTDefault.h
@@ -7,10 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "CompatibilityMacros.h"
 
 @interface ARTDefault : NSObject
 
-+ (NSArray*)fallbackHosts;
++ (__GENERIC(NSArray, NSString *) *)fallbackHosts;
 + (NSString*)restHost;
 + (NSString*)realtimeHost;
 + (int)port;

--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -12,7 +12,7 @@
 
 NSString *const ARTDefault_restHost = @"rest.ably.io";
 NSString *const ARTDefault_realtimeHost = @"realtime.ably.io";
-NSString *const ARTDefault_version = @"0.8";
+NSString *const ARTDefault_version = @"0.9";
 NSString *const ARTDefault_ablyBundleId = @"io.ably.Ably";
 NSString *const ARTDefault_bundleVersionKey = @"CFBundleShortVersionString";
 NSString *const ARTDefault_platform = @"ios-";

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.7</string>
+	<string>0.9.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -36,7 +36,7 @@ class RealtimeClient: QuickSpec {
                     channel.publish(nil, data: "message") { error in
                         expect(error).to(beNil())
                         let transport = client.transport as! TestProxyTransport
-                        expect(transport.lastUrl!.query).to(haveParam("v", withValue: "0.8"))
+                        expect(transport.lastUrl!.query).to(haveParam("v", withValue: "0.9"))
                         done()
                     }
                 }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2824,7 +2824,7 @@ class RealtimeClientConnection: QuickSpec {
                         NSRegularExpression.extract(url.absoluteString, pattern: "[a-e].ably-realtime.com")
                     }
                     let resultFallbackHosts = urlConnections.flatMap(extractHostname)
-                    let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] as! String }))
+                    let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] }))
 
                     expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
                 }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -213,7 +213,7 @@ class RealtimeClientConnection: QuickSpec {
                             done()
                         case .Connected:
                             if let transport = client.transport as? TestProxyTransport, let query = transport.lastUrl?.query {
-                                expect(query).to(haveParam("lib", withValue: "ios-0.8.7"))
+                                expect(query).to(haveParam("lib", withValue: "ios-0.9.0"))
                             }
                             else {
                                 XCTFail("MockTransport isn't working")

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -29,7 +29,7 @@ class RestClient: QuickSpec {
                     channel.publish(nil, data: "message") { error in
                         expect(error).to(beNil())
                         let version = testHTTPExecutor.requests.first!.allHTTPHeaderFields?["X-Ably-Version"]
-                        expect(version).to(equal("0.8"))
+                        expect(version).to(equal("0.9"))
                         done()
                     }
                 }
@@ -1092,7 +1092,7 @@ class RestClient: QuickSpec {
                         let ablyBundleLibVersion = ARTDefault.libraryVersion()
                         expect(headerLibVersion).to(equal(ablyBundleLibVersion))
                         
-                        let patternToMatch = "ios-0.8."
+                        let patternToMatch = "ios-0.9."
                         let match = headerLibVersion?.hasPrefix(patternToMatch)
                         expect(match).to(beTrue())
                         

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -792,7 +792,7 @@ class RestClient: QuickSpec {
                             NSRegularExpression.extract(request.URL!.absoluteString, pattern: "[a-e].ably-realtime.com")
                         }
                         let resultFallbackHosts = testHTTPExecutor.requests.flatMap(extractHostname)
-                        let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] as! String })[0..<Int(options.httpMaxRetryCount)])
+                        let expectedFallbackHosts = Array(expectedHostOrder.map({ ARTDefault.fallbackHosts()[$0] })[0..<Int(options.httpMaxRetryCount)])
 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
                     }
@@ -848,7 +848,7 @@ class RestClient: QuickSpec {
                             NSRegularExpression.extract(request.URL!.absoluteString, pattern: "[a-e].ably-realtime.com")
                         }
                         let resultFallbackHosts = testHTTPExecutor.requests.flatMap(extractHostname)
-                        let expectedFallbackHosts = expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] as! String }
+                        let expectedFallbackHosts = expectedHostOrder.map { ARTDefault.fallbackHosts()[$0] }
 
                         expect(resultFallbackHosts).to(equal(expectedFallbackHosts))
                     }

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -758,6 +758,14 @@ class RestClient: QuickSpec {
                         ARTFallback_getRandomHostIndex = originalARTFallback_getRandomHostIndex
                     }
 
+                    it("default fallback hosts should match @[a-e].ably-realtime.com@") {
+                        let defaultFallbackHosts = ARTDefault.fallbackHosts()
+                        defaultFallbackHosts.forEach { host in
+                            expect(host).to(match("[a-e].ably-realtime.com"))
+                        }
+                        expect(defaultFallbackHosts).to(haveCount(5))
+                    }
+
                     it("until httpMaxRetryCount has been reached") {
                         let options = ARTClientOptions(key: "xxxx:xxxx")
                         let client = ARTRest(options: options)


### PR DESCRIPTION
> If an array of custom fallback hosts are provided in @ClientOptions#fallbackHosts@, then they will be used instead.

Already implemented.

> If an empty array of fallback hosts is provided, then fallback host functionality is disabled

Already implemented.