### PR TITLE
Fix: Realtime transport should fire events on a serial queue

### DIFF
--- a/Examples/Tests/TestsTests/TestsTests.swift
+++ b/Examples/Tests/TestsTests/TestsTests.swift
@@ -62,5 +62,23 @@ class TestsTests: XCTestCase {
         client.channels.get("test").publish(nil, data: "Get this!")
 
         self.waitForExpectationsWithTimeout(10, handler: nil)
+
+        let backgroundRealtimeExpectation = self.expectationWithDescription("Realtime in a Background Queue")
+        NSURLSession.sharedSession().dataTaskWithURL(NSURL(string:"https://ably.io")!) { _ in
+            let realtime = ARTRealtime(key: key as String)
+            realtime.channels.get("foo").attach { _ in
+                defer { backgroundRealtimeExpectation.fulfill() }
+            }
+        }.resume()
+        self.waitForExpectationsWithTimeout(10, handler: nil)
+
+        let backgroundRestExpectation = self.expectationWithDescription("Rest in a Background Queue")
+        NSURLSession.sharedSession().dataTaskWithURL(NSURL(string:"https://ably.io")!) { _ in
+            let rest = ARTRest(key: key as String)
+            rest.channels.get("foo").history { _ in
+                defer { backgroundRestExpectation.fulfill() }
+            }
+        }.resume()
+        self.waitForExpectationsWithTimeout(10, handler: nil)
     }
 }

--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -15,11 +15,14 @@
 
 @end
 
-@implementation ARTConnection
+@implementation ARTConnection {
+    _Nonnull dispatch_queue_t _queue;
+}
 
 - (instancetype)initWithRealtime:(ARTRealtime *)realtime {
     if (self == [super init]) {
-        _eventEmitter = [[ARTEventEmitter alloc] init];
+        _queue = dispatch_queue_create("io.ably.realtime.connection", DISPATCH_QUEUE_SERIAL);
+        _eventEmitter = [[ARTEventEmitter alloc] initWithQueue:_queue];
         _realtime = realtime;
         _serial = -1;
     }

--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -16,8 +16,8 @@ NSString *const ARTDefault_version = @"0.8";
 NSString *const ARTDefault_libraryVersion = @"0.8.9";
 NSString *const ARTDefault_platform = @"ios-";
 
-static int _realtimeRequestTimeout = 10.0;
-static int _connectionStateTtl = 60.0;
+static NSTimeInterval _realtimeRequestTimeout = 10.0;
+static NSTimeInterval _connectionStateTtl = 60.0;
 
 + (NSArray*)fallbackHosts {
     return @[@"a.ably-realtime.com", @"b.ably-realtime.com", @"c.ably-realtime.com", @"d.ably-realtime.com", @"e.ably-realtime.com"];

--- a/Source/ARTEventEmitter.h
+++ b/Source/ARTEventEmitter.h
@@ -21,6 +21,9 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface __GENERIC(ARTEventEmitter, EventType, ItemType) : NSObject
 
+- (instancetype)init;
+- (instancetype)initWithQueue:(dispatch_queue_t)queue;
+
 - (__GENERIC(ARTEventListener, ItemType) *)on:(EventType)event callback:(void (^)(ItemType __art_nullable))cb;
 - (__GENERIC(ARTEventListener, ItemType) *)on:(void (^)(ItemType __art_nullable))cb;
 

--- a/Source/ARTEventEmitter.m
+++ b/Source/ARTEventEmitter.m
@@ -29,7 +29,7 @@
 
 @interface ARTEventListener ()
 
-- (instancetype)initWithBlock:(void (^)(id __art_nonnull))block;
+- (instancetype)initWithBlock:(void (^)(id __art_nonnull))block queue:(dispatch_queue_t)queue;
 - (void)setTimerWithDeadline:(NSTimeInterval)deadline onTimeout:(void (^)())onTimeout;
 - (void)off;
 
@@ -37,13 +37,15 @@
 
 @implementation ARTEventListener {
     void (^_block)(id __art_nonnull);
-    dispatch_block_t _timerBlock;
+    _Nonnull dispatch_queue_t _queue;
+    _Nullable dispatch_block_t _timerBlock;
 }
 
-- (instancetype)initWithBlock:(void (^)(id __art_nonnull))block {
+- (instancetype)initWithBlock:(void (^)(id __art_nonnull))block queue:(dispatch_queue_t)queue {
     self = [self init];
     if (self) {
         _block = block;
+        _queue = queue;
     }
     return self;
 }
@@ -55,14 +57,15 @@
 
 - (void)setTimerWithDeadline:(NSTimeInterval)deadline onTimeout:(void (^)())onTimeout {
     [self cancelTimer];
-    _timerBlock = dispatch_block_create(0, onTimeout);
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, deadline * NSEC_PER_SEC), dispatch_get_main_queue(), _timerBlock);
+    _timerBlock = dispatch_block_create(0, ^{
+        onTimeout();
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, deadline * NSEC_PER_SEC), _queue, _timerBlock);
 }
 
 - (void)cancelTimer {
     if (_timerBlock) {
         dispatch_block_cancel(_timerBlock);
-        _timerBlock = nil;
     }
 }
 
@@ -74,7 +77,7 @@
 
 @implementation ARTEventEmitterEntry
 
--(instancetype)initWithListener:(ARTEventListener *)listener once:(BOOL)once {
+- (instancetype)initWithListener:(ARTEventListener *)listener once:(BOOL)once {
     self = [self init];
     if (self) {
         _listener = listener;
@@ -92,23 +95,31 @@
 
 @end
 
-@implementation ARTEventEmitter
+@implementation ARTEventEmitter {
+    _Nonnull dispatch_queue_t _queue;
+}
+
 - (instancetype)init {
+    return [self initWithQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)];
+}
+
+- (instancetype)initWithQueue:(dispatch_queue_t)queue {
     self = [super init];
     if (self) {
+        _queue = queue;
         [self resetListeners];
     }
     return self;
 }
 
 - (ARTEventListener *)on:(id)event callback:(void (^)(id __art_nonnull))cb {
-    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb queue:_queue];
     [self addOnEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:false] event:event];
     return listener;
 }
 
 - (ARTEventListener *)once:(id)event callback:(void (^)(id __art_nonnull))cb {
-    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb queue:_queue];
     [self addOnEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:true] event:event];
     return listener;
 }
