### PR TITLE
Swift performance: speed up code completion

### DIFF
--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -45,14 +45,15 @@ class RealtimeClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
 
                     waitUntil(timeout: testTimeout) { done in
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     options.autoConnect = false
@@ -85,12 +86,12 @@ class RealtimeClientPresence: QuickSpec {
                 let options = AblyTests.commonAppSetup()
                 options.disconnectedRetryTimeout = 1.0
                 var clientSecondary: ARTRealtime!
-                defer { clientSecondary.close() }
+                defer { clientSecondary.dispose(); clientSecondary.close() }
 
                 waitUntil(timeout: testTimeout) { done in
                     clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options) {
                         done()
-                    }.first
+                    }
                 }
 
                 let client = AblyTests.newRealtime(options)
@@ -126,12 +127,12 @@ class RealtimeClientPresence: QuickSpec {
             it("should receive all 250 members") {
                 let options = AblyTests.commonAppSetup()
                 var clientSource: ARTRealtime!
-                defer { clientSource.close() }
+                defer { clientSource.dispose(); clientSource.close() }
 
                 waitUntil(timeout: testTimeout) { done in
                     clientSource = AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options) {
                         done()
-                    }.first
+                    }
                 }
 
                 let clientTarget = ARTRealtime(options: options)
@@ -854,7 +855,7 @@ class RealtimeClientPresence: QuickSpec {
                 waitUntil(timeout: testTimeout) { done in
                     clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 100, options: options) {
                         done()
-                    }.first
+                    }
                 }
 
                 let client = AblyTests.newRealtime(options)
@@ -1695,15 +1696,16 @@ class RealtimeClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
 
                     let expectedData = "online"
                     waitUntil(timeout: testTimeout) { done in
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 150, data:expectedData, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 150, data:expectedData, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     let client = ARTRealtime(options: options)
@@ -1847,7 +1849,7 @@ class RealtimeClientPresence: QuickSpec {
                     waitUntil(timeout: testTimeout) { done in
                         clientMembers = AblyTests.addMembersSequentiallyToChannel("test", members: 120, options: options) {
                             done()
-                        }.first
+                        }
                     }
 
                     waitUntil(timeout: testTimeout) { done in
@@ -1876,12 +1878,12 @@ class RealtimeClientPresence: QuickSpec {
                     it("waitForSync is true, should wait until SYNC is complete before returning a list of members") {
                         let options = AblyTests.commonAppSetup()
                         var clientSecondary: ARTRealtime!
-                        defer { clientSecondary.close() }
+                        defer { clientSecondary.dispose(); clientSecondary.close() }
 
                         waitUntil(timeout: testTimeout) { done in
                             clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options) {
                                 done()
-                            }.first
+                            }
                         }
 
                         let client = AblyTests.newRealtime(options)
@@ -1914,12 +1916,12 @@ class RealtimeClientPresence: QuickSpec {
                     it("waitForSync is false, should return immediately the known set of presence members") {
                         let options = AblyTests.commonAppSetup()
                         var clientSecondary: ARTRealtime!
-                        defer { clientSecondary.close() }
+                        defer { clientSecondary.dispose(); clientSecondary.close() }
 
                         waitUntil(timeout: testTimeout) { done in
                             clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options) {
                                 done()
-                            }.first
+                            }
                         }
 
                         let client = AblyTests.newRealtime(options)
@@ -2005,14 +2007,14 @@ class RealtimeClientPresence: QuickSpec {
                     let options = AblyTests.commonAppSetup()
 
                     var clientSecondary: ARTRealtime!
-                    defer { clientSecondary.close() }
+                    defer { clientSecondary.dispose(); clientSecondary.close() }
 
                     let expectedData = ["x", "y"]
                     let expectedPattern = "^user(\\d+)$"
                     waitUntil(timeout: testTimeout) { done in
                         clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData, options: options) {
                             done()
-                        }.first
+                        }
                     }
 
                     let client = ARTRealtime(options: options)
@@ -2134,14 +2136,15 @@ class RealtimeClientPresence: QuickSpec {
                         var disposable = [ARTRealtime]()
                         defer {
                             for clientItem in disposable {
+                                clientItem.dispose()
                                 clientItem.close()
                             }
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 25, options: options) {
+                            disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 25, options: options) {
                                 done()
-                            }
+                            }]
                         }
 
                         let client = ARTRealtime(options: options)
