### PR TITLE
Default token TTL to nil, not 60*60.

### DIFF
--- a/Source/ARTJsonLikeEncoder.m
+++ b/Source/ARTJsonLikeEncoder.m
@@ -404,7 +404,6 @@
 
     NSMutableDictionary *dictionary = [@{
              @"keyName":tokenRequest.keyName ? tokenRequest.keyName : @"",
-             @"ttl":[NSNumber numberWithUnsignedLongLong: timeIntervalToMilliseconds(tokenRequest.ttl)],
              @"capability":tokenRequest.capability ? tokenRequest.capability : @"",
              @"timestamp":timestamp,
              @"nonce":tokenRequest.nonce ? tokenRequest.nonce : @"",
@@ -413,6 +412,9 @@
 
     if (tokenRequest.clientId) {
         dictionary[@"clientId"] = tokenRequest.clientId;
+    }
+    if (tokenRequest.ttl) {
+        dictionary[@"ttl"] = [NSNumber numberWithUnsignedLongLong:timeIntervalToMilliseconds([tokenRequest.ttl doubleValue])];
     }
 
     return dictionary;
@@ -441,7 +443,7 @@
 
     ARTTokenParams *params = [[ARTTokenParams alloc] initWithClientId:[input artString:@"clientId"]
                                                                 nonce:[input artString:@"nonce"]];
-    params.ttl = millisecondsToTimeInterval([input artInteger:@"ttl"]);
+    params.ttl = [NSNumber numberWithDouble:millisecondsToTimeInterval([input artInteger:@"ttl"])];
     params.capability = [input artString:@"capability"];
     params.timestamp = [input artDate:@"timestamp"];
 

--- a/Source/ARTTokenParams.h
+++ b/Source/ARTTokenParams.h
@@ -20,9 +20,9 @@ ART_ASSUME_NONNULL_BEGIN
 @interface ARTTokenParams : NSObject
 
 /**
- Represents time to live (expiry) of this token in seconds.
+ Represents time to live (expiry) of this token as a NSTimeInterval.
  */
-@property (nonatomic, assign) NSTimeInterval ttl;
+@property (nonatomic, strong, nullable) NSNumber *ttl;
 
 /**
  Contains the capability JSON stringified.

--- a/Source/ARTTokenRequest.h
+++ b/Source/ARTTokenRequest.h
@@ -44,9 +44,9 @@ ART_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *capability;
 
 /**
- Represents time to live (expiry) of this token in seconds.
+ Represents time to live (expiry) of this token as a NSTimeInterval.
  */
-@property (nonatomic, assign) NSTimeInterval ttl;
+@property (nonatomic, strong, nullable) NSNumber *ttl;
 
 /**
  Timestamp (in millis since the epoch) of this request. Timestamps, in conjunction with the nonce, are used to prevent n requests from being replayed.

--- a/Source/ARTTokenRequest.m
+++ b/Source/ARTTokenRequest.m
@@ -15,7 +15,7 @@
 
 - (instancetype)initWithTokenParams:(ARTTokenParams *)tokenParams keyName:(NSString *)keyName nonce:(NSString *)nonce mac:(NSString *)mac {
     if (self = [super init]) {
-        self.ttl = tokenParams.ttl ? tokenParams.ttl : [ARTDefault ttl];
+        self.ttl = tokenParams.ttl;
         self.capability = tokenParams.capability;
         self.clientId = tokenParams.clientId;
         self.timestamp = tokenParams.timestamp;
@@ -31,7 +31,7 @@
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat: @"ARTTokenRequest: keyName=%@ clientId=%@ nonce=%@ mac=%@ ttl=%f capability=%@ timestamp=%@",
+    return [NSString stringWithFormat: @"ARTTokenRequest: keyName=%@ clientId=%@ nonce=%@ mac=%@ ttl=%@ capability=%@ timestamp=%@",
             self.keyName, self.clientId, self.nonce, self.mac, self.ttl, self.capability, self.timestamp];
 }
 
@@ -52,7 +52,7 @@
                                                                            nonce:dict[@"nonce"]
                                                                              mac:dict[@"mac"]];
     tokenRequest.clientId = dict[@"clientId"];
-    tokenRequest.ttl = millisecondsToTimeInterval([dict[@"ttl"] doubleValue]);
+    tokenRequest.ttl = dict[@"ttl"] ? [NSNumber numberWithDouble:millisecondsToTimeInterval([dict[@"ttl"] unsignedLongLongValue])] : nil;
     tokenRequest.capability = dict[@"capability"];
     tokenRequest.timestamp = [NSDate dateWithTimeIntervalSince1970:[dict[@"timestamp"] doubleValue] / 1000];
 

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -1871,7 +1871,7 @@ class RealtimeClientConnection: QuickSpec {
                     options.autoConnect = false
                     options.authCallback = { tokenParams, callback in
                         delay(0) {
-                            callback(getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl), nil)
+                            callback(getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl as! TimeInterval?), nil)
                         }
                     }
                     let tokenTtl = 3.0
@@ -2665,7 +2665,7 @@ class RealtimeClientConnection: QuickSpec {
                         options.disconnectedRetryTimeout = 1.0
                         options.autoConnect = false
                         options.authCallback = { tokenParams, callback in
-                            callback(getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl), nil)
+                            callback(getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: TimeInterval(tokenParams.ttl!)), nil)
                         }
                         let tokenTtl = 5.0
                         options.token = getTestToken(key: options.key, ttl: tokenTtl)

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -510,7 +510,7 @@ class RestClient: QuickSpec {
                             rest.httpExecutor = testHTTPExecutor
 
                             // Delay for token expiration
-                            delay(tokenParams.ttl) {
+                            delay(TimeInterval(tokenParams.ttl!)) {
                                 // [40140, 40150) - token expired and will not recover because authUrl is invalid
                                 publishTestMessage(rest) { error in
                                     guard let errorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
@@ -559,7 +559,7 @@ class RestClient: QuickSpec {
                             rest.httpExecutor = testHTTPExecutor
 
                             // Delay for token expiration
-                            delay(tokenParams.ttl) {
+                            delay(TimeInterval(tokenParams.ttl!)) {
                                 // [40140, 40150) - token expired and will not recover because authUrl is invalid
                                 publishTestMessage(rest) { error in
                                     guard let errorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -447,7 +447,7 @@ func getTestTokenDetails(key: String? = nil, clientId: String? = nil, capability
     }
     if let ttl = ttl {
         if tokenParams == nil { tokenParams = ARTTokenParams() }
-        tokenParams!.ttl = ttl
+        tokenParams!.ttl = NSNumber(value: ttl)
     }
     if let clientId = clientId {
         if tokenParams == nil { tokenParams = ARTTokenParams() }


### PR DESCRIPTION
Fixes #618.

Part of ably/docs#303.