@@ -118,13 +129,13 @@
 }
 
 - (ARTEventListener *)on:(void (^)(id __art_nonnull))cb {
-    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb queue:_queue];
     [self addOnAllEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:false]];
     return listener;
 }
 
 - (ARTEventListener *)once:(void (^)(id __art_nonnull))cb {
-    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb];
+    ARTEventListener *listener = [[ARTEventListener alloc] initWithBlock:cb queue:_queue];
     [self addOnAllEntry:[[ARTEventEmitterEntry alloc] initWithListener:listener once:true]];
     return listener;
 }

--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -54,9 +54,6 @@ ART_ASSUME_NONNULL_BEGIN
 @end
 
 @interface ARTHttp : NSObject<ARTHTTPExecutor>
-{
-    
-}
 
 @property (nonatomic, weak) ARTLog *logger;
 

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -156,7 +156,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _queue = dispatch_queue_create("com.ably.rest.http", DISPATCH_QUEUE_SERIAL);
+        _queue = dispatch_queue_create("io.ably.rest.http", DISPATCH_QUEUE_SERIAL);
         _urlSession = [[ARTURLSessionServerTrust alloc] init];
         _baseUrl = nil;
     }

--- a/Source/ARTPresenceMap.h
+++ b/Source/ARTPresenceMap.h
@@ -25,6 +25,9 @@ ART_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, assign) BOOL syncComplete;
 @property (readonly, nonatomic, getter=getSyncInProgress) BOOL syncInProgress;
 
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)initWithQueue:(_Nonnull dispatch_queue_t)queue;
+
 - (void)put:(ARTPresenceMessage *)message;
 - (void)clean;
 

--- a/Source/ARTPresenceMap.m
+++ b/Source/ARTPresenceMap.m
@@ -21,13 +21,13 @@
 
 @implementation ARTPresenceMap
 
-- (id)init {
+- (instancetype)initWithQueue:(_Nonnull dispatch_queue_t)queue {
     self = [super init];
     if(self) {
         _recentMembers = [NSMutableDictionary dictionary];
         _syncStarted = false;
         _syncComplete = false;
-        _syncEndedEventEmitter = [[ARTEventEmitter alloc] init];
+        _syncEndedEventEmitter = [[ARTEventEmitter alloc] initWithQueue:queue];
     }
     return self;
 }

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -220,8 +220,8 @@
     if (errorInfo != nil) {
         [self.connection setErrorReason:errorInfo];
     }
-    [self.connection emit:state with:stateChange];
     [_internalEventEmitter emit:[NSNumber numberWithInteger:state] with:stateChange];
+    [self.connection emit:state with:stateChange];
 }
 
 - (void)transitionSideEffects:(ARTConnectionStateChange *)stateChange {

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -215,21 +215,28 @@
     ARTConnectionStateChange *stateChange = [[ARTConnectionStateChange alloc] initWithCurrent:state previous:self.connection.state reason:errorInfo retryIn:0];
     [self.connection setState:state];
 
-    [self transitionSideEffects:stateChange];
-
     if (errorInfo != nil) {
         [self.connection setErrorReason:errorInfo];
     }
+
+    dispatch_semaphore_t waitingForCurrentEventSemaphore = [self transitionSideEffects:stateChange];
+
     [_internalEventEmitter emit:[NSNumber numberWithInteger:state] with:stateChange];
     [self.connection emit:state with:stateChange];
+
+    if (waitingForCurrentEventSemaphore) {
+        // Current event is handled. Start running timeouts.
+        dispatch_semaphore_signal(waitingForCurrentEventSemaphore);
+    }
 }
 
-- (void)transitionSideEffects:(ARTConnectionStateChange *)stateChange {
+- (_Nullable dispatch_semaphore_t)transitionSideEffects:(ARTConnectionStateChange *)stateChange {
     ARTStatus *status = nil;
+    dispatch_semaphore_t waitingForCurrentEventSemaphore = nil;
 
     switch (stateChange.current) {
         case ARTRealtimeConnecting: {
-            [self unlessStateChangesBefore:[ARTDefault realtimeRequestTimeout] do:^{
+            waitingForCurrentEventSemaphore = [self unlessStateChangesBefore:[ARTDefault realtimeRequestTimeout] do:^{
                 [self transition:ARTRealtimeDisconnected withErrorInfo:[ARTErrorInfo createWithCode:0 status:ARTStateConnectionFailed message:@"timed out"]];
             }];
 
@@ -279,7 +286,7 @@
         }
         case ARTRealtimeClosing: {
             [_reachability off];
-            [self unlessStateChangesBefore:[ARTDefault realtimeRequestTimeout] do:^{
+            waitingForCurrentEventSemaphore = [self unlessStateChangesBefore:[ARTDefault realtimeRequestTimeout] do:^{
                 [self transition:ARTRealtimeClosed];
             }];
             [self.transport sendClose];
@@ -312,18 +319,16 @@
             }
             if ([[NSDate date] timeIntervalSinceDate:_startedReconnection] >= _connectionStateTtl) {
                 [self transition:ARTRealtimeSuspended withErrorInfo:stateChange.reason];
-                return;
+                return nil;
             }
 
             [self.transport close];
             self.transport.delegate = nil;
             _transport = nil;
             [stateChange setRetryIn:self.options.disconnectedRetryTimeout];
-
-            [self unlessStateChangesBefore:stateChange.retryIn do:^{
+            waitingForCurrentEventSemaphore = [self unlessStateChangesBefore:stateChange.retryIn do:^{
                 [self transition:ARTRealtimeConnecting];
             }];
-
             break;
         }
         case ARTRealtimeSuspended: {
@@ -331,7 +336,7 @@
             self.transport.delegate = nil;
             _transport = nil;
             [stateChange setRetryIn:self.options.suspendedRetryTimeout];
-            [self unlessStateChangesBefore:stateChange.retryIn do:^{
+            waitingForCurrentEventSemaphore = [self unlessStateChangesBefore:stateChange.retryIn do:^{
                 [self transition:ARTRealtimeConnecting];
             }];
             break;
@@ -383,24 +388,27 @@
             }
         }
     }
+
+    return waitingForCurrentEventSemaphore;
 }
 
-- (void)unlessStateChangesBefore:(NSTimeInterval)deadline do:(void(^)())callback {
-    // Defer until next event loop execution so that any event emitted in the current
-    // one doesn't cancel the timeout.
+- (_Nonnull dispatch_semaphore_t)unlessStateChangesBefore:(NSTimeInterval)deadline do:(void(^)())callback __attribute__((warn_unused_result)) {
+    // Defer until next event loop execution so that any event emitted in the current one doesn't cancel the timeout.
     ARTRealtimeConnectionState state = self.connection.state;
-    CFRunLoopObserverRef observer = CFRunLoopObserverCreateWithHandler(NULL, kCFRunLoopExit, YES, 0, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
-        ARTEventListener *listener = [_internalEventEmitter once:^(ARTConnectionStateChange *change) {
-            // Any state change cancels the timeout.
-        }];
+    // Timeout should be dispatched after current event.
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0), _eventQueue, ^{
+        // Wait until the current event is done.
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
         if (state != self.connection.state) {
-            // Already changed; Cancels the timeout.
-            [_internalEventEmitter off:listener];
+            // Already changed; Ignore the timer.
             return;
         }
-        [_internalEventEmitter timed:listener deadline:deadline onTimeout:callback];
+        [_internalEventEmitter timed:[_internalEventEmitter once:^(ARTConnectionStateChange *change) {
+            // Any state change cancels the timeout.
+        }] deadline:deadline onTimeout:callback];
     });
-    CFRunLoopAddObserver(CFRunLoopGetCurrent(), observer, kCFRunLoopCommonModes);
+    return semaphore;
 }
 
 - (void)onHeartbeat {
@@ -451,10 +459,14 @@
             }
             [self transition:ARTRealtimeConnected withErrorInfo:message.error];
             break;
-        case ARTRealtimeConnected:
+        case ARTRealtimeConnected: {
             // Renewing token.
-            [self transitionSideEffects:[[ARTConnectionStateChange alloc] initWithCurrent:ARTRealtimeConnected previous:ARTRealtimeConnected reason:nil]];
+            dispatch_semaphore_t semaphore = [self transitionSideEffects:[[ARTConnectionStateChange alloc] initWithCurrent:ARTRealtimeConnected previous:ARTRealtimeConnected reason:nil]];
             [self transition:ARTRealtimeConnected withErrorInfo:message.error];
+            if (semaphore) {
+                dispatch_semaphore_signal(semaphore);
+            }
+        }
         default:
             break;
     }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -503,12 +503,11 @@
             presence.id = [NSString stringWithFormat:@"%@:%d", message.id, i];
         }
 
-        [self.presenceMap onceSyncEnds:^(__GENERIC(NSArray, ARTPresenceMessage *) *msgs) {
-            [self.presenceMap put:presence];
+        [self.presenceMap put:presence];
+        if (!self.presenceMap.syncInProgress) {
             [self.presenceMap clean];
-
-            [self broadcastPresence:presence];
-        }];
+        }
+        [self broadcastPresence:presence];
 
         ++i;
     }

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -37,25 +37,26 @@
 
 @end
 
-@implementation ARTRealtimeChannel
+@implementation ARTRealtimeChannel {
+    _Nonnull dispatch_queue_t _eventQueue;
+}
 
 - (instancetype)initWithRealtime:(ARTRealtime *)realtime andName:(NSString *)name withOptions:(ARTChannelOptions *)options {
     self = [super initWithName:name andOptions:options andLogger:realtime.options.logHandler];
     if (self) {
+        _eventQueue = dispatch_queue_create("io.ably.realtime.channel", DISPATCH_QUEUE_SERIAL);
         _realtime = realtime;
         _restChannel = [_realtime.rest.channels get:self.name options:options];
         _state = ARTRealtimeChannelInitialized;
         _queuedMessages = [NSMutableArray array];
         _attachSerial = nil;
-        _presenceMap = [[ARTPresenceMap alloc] init];
+        _presenceMap = [[ARTPresenceMap alloc] initWithQueue:_eventQueue];
         _lastPresenceAction = ARTPresenceAbsent;
-        
-        _statesEventEmitter = [[ARTEventEmitter alloc] init];
-        _messagesEventEmitter = [[ARTEventEmitter alloc] init];
-        _presenceEventEmitter = [[ARTEventEmitter alloc] init];
-
-        _attachedEventEmitter = [[ARTEventEmitter alloc] init];
-        _detachedEventEmitter = [[ARTEventEmitter alloc] init];
+        _statesEventEmitter = [[ARTEventEmitter alloc] initWithQueue:_eventQueue];
+        _messagesEventEmitter = [[ARTEventEmitter alloc] initWithQueue:_eventQueue];
+        _presenceEventEmitter = [[ARTEventEmitter alloc] initWithQueue:_eventQueue];
+        _attachedEventEmitter = [[ARTEventEmitter alloc] initWithQueue:_eventQueue];
+        _detachedEventEmitter = [[ARTEventEmitter alloc] initWithQueue:_eventQueue];
     }
     return self;
 }
@@ -334,7 +335,7 @@
     // Defer until next event loop execution so that any event emitted in the current
     // one doesn't cancel the timeout.
     ARTRealtimeChannelState state = self.state;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0), _eventQueue, ^{
         if (state != self.state) {
             // Already changed; do nothing.
             return;

--- a/Source/ARTWebSocketTransport+Private.h
+++ b/Source/ARTWebSocketTransport+Private.h
@@ -19,8 +19,6 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTWebSocketTransport () <SRWebSocketDelegate>
 
-@property (readonly, assign, nonatomic) CFRunLoopRef rl;
-
 // From RestClient
 @property (readwrite, strong, nonatomic) id<ARTEncoder> encoder;
 @property (readonly, strong, nonatomic) ARTLog *logger;

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -39,7 +39,6 @@ enum {
 @implementation ARTWebSocketTransport {
     /**
       A dispatch queue for firing the events.
-      If `nil`, the socket uses the main queue for performing all delegate method calls.
      */
     _Nonnull dispatch_queue_t _workQueue;
 }

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -47,7 +47,7 @@ enum {
 - (instancetype)initWithRest:(ARTRest *)rest options:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey connectionSerial:(NSNumber *)connectionSerial {
     self = [super init];
     if (self) {
-        _workQueue = dispatch_queue_create("com.ably.transport.websocket", DISPATCH_QUEUE_SERIAL);
+        _workQueue = dispatch_queue_create("io.ably.transport.websocket", DISPATCH_QUEUE_SERIAL);
         _websocket = nil;
         _closing = NO;
         _encoder = rest.defaultEncoder;

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -36,16 +36,21 @@ enum {
     ARTWsTlsError = 1015
 };
 
-@implementation ARTWebSocketTransport
+@implementation ARTWebSocketTransport {
+    /**
+      A dispatch queue for firing the events.
+      If `nil`, the socket uses the main queue for performing all delegate method calls.
+     */
+    _Nonnull dispatch_queue_t _workQueue;
+}
 
 // FIXME: Realtime sould be extending from RestClient
 - (instancetype)initWithRest:(ARTRest *)rest options:(ARTClientOptions *)options resumeKey:(NSString *)resumeKey connectionSerial:(NSNumber *)connectionSerial {
     self = [super init];
     if (self) {
-        _rl = CFRunLoopGetCurrent();
+        _workQueue = dispatch_queue_create("com.ably.transport.websocket", DISPATCH_QUEUE_SERIAL);
         _websocket = nil;
         _closing = NO;
-
         _encoder = rest.defaultEncoder;
         _logger = rest.logger;
         _auth = rest.auth;
@@ -187,6 +192,7 @@ enum {
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
 
     self.websocket = [[SRWebSocket alloc] initWithURLRequest:request];
+    [self.websocket setDelegateDispatchQueue:_workQueue];
     self.websocket.delegate = self;
     self.websocketURL = url;
     return url;
@@ -238,20 +244,19 @@ enum {
     ARTWebSocketTransport * __weak weakSelf = self;
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket did open", _delegate, self];
 
-    CFRunLoopPerformBlock(self.rl, kCFRunLoopDefaultMode, ^{
+    dispatch_async(_workQueue, ^{
         ARTWebSocketTransport *s = weakSelf;
         if (s) {
             [s.delegate realtimeTransportAvailable:s];
         }
     });
-    CFRunLoopWakeUp(self.rl);
 }
 
 - (void)webSocket:(SRWebSocket *)webSocket didCloseWithCode:(NSInteger)code reason:(NSString *)reason wasClean:(BOOL)wasClean {
     ARTWebSocketTransport * __weak weakSelf = self;
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket did disconnect (code %ld) %@", _delegate, self, (long)code, reason];
 
-    CFRunLoopPerformBlock(self.rl, kCFRunLoopDefaultMode, ^{
+    dispatch_async(_workQueue, ^{
         ARTWebSocketTransport *s = weakSelf;
         if (!s) {
             return;
@@ -295,20 +300,18 @@ enum {
                 break;
         }
     });
-    CFRunLoopWakeUp(self.rl);
 }
 
 - (void)webSocket:(SRWebSocket *)webSocket didFailWithError:(NSError *)error {
     ARTWebSocketTransport * __weak weakSelf = self;
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket did receive error %@", _delegate, self, error];
 
-    CFRunLoopPerformBlock(self.rl, kCFRunLoopDefaultMode, ^{
+    dispatch_async(_workQueue, ^{
         ARTWebSocketTransport *s = weakSelf;
         if (s) {
             [s.delegate realtimeTransportFailed:s withError:[self classifyError:error]];
         }
     });
-    CFRunLoopWakeUp(self.rl);
 }
 
 - (ARTRealtimeTransportError *)classifyError:(NSError *)error {
@@ -344,7 +347,7 @@ enum {
     ARTWebSocketTransport * __weak weakSelf = self;
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket did receive message %@", _delegate, self, text];
 
-    CFRunLoopPerformBlock(self.rl, kCFRunLoopDefaultMode, ^{
+    dispatch_async(_workQueue, ^{
         NSData *data = nil;
         data = [((NSString *)text) dataUsingEncoding:NSUTF8StringEncoding];
 
@@ -353,20 +356,18 @@ enum {
             [s receiveWithData:data];
         }
     });
-    CFRunLoopWakeUp(self.rl);
 }
 
 - (void)webSocketMessageData:(NSData *)data {
     ARTWebSocketTransport * __weak weakSelf = self;
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p WS:%p websocket did receive data %@", _delegate, self, data];
 
-    CFRunLoopPerformBlock(self.rl, kCFRunLoopDefaultMode, ^{
+    dispatch_async(_workQueue, ^{
         ARTWebSocketTransport *s = weakSelf;
         if (s) {
             [s receiveWithData:data];
         }
     });
-    CFRunLoopWakeUp(self.rl);
 }
 
 @end

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -352,6 +352,20 @@ class RealtimeClient: QuickSpec {
                 }
             }
 
+            // https://github.com/ably/ably-ios/issues/577
+            it("background behaviour") {
+                let options = AblyTests.commonAppSetup()
+                waitUntil(timeout: testTimeout) { done in
+                    NSURLSession.sharedSession().dataTaskWithURL(NSURL(string:"https://ably.io")!) { _ in
+                        let realtime = ARTRealtime(options: options)
+                        realtime.channels.get("foo").attach { error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }.resume()
+                }
+            }
+
             it("should never register any connection listeners for internal use with the public EventEmitter") {
                 let options = AblyTests.commonAppSetup()
                 options.autoConnect = false

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -605,7 +605,7 @@ class RealtimeClientChannel: QuickSpec {
                     expect(channel.errorReason).toNot(beNil())
                     expect(callbackCalled).to(beTrue())
                     let end = NSDate()
-                    expect(start.dateByAddingTimeInterval(3.0)).to(beCloseTo(end, within: 0.5))
+                    expect(start.dateByAddingTimeInterval(3.0)).to(beCloseTo(end, within: 0.9))
                 }
 
                 it("if called with a callback should call it once attached") {

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -475,6 +475,7 @@ class RealtimeClientConnection: QuickSpec {
                 TotalReach.shared = 0
                 defer {
                     for client in disposable {
+                        client.dispose()
                         client.close()
                     }
                 }
@@ -1251,7 +1252,7 @@ class RealtimeClientConnection: QuickSpec {
 
 
                     expect(lastStateChange).toEventuallyNot(beNil(), timeout: testTimeout)
-                    expect(lastStateChange!.current).toEventually(equal(ARTRealtimeConnectionState.Closing), timeout: testTimeout)
+                    expect(lastStateChange!.current).toEventually(equal(ARTRealtimeConnectionState.Closed), timeout: testTimeout)
                 }
 
                 // RTN12a
@@ -1816,7 +1817,7 @@ class RealtimeClientConnection: QuickSpec {
 
                         client.connection.on(.Suspended) { stateChange in
                             let end = NSDate()
-                            expect(end.timeIntervalSinceDate(start!)).to(beCloseTo(expectedTime, within: 0.5))
+                            expect(end.timeIntervalSinceDate(start!)).to(beCloseTo(expectedTime, within: 0.9))
                             partialDone()
                         }
 

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -819,7 +819,7 @@ class RealtimeClientPresence: QuickSpec {
                         channel.presence.leave("offline")
                     }
 
-                    expect(channel.presenceMap.members).toEventually(haveCount(0), timeout: testTimeout)
+                    expect(channel.presenceMap.members).toEventually(beEmpty(), timeout: testTimeout)
                 }
 
                 // RTP10a

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -45,6 +45,7 @@ class RealtimeClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
@@ -85,7 +86,7 @@ class RealtimeClientPresence: QuickSpec {
                 let options = AblyTests.commonAppSetup()
                 options.disconnectedRetryTimeout = 1.0
                 var clientSecondary: ARTRealtime!
-                defer { clientSecondary.close() }
+                defer { clientSecondary.dispose(); clientSecondary.close() }
 
                 waitUntil(timeout: testTimeout) { done in
                     clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options) {
@@ -114,8 +115,10 @@ class RealtimeClientPresence: QuickSpec {
                 expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.Connecting), timeout: options.disconnectedRetryTimeout + 1.0)
                 expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.Connected), timeout: testTimeout)
 
-                //Client library requests a SYNC resume by sending a SYNC ProtocolMessage with the last received sync serial number
-                let transport = client.transport as! TestProxyTransport
+                // Client library requests a SYNC resume by sending a SYNC ProtocolMessage with the last received sync serial number
+                guard let transport = client.transport as? TestProxyTransport else {
+                    fail("Transport is nil"); return
+                }
                 expect(transport.protocolMessagesSent.filter{ $0.action == .Sync }).toEventually(haveCount(1), timeout: testTimeout)
                 expect(transport.protocolMessagesSent.filter{ $0.action == .Sync }.first!.channelSerial).to(equal(lastSyncSerial))
 
@@ -126,7 +129,7 @@ class RealtimeClientPresence: QuickSpec {
             it("should receive all 250 members") {
                 let options = AblyTests.commonAppSetup()
                 var clientSource: ARTRealtime!
-                defer { clientSource.close() }
+                defer { clientSource.dispose(); clientSource.close() }
 
                 waitUntil(timeout: testTimeout) { done in
                     clientSource = AblyTests.addMembersSequentiallyToChannel("test", members: 250, options: options) {
@@ -850,7 +853,7 @@ class RealtimeClientPresence: QuickSpec {
             it("should be used a PresenceMap to maintain a list of members") {
                 let options = AblyTests.commonAppSetup()
                 var clientSecondary: ARTRealtime!
-                defer { clientSecondary.close() }
+                defer { clientSecondary.dispose(); clientSecondary.close() }
 
                 waitUntil(timeout: testTimeout) { done in
                     clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 100, options: options) {
@@ -1690,6 +1693,7 @@ class RealtimeClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
@@ -1861,7 +1865,7 @@ class RealtimeClientPresence: QuickSpec {
                     it("waitForSync is true, should wait until SYNC is complete before returning a list of members") {
                         let options = AblyTests.commonAppSetup()
                         var clientSecondary: ARTRealtime!
-                        defer { clientSecondary.close() }
+                        defer { clientSecondary.dispose(); clientSecondary.close() }
 
                         waitUntil(timeout: testTimeout) { done in
                             clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options) {
@@ -1899,7 +1903,7 @@ class RealtimeClientPresence: QuickSpec {
                     it("waitForSync is false, should return immediately the known set of presence members") {
                         let options = AblyTests.commonAppSetup()
                         var clientSecondary: ARTRealtime!
-                        defer { clientSecondary.close() }
+                        defer { clientSecondary.dispose(); clientSecondary.close() }
 
                         waitUntil(timeout: testTimeout) { done in
                             clientSecondary = AblyTests.addMembersSequentiallyToChannel("test", members: 150, options: options) {
@@ -1990,7 +1994,7 @@ class RealtimeClientPresence: QuickSpec {
                     let options = AblyTests.commonAppSetup()
 
                     var clientSecondary: ARTRealtime!
-                    defer { clientSecondary.close() }
+                    defer { clientSecondary.dispose(); clientSecondary.close() }
 
                     let expectedData = ["x", "y"]
                     let expectedPattern = "^user(\\d+)$"
@@ -2119,6 +2123,7 @@ class RealtimeClientPresence: QuickSpec {
                         var disposable = [ARTRealtime]()
                         defer {
                             for clientItem in disposable {
+                                clientItem.dispose()
                                 clientItem.close()
                             }
                         }
@@ -2169,6 +2174,7 @@ class RealtimeClientPresence: QuickSpec {
                 var disposable = [ARTRealtime]()
                 defer {
                     for clientItem in disposable {
+                        clientItem.dispose()
                         clientItem.close()
                     }
                 }

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -1129,6 +1129,19 @@ class RestClient: QuickSpec {
                 }
             }
 
+            // https://github.com/ably/ably-ios/issues/577
+            it("background behaviour") {
+                let options = AblyTests.commonAppSetup()
+                waitUntil(timeout: testTimeout) { done in
+                    NSURLSession.sharedSession().dataTaskWithURL(NSURL(string:"https://ably.io")!) { _ in
+                        let rest = ARTRest(options: options)
+                        rest.channels.get("foo").history { _ in
+                            done()
+                        }
+                    }.resume()
+                }
+            }
+
         } //RestClient
     }
 }

--- a/Spec/RestClientPresence.swift
+++ b/Spec/RestClientPresence.swift
@@ -26,6 +26,7 @@ class RestClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
@@ -131,6 +132,7 @@ class RestClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
@@ -180,7 +182,7 @@ class RestClientPresence: QuickSpec {
                     let channel = client.channels.get("test")
 
                     var realtime: ARTRealtime!
-                    defer { realtime.close() }
+                    defer { realtime.dispose(); realtime.close() }
 
                     let expectedData = "online"
                     let expectedPattern = "^user(\\d+)$"
@@ -244,6 +246,7 @@ class RestClientPresence: QuickSpec {
                         var disposable = [ARTRealtime]()
                         defer {
                             for clientItem in disposable {
+                                clientItem.dispose()
                                 clientItem.close()
                             }
                         }
@@ -299,7 +302,7 @@ class RestClientPresence: QuickSpec {
                         let channel = client.channels.get("test")
 
                         var realtime: ARTRealtime!
-                        defer { realtime.close() }
+                        defer { realtime.dispose(); realtime.close() }
 
                         waitUntil(timeout: testTimeout) { done in
                             realtime = AblyTests.addMembersSequentiallyToChannel("test", members: 1, options: options) {
@@ -338,6 +341,7 @@ class RestClientPresence: QuickSpec {
                     var disposable = [ARTRealtime]()
                     defer {
                         for clientItem in disposable {
+                            clientItem.dispose()
                             clientItem.close()
                         }
                     }
@@ -392,6 +396,7 @@ class RestClientPresence: QuickSpec {
                         var disposable = [ARTRealtime]()
                         defer {
                             for clientItem in disposable {
+                                clientItem.dispose()
                                 clientItem.close()
                             }
                         }


### PR DESCRIPTION
It wasn't firing transport events when the Realtime object was created on a background queue.
UPDATE: Rest was with the same problem.