@@ -2154,9 +2157,9 @@ class RealtimeClientPresence: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            disposable += AblyTests.addMembersSequentiallyToChannel("test", startFrom: 26, members: 35, options: options) {
+                            disposable += [AblyTests.addMembersSequentiallyToChannel("test", startFrom: 26, members: 35, options: options) {
                                 done()
-                            }
+                            }]
                         }
 
                         let query = ARTRealtimeHistoryQuery()
@@ -2184,14 +2187,15 @@ class RealtimeClientPresence: QuickSpec {
                 var disposable = [ARTRealtime]()
                 defer {
                     for clientItem in disposable {
+                        clientItem.dispose()
                         clientItem.close()
                     }
                 }
 
                 waitUntil(timeout: testTimeout) { done in
-                    disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options) {
+                    disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options) {
                         done()
-                    }
+                    }]
                 }
 
                 let client = AblyTests.newRealtime(options)

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -777,11 +777,9 @@ class RealtimeClientPresence: QuickSpec {
                     expect(sent.action).to(equal(ARTPresenceAction.Update))
                     expect(sent.clientId).to(beNil())
 
-                    let received = transport.protocolMessagesReceived
-                        .filter({ $0.action == .Presence })
-                        .map({ $0.presence! })
-                        .reduce([], combine: +)
-                        .filter({ $0.action == .Update })[0]
+                    let receivedPresenceProtocolMessages = transport.protocolMessagesReceived.filter({ $0.action == .Presence })
+                    let receivedPresenceMessages = receivedPresenceProtocolMessages.flatMap({ $0.presence! })
+                    let received = receivedPresenceMessages.filter({ $0.action == .Update })[0]
                     expect(received.action).to(equal(ARTPresenceAction.Update))
                     expect(received.clientId).to(equal("john"))
                 }
@@ -1114,11 +1112,9 @@ class RealtimeClientPresence: QuickSpec {
                     expect(sent.action).to(equal(ARTPresenceAction.Leave))
                     expect(sent.clientId).to(beNil())
 
-                    let received = transport.protocolMessagesReceived
-                        .filter({ $0.action == .Presence })
-                        .map({ $0.presence! })
-                        .reduce([], combine: +)
-                        .filter({ $0.action == .Leave })[0]
+                    let receivedPresenceProtocolMessages = transport.protocolMessagesReceived.filter({ $0.action == .Presence })
+                    let receivedPresenceMessages = receivedPresenceProtocolMessages.flatMap({ $0.presence! })
+                    let received = receivedPresenceMessages.filter({ $0.action == .Leave })[0]
                     expect(received.action).to(equal(ARTPresenceAction.Leave))
                     expect(received.clientId).to(equal("john"))
                 }

--- a/Spec/RestClientPresence.swift
+++ b/Spec/RestClientPresence.swift
@@ -26,6 +26,7 @@ class RestClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
@@ -34,9 +35,9 @@ class RestClientPresence: QuickSpec {
                     let expectedPattern = "^user(\\d+)$"
                     waitUntil(timeout: testTimeout) { done in
                         // Load 150 members (2 pages)
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 150, data:expectedData, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 150, data:expectedData, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     waitUntil(timeout: testTimeout) { done in
@@ -131,22 +132,23 @@ class RestClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
 
                     waitUntil(timeout: testTimeout) { done in
                         // One connection
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     waitUntil(timeout: testTimeout) { done in
                         // Another connection
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     let query = ARTRealtimePresenceQuery()
@@ -180,14 +182,14 @@ class RestClientPresence: QuickSpec {
                     let channel = client.channels.get("test")
 
                     var realtime: ARTRealtime!
-                    defer { realtime.close() }
+                    defer { realtime.dispose(); realtime.close() }
 
                     let expectedData = "online"
                     let expectedPattern = "^user(\\d+)$"
                     waitUntil(timeout: testTimeout) { done in
                         realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 150, data: expectedData, options: options) {
                             done()
-                        }.first
+                        }
                     }
 
                     waitUntil(timeout: testTimeout) { done in
@@ -244,14 +246,15 @@ class RestClientPresence: QuickSpec {
                         var disposable = [ARTRealtime]()
                         defer {
                             for clientItem in disposable {
+                                clientItem.dispose()
                                 clientItem.close()
                             }
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 10, data:nil, options: options) {
+                            disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 10, data:nil, options: options) {
                                 done()
-                            }
+                            }]
                         }
 
                         let query = ARTDataQuery()
@@ -299,12 +302,12 @@ class RestClientPresence: QuickSpec {
                         let channel = client.channels.get("test")
 
                         var realtime: ARTRealtime!
-                        defer { realtime.close() }
+                        defer { realtime.dispose(); realtime.close() }
 
                         waitUntil(timeout: testTimeout) { done in
                             realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 1, options: options) {
                                 done()
-                            }.first
+                            }
                         }
 
                         let query = ARTDataQuery()
@@ -338,22 +341,23 @@ class RestClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
 
                     waitUntil(timeout: testTimeout) { done in
                         // One connection
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 6, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     waitUntil(timeout: testTimeout) { done in
                         // Another connection
-                        disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options) {
+                        disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, startFrom: 7, options: options) {
                             done()
-                        }
+                        }]
                     }
 
                     let query = ARTRealtimePresenceQuery()
@@ -392,6 +396,7 @@ class RestClientPresence: QuickSpec {
                         var disposable = [ARTRealtime]()
                         defer {
                             for clientItem in disposable {
+                                clientItem.dispose()
                                 clientItem.close()
                             }
                         }
@@ -399,9 +404,9 @@ class RestClientPresence: QuickSpec {
                         let query = ARTDataQuery()
 
                         waitUntil(timeout: testTimeout) { done in
-                            disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 25, options: options) {
+                            disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 25, options: options) {
                                 done()
-                            }
+                            }]
                         }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -417,9 +422,9 @@ class RestClientPresence: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 3, options: options) {
+                            disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 3, options: options) {
                                 done()
-                            }
+                            }]
                         }
 
                         waitUntil(timeout: testTimeout) { done in
@@ -431,9 +436,9 @@ class RestClientPresence: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            disposable += AblyTests.addMembersSequentiallyToChannel("test", members: 10, options: options) {
+                            disposable += [AblyTests.addMembersSequentiallyToChannel("test", members: 10, options: options) {
                                 done()
-                            }
+                            }]
                         }
 
                         waitUntil(timeout: testTimeout) { done in

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -189,7 +189,7 @@ class AblyTests {
         return NSProcessInfo.processInfo().globallyUniqueString
     }
 
-    class func addMembersSequentiallyToChannel(channelName: String, members: Int = 1, startFrom: Int = 1, data: AnyObject? = nil, options: ARTClientOptions, done: ()->()) -> [ARTRealtime] {
+    class func addMembersSequentiallyToChannel(channelName: String, members: Int = 1, startFrom: Int = 1, data: AnyObject? = nil, options: ARTClientOptions, done: ()->()) -> ARTRealtime {
         let client = ARTRealtime(options: options)
         let channel = client.channels.get(channelName)
 
@@ -208,7 +208,8 @@ class AblyTests {
                 }
             }
         }
-        return [client]
+
+        return client
     }
 
     class func splitDone(howMany: Int, file: StaticString = #file, line: UInt = #line, done: () -> Void) -> (() -> Void) {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -28,8 +28,8 @@ enum CryptoTest: String {
 
 class Configuration : QuickConfiguration {
     override class func configure(configuration: Quick.Configuration!) {
-        configuration.beforeEach {
-
+        configuration.beforeSuite {
+            AsyncDefaults.Timeout = testTimeout
         }
     }
 }


### PR DESCRIPTION
This was killing me. This is fixed on Swift v3.0 but since we are still using v2.2 I decided to change the code because Xcode is taking ~7 seconds indexing.