### PR TITLE
Fix timestamp decoding for 32-bit architectures.

### DIFF
--- a/Source/ARTNSDate+ARTUtil.h
+++ b/Source/ARTNSDate+ARTUtil.h
@@ -11,7 +11,7 @@
 @interface NSDate (ARTUtil)
 
 + (instancetype)artDateFromNumberMs:(NSNumber *)number;
-+ (instancetype)artDateFromIntegerMs:(NSInteger)ms;
++ (instancetype)artDateFromIntegerMs:(long long)ms;
 
 - (NSNumber *)artToNumberMs;
 - (NSInteger)artToIntegerMs;

--- a/Source/ARTNSDate+ARTUtil.m
+++ b/Source/ARTNSDate+ARTUtil.m
@@ -10,13 +10,13 @@
 
 @implementation NSDate (ARTUtil)
 
-+ (instancetype)artDateFromIntegerMs:(NSInteger)ms {
++ (instancetype)artDateFromIntegerMs:(long long)ms {
     NSTimeInterval intervalSince1970 = ms / 1000.0;
     return [NSDate dateWithTimeIntervalSince1970:intervalSince1970];
 }
 
 + (instancetype)artDateFromNumberMs:(NSNumber *)number {
-    return [self artDateFromIntegerMs:[number integerValue]];
+    return [self artDateFromIntegerMs:[number longLongValue]];
 }
 
 - (NSNumber *)artToNumberMs {


### PR DESCRIPTION
We were converting timestamps to NSInteger, which is a 32-bit or 64-bit
int depending on the architecture. `long long` is guaranteed to be
64-bit wide.

Fixes #525.