### PR TITLE
[WIP] Make the library thread-safe.

### DIFF
--- a/Ably.xcodeproj/project.pbxproj
+++ b/Ably.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		EB2D84F71CD75CCE00F23CDA /* ARTReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = EB2D84F61CD75CCE00F23CDA /* ARTReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EB2D84FD1CD769B800F23CDA /* ARTOSReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = EB2D84FC1CD769B700F23CDA /* ARTOSReachability.m */; };
 		EB2D85011CD769C800F23CDA /* ARTOSReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = EB2D85001CD769C800F23CDA /* ARTOSReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB4B1A0C1F2190BB00467F07 /* ARTRestChannels+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB4B1A0B1F2190BB00467F07 /* ARTRestChannels+Private.h */; };
 		EB503C881C7E4A090053AF00 /* ARTClientOptions+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB503C871C7E4A090053AF00 /* ARTClientOptions+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB503C8A1C7F1FE40053AF00 /* ARTLog+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB503C891C7F1FE40053AF00 /* ARTLog+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		EB5E058D1C77027600A48B39 /* ARTCrypto+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EB5E058C1C77027600A48B39 /* ARTCrypto+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -415,6 +416,7 @@
 		EB2D85001CD769C800F23CDA /* ARTOSReachability.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTOSReachability.h; sourceTree = "<group>"; };
 		EB3239421C59AB0400892664 /* ARTDataEncoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARTDataEncoder.m; sourceTree = "<group>"; };
 		EB3239461C59AB2C00892664 /* ARTDataEncoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARTDataEncoder.h; sourceTree = "<group>"; };
+		EB4B1A0B1F2190BB00467F07 /* ARTRestChannels+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTRestChannels+Private.h"; sourceTree = "<group>"; };
 		EB503C871C7E4A090053AF00 /* ARTClientOptions+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTClientOptions+Private.h"; sourceTree = "<group>"; };
 		EB503C891C7F1FE40053AF00 /* ARTLog+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTLog+Private.h"; sourceTree = "<group>"; };
 		EB5E058C1C77027600A48B39 /* ARTCrypto+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ARTCrypto+Private.h"; sourceTree = "<group>"; };
@@ -634,6 +636,7 @@
 				D7F1D3721BF4DE07001A4B5E /* ARTRestPresence.m */,
 				EB89D4021C61C1A4007FA5B7 /* ARTRestChannels.h */,
 				EB89D4031C61C1A4007FA5B7 /* ARTRestChannels.m */,
+				EB4B1A0B1F2190BB00467F07 /* ARTRestChannels+Private.h */,
 			);
 			name = Rest;
 			sourceTree = "<group>";
@@ -868,6 +871,7 @@
 				D746AE2F1BBBE7D7003ECEF8 /* ARTPaginatedResult+Private.h in Headers */,
 				D746AE431BBC5CD0003ECEF8 /* ARTRealtimeChannel+Private.h in Headers */,
 				D746AE251BBB611C003ECEF8 /* ARTChannel+Private.h in Headers */,
+				EB4B1A0C1F2190BB00467F07 /* ARTRestChannels+Private.h in Headers */,
 				D7F1D3731BF4DE07001A4B5E /* ARTRestPresence.h in Headers */,
 				D7B17EE31.0.308B00A6958E /* ARTConnectionDetails.h in Headers */,
 				D7F2B8B21E42410D00B65151 /* ARTPresenceMessage+Private.h in Headers */,

--- a/Examples/Tests/Podfile.lock
+++ b/Examples/Tests/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Ably (1.0.4):
+  - Ably (1.0.6):
     - KSCrashAblyFork (= 1.15.8-ably-1)
     - msgpack (= 0.1.8)
     - SocketRocket (= 0.5.1)
@@ -77,11 +77,11 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Ably: 86a62e0d7ca9f03fa776088e5ae1f58163fde7f0
+  Ably: 86578d591c0a840c82e099a73e23b29466ff6af5
   KSCrashAblyFork: 6d0dd5b033710109a8fdde28103eeb0e7f9ba1f7
   msgpack: 97491d2ea799408f4694f2c7d7fd79baf77853dd
   SocketRocket: d57c7159b83c3c6655745cd15302aa24b6bae531
 
 PODFILE CHECKSUM: 6af34bf7f91045b23539816c1d0cfe253bec5ea5
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/Examples/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Examples/Tests/Tests.xcodeproj/project.pbxproj
@@ -245,7 +245,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		4B4F9EED98BC61874DAB2F62 /* [CP] Check Pods Manifest.lock */ = {
@@ -260,7 +260,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		751C5C44401069CC5CAAEE9B /* [CP] Embed Pods Frameworks */ = {

--- a/Examples/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Examples/Tests/Tests.xcodeproj/project.pbxproj
@@ -186,9 +186,11 @@
 				TargetAttributes = {
 					EBF38F571CE3D0E000F0D574 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 					};
 					EBF38F6B1CE3D0E000F0D574 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 						TestTargetID = EBF38F571CE3D0E000F0D574;
 					};
 				};
@@ -472,7 +474,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.ably.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -485,7 +487,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.ably.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -498,7 +500,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.ably.TestsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tests.app/Tests";
 			};
 			name = Debug;
@@ -512,7 +514,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.ably.TestsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Tests.app/Tests";
 			};
 			name = Release;

--- a/Examples/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Examples/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -75,7 +75,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"

--- a/Examples/Tests/Tests/AppDelegate.swift
+++ b/Examples/Tests/Tests/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Examples/Tests/Tests/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Tests/Tests/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -32,6 +42,16 @@
     },
     {
       "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
     },
@@ -58,6 +78,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],

--- a/Examples/Tests/TestsTests/TestsTests.swift
+++ b/Examples/Tests/TestsTests/TestsTests.swift
@@ -16,28 +16,28 @@ class TestsTests: XCTestCase {
     let options: ARTClientOptions! = nil
 
     func testAblyWorks() {
-        var responseData: NSData?
+        var responseData: Data?
 
-        let postAppExpectation = self.expectationWithDescription("POST app to sandbox")
-        let request = NSMutableURLRequest(URL: NSURL(string: "https://sandbox-rest.ably.io:443/apps")!)
-        request.HTTPMethod = "POST"
-        request.HTTPBody = "{\"keys\":[{}]}".dataUsingEncoding(NSUTF8StringEncoding)
+        let postAppExpectation = self.expectation(description: "POST app to sandbox")
+        let request = NSMutableURLRequest(url: URL(string: "https://sandbox-rest.ably.io:443/apps")!)
+        request.httpMethod = "POST"
+        request.httpBody = "{\"keys\":[{}]}".data(using: String.Encoding.utf8)
         request.allHTTPHeaderFields = [
             "Accept" : "application/json",
             "Content-Type" : "application/json"
         ]
-        NSURLSession.sharedSession().dataTaskWithRequest(request) { data, _, error in
+        URLSession.shared.dataTask(with: request, completionHandler: { data, _, error in
             defer { postAppExpectation.fulfill() }
             if let e = error {
                 XCTFail("Error setting up sandbox app: \(e)")
                 return
             }
             responseData = data
-        }.resume()
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        }) .resume()
+        self.waitForExpectations(timeout: 10, handler: nil)
 
         guard let key = responseData
-            .flatMap({ try? NSJSONSerialization.JSONObjectWithData($0, options: NSJSONReadingOptions(rawValue: 0)) })
+            .flatMap({ try? JSONSerialization.jsonObject(with: $0, options: JSONSerialization.ReadingOptions(rawValue: 0)) })
             .flatMap({ $0 as? NSDictionary })
             .flatMap({ $0["keys"] as? NSArray })
             .flatMap({ $0[0] as? NSDictionary })
@@ -51,7 +51,7 @@ class TestsTests: XCTestCase {
         options.environment = "sandbox"
         let client = ARTRealtime(options: options)
 
-        let receiveExpectation = self.expectationWithDescription("message received")
+        let receiveExpectation = self.expectation(description: "message received")
 
         client.channels.get("test").subscribe { message in
             XCTAssertEqual(message.data as? NSString, "Get this!")
@@ -61,26 +61,26 @@ class TestsTests: XCTestCase {
         
         client.channels.get("test").publish(nil, data: "Get this!")
 
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
 
-        let backgroundRealtimeExpectation = self.expectationWithDescription("Realtime in a Background Queue")
+        let backgroundRealtimeExpectation = self.expectation(description: "Realtime in a Background Queue")
         var realtime: ARTRealtime! //strong reference
-        NSURLSession.sharedSession().dataTaskWithURL(NSURL(string:"https://ably.io")!) { _ in
+        URLSession.shared.dataTask(with: URL(string:"https://ably.io")!, completionHandler: { _ in
             realtime = ARTRealtime(key: key as String)
             realtime.channels.get("foo").attach { _ in
                 defer { backgroundRealtimeExpectation.fulfill() }
             }
-        }.resume()
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        }) .resume()
+        self.waitForExpectations(timeout: 10, handler: nil)
 
-        let backgroundRestExpectation = self.expectationWithDescription("Rest in a Background Queue")
+        let backgroundRestExpectation = self.expectation(description: "Rest in a Background Queue")
         var rest: ARTRest! //strong reference
-        NSURLSession.sharedSession().dataTaskWithURL(NSURL(string:"https://ably.io")!) { _ in
+        URLSession.shared.dataTask(with: URL(string:"https://ably.io")!, completionHandler: { _ in
             rest = ARTRest(key: key as String)
             rest.channels.get("foo").history { _ in
                 defer { backgroundRestExpectation.fulfill() }
             }
-        }.resume()
-        self.waitForExpectationsWithTimeout(10, handler: nil)
+        }) .resume()
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ The library makes the following thread-safety guarantees:
 * "Value" objects (e. g. `ARTTokenDetails`, data from messages) returned by the library can be safely read from and written to.
 * Objects passed to the library must not be mutated afterwards. They can be safely passed again, or read from; they won't be written to by the library.
 
-All internal operations are dispatched to a single serial GCD queue. By default, this
-queue uses the global queue with `QOS_CLASS_BACKGROUND` as a delegate. You can specify
-another delegate queue with `ARTClientOptions.internalDispatchQueue`.
+All internal operations are dispatched to a single serial GCD queue. You can specify
+a custom queue for this, which must be serial, with `ARTClientOptions.internalDispatchQueue`.
 
 All calls to callbacks provided by the user are dispatched to the main queue by default.
 This allows you to react to Ably's output by doing UI operations directly. You

--- a/README.md
+++ b/README.md
@@ -39,83 +39,19 @@ And then run `carthage update` to build the framework and drag the built Ably.fr
 
 ## Thread-safety
 
-**The iOS client libraries are not thread-safe yet.** We recommend that you ensure that all operations on a `ARTRest` or `ARTRealtime` object happen in the same [Grand Central Dispatch serial queue](https://developer.apple.com/library/content/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html#//apple_ref/doc/uid/TP40008091-CH102-SW6). Also, it's undefined from which queue or thread will callback blocks provided to the Ably library be called. This queue may be the same queue you use to call Ably, so if you're calling another Ably operation from your callback, you should only dispatch a new task for it if you're not already in Ably's queue. For example:
+The library makes the following thread-safety guarantees:
 
-**Swift**
+* The whole public interface can be safely accessed, both for read and writing, from any thread.
+* "Value" objects (e. g. `ARTTokenDetails`, data from messages) returned by the library can be safely read from and written to.
+* Objects passed to the library must not be mutated afterwards. They can be safely passed again, or read from; they won't be written to by the library.
 
-```swift
-class YourClass {
-    var ablyQueue: DispatchQueue!
-    var ably: ARTRealtime!
+All internal operations are dispatched to a single serial GCD queue. By default, this
+queue uses the global queue with `QOS_CLASS_BACKGROUND` as a delegate. You can specify
+another delegate queue with `ARTClientOptions.internalDispatchQueue`.
 
-    func initializeAbly() {
-        self.ablyQueue = DispatchQueue(label: "com.example.ably")
-        self.doAblyOperation {
-            self.ably = ARTRealtime(options: self.ablyOptions)
-        }
-    }
-
-    func subscribeToAbly() {
-        self.doAblyOperation {
-            self.ably.channels.get("foo").subscribe { message in
-                // Answer back.
-                self.doAblyOperation {
-                    self.ably.channels.get("foo").publish("reply", data:"Hi back!")
-                }
-            }
-        }
-    }
-
-    func doAblyOperation(_ operation: () -> Void) {
-        // Make sure we're not already in the Ably queue! This can happen if Ably
-        // calls our callback from the same task we dispatch.
-        if (String(validatingUTF8: __dispatch_queue_get_label(nil)) == "com.example.ably") {
-            operation()
-        } else {
-            self.ablyQueue.sync(execute: operation)
-        }
-    }
-}
-```
-
-**Objective-C**
-
-```objc
-@implementation YourClass {
-    dispatch_queue_t _ablyQueue;
-    ARTRealtime *ably;
-}
-
-- (void)initializeAbly {
-    _ablyQueue = dispatch_queue_create("com.example.ably", NULL);
-    [self doAblyOperation:^{
-        _ably = [ARTRealtime initWithOptions:[self ablyOptions]];
-    }];
-}
-
-- (void)subscribeToAbly {
-    [self doAblyOperation:^{
-        [[_ably.channels get:@"foo"] subscribe:^(ARTMessage *message) {
-            // Answer back.
-            [self doAblyOperation:^{
-                [[_ably.channels get:@"foo"] publish:@"reply" data:@"Hi back!"];
-            }];
-        }];
-    }];
-}
-
-- (void)doAblyOperation:(dispatch_block_t)block {
-    // Make sure we're not already in the Ably queue! This can happen if Ably
-    // calls our callback from the same task we dispatch.
-    if (dispatch_get_current_queue() == _ablyQueue) {
-        block();
-    } else {
-        dispatch_sync(_ablyQueue, block);
-    }
-}
-```
-
-We're working on improving this situation to be more developer-friendly and less error-prone.
+All callbacks provided by the user will be dispatched to the main queue by default.
+This allows you to react to Ably's output by doing UI operations directly. You
+can specify a different queue with `ARTClientOptions.dispatchQueue`.
 
 ## Using the Realtime API
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ All internal operations are dispatched to a single serial GCD queue. By default,
 queue uses the global queue with `QOS_CLASS_BACKGROUND` as a delegate. You can specify
 another delegate queue with `ARTClientOptions.internalDispatchQueue`.
 
-All callbacks provided by the user will be dispatched to the main queue by default.
+All calls to callbacks provided by the user are dispatched to the main queue by default.
 This allows you to react to Ably's output by doing UI operations directly. You
-can specify a different queue with `ARTClientOptions.dispatchQueue`.
+can specify a different queue with `ARTClientOptions.dispatchQueue`. It shouldn't
+be the same queue as the `ARTClientOptions.internalDispatchQueue`, since that can
+lead to deadlocks.
 
 ## Using the Realtime API
 

--- a/Source/ARTAuth+Private.h
+++ b/Source/ARTAuth+Private.h
@@ -39,6 +39,8 @@ ART_ASSUME_NONNULL_BEGIN
 - (void)_authorize:(art_nullable ARTTokenParams *)tokenParams options:(art_nullable ARTAuthOptions *)authOptions
          callback:(void (^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable))callback;
 
+- (void)_requestToken:(ARTTokenParams *__art_nullable)tokenParams withOptions:(ARTAuthOptions *__art_nullable)authOptions callback:(void (^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable))callback;
+
 @end
 
 @interface ARTAuth (Private)

--- a/Source/ARTAuth+Private.h
+++ b/Source/ARTAuth+Private.h
@@ -7,7 +7,7 @@
 //
 
 #import "ARTAuth.h"
-#import "ARTEventEmitter.h"
+#import "ARTEventEmitter+Private.h"
 
 typedef NS_ENUM(NSUInteger, ARTAuthorizationState) {
     ARTAuthorizationSucceeded, //ItemType: nil
@@ -24,6 +24,8 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTAuth ()
 
+- (NSString *)clientId_nosync;
+
 @property (nonatomic, readonly, strong) ARTClientOptions *options;
 @property (nonatomic, readonly, assign) ARTAuthMethod method;
 
@@ -34,9 +36,14 @@ ART_ASSUME_NONNULL_BEGIN
 @property (art_nullable, weak) id<ARTAuthDelegate> delegate;
 @property (readonly, assign) BOOL authorizing;
 
+- (void)_authorize:(art_nullable ARTTokenParams *)tokenParams options:(art_nullable ARTAuthOptions *)authOptions
+         callback:(void (^)(ARTTokenDetails *__art_nullable, NSError *__art_nullable))callback;
+
 @end
 
 @interface ARTAuth (Private)
+
+- (instancetype)init:(ARTRest *)rest withOptions:(ARTClientOptions *)options;
 
 - (ARTAuthOptions *)mergeOptions:(ARTAuthOptions *)customOptions;
 - (ARTTokenParams *)mergeParams:(ARTTokenParams *)customParams;

--- a/Source/ARTAuth.h
+++ b/Source/ARTAuth.h
@@ -24,10 +24,9 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTAuth : NSObject
 
-@property (art_nullable, readonly, getter=getClientId) NSString *clientId;
+- (instancetype)init NS_UNAVAILABLE;
 
-// FIXME: review (Why rest?)
-- (instancetype)init:(ARTRest *)rest withOptions:(ARTClientOptions *)options;
+@property (art_nullable, readonly, getter=getClientId) NSString *clientId;
 
 /**
  # (RSA8) Auth#requestToken

--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -560,8 +560,9 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
                 if (error) {
                     callback(nil, error);
                 } else {
-                    _timeOffset = [time timeIntervalSinceNow];
-                    currentTokenParams.timestamp = time;
+                    NSDate *serverTime = [self handleServerTime:time];
+                    _timeOffset = [serverTime timeIntervalSinceNow];
+                    currentTokenParams.timestamp = serverTime;
                     callback([currentTokenParams sign:replacedOptions.key], nil);
                 }
             }];
@@ -569,6 +570,13 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
             callback([currentTokenParams sign:replacedOptions.key], nil);
         }
     }
+} ART_TRY_OR_REPORT_CRASH_END
+}
+
+// For mocking when testing.
+- (NSDate *)handleServerTime:(NSDate *)time {
+ART_TRY_OR_REPORT_CRASH_START(_rest) {
+    return time;
 } ART_TRY_OR_REPORT_CRASH_END
 }
 

--- a/Source/ARTChannel+Private.h
+++ b/Source/ARTChannel+Private.h
@@ -18,6 +18,7 @@ ART_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) ARTDataEncoder *dataEncoder;
 
 - (void)internalPostMessages:(id)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;
+- (void)_setOptions:(ARTChannelOptions *__art_nullable)options;
 
 @end
 

--- a/Source/ARTChannel.h
+++ b/Source/ARTChannel.h
@@ -11,6 +11,7 @@
 #import "ARTDataEncoder.h"
 #import "ARTLog.h"
 
+@class ARTRest;
 @class ARTChannelOptions;
 @class ARTMessage;
 @class __GENERIC(ARTPaginatedResult, ItemType);
@@ -22,7 +23,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) NSString *name;
 
-- (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options andLogger:(ARTLog *)logger;
+- (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options rest:(ARTRest *)rest;
 
 - (void)publish:(art_nullable NSString *)name data:(art_nullable id)data;
 - (void)publish:(art_nullable NSString *)name data:(art_nullable id)data callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback;

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -28,7 +28,7 @@
         _rest = rest;
         _queue = rest.queue;
         [self _setOptions:options];
-        NSError *error;
+        NSError *error = nil;
         _dataEncoder = [[ARTDataEncoder alloc] initWithCipherParams:_options.cipher error:&error];
         if (error != nil) {
             [_logger warn:@"creating ARTDataEncoder: %@", error];
@@ -65,7 +65,7 @@
 }
 
 - (void)publish:(art_nullable NSString *)name data:(art_nullable id)data extras:(id<ARTJsonCompatible>)extras callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback {
-    NSError *error;
+    NSError *error = nil;
     ARTMessage *message = [[ARTMessage alloc] initWithName:name data:data];
     message.extras = extras;
     ARTMessage *messagesWithDataEncoded = [self encodeMessageIfNeeded:message error:&error];
@@ -89,7 +89,7 @@
 }
 
 - (void)publish:(NSString *)name data:(id)data clientId:(NSString *)clientId extras:(id<ARTJsonCompatible>)extras callback:(void (^)(ARTErrorInfo * _Nullable))callback {
-    NSError *error;
+    NSError *error = nil;
     ARTMessage *message = [[ARTMessage alloc] initWithName:name data:data clientId:clientId];
     message.extras = extras;
     ARTMessage *messagesWithDataEncoded = [self encodeMessageIfNeeded:message error:&error];
@@ -105,7 +105,7 @@
 }
 
 - (void)publish:(__GENERIC(NSArray, ARTMessage *) *)messages callback:(art_nullable void (^)(ARTErrorInfo *__art_nullable error))callback {
-    NSError *error;
+    NSError *error = nil;
     NSMutableArray<ARTMessage *> *messagesWithDataEncoded = [NSMutableArray new];
     for (ARTMessage *message in messages) {
         [messagesWithDataEncoded addObject:[self encodeMessageIfNeeded:message error:&error]];

--- a/Source/ARTChannel.m
+++ b/Source/ARTChannel.m
@@ -18,6 +18,7 @@
 
 @implementation ARTChannel {
     __weak ARTRest *_rest;
+    dispatch_queue_t _queue;
 }
 
 - (instancetype)initWithName:(NSString *)name andOptions:(ARTChannelOptions *)options rest:(ARTRest *)rest {
@@ -25,6 +26,7 @@
         _name = name;
         _logger = rest.logger;
         _rest = rest;
+        _queue = rest.queue;
         [self _setOptions:options];
         NSError *error;
         _dataEncoder = [[ARTDataEncoder alloc] initWithCipherParams:_options.cipher error:&error];
@@ -37,7 +39,7 @@
 }
 
 - (void)setOptions:(ARTChannelOptions *)options {
-    dispatch_sync(_rest.queue, ^{
+    dispatch_sync(_queue, ^{
         [self _setOptions:options];
     });
 }

--- a/Source/ARTChannels+Private.h
+++ b/Source/ARTChannels+Private.h
@@ -32,9 +32,11 @@ extern NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
 @property (nonatomic, readonly) __GENERIC(NSMutableDictionary, NSString *, ChannelType) *channels;
 @property (readonly, getter=getNosyncIterable) id<NSFastEnumeration> nosyncIterable;
 
++ (NSString *)addPrefix:(NSString *)name;
+
 - (BOOL)_exists:(NSString *)name;
 - (ChannelType)_get:(NSString *)name;
-- (ChannelType)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options;
+- (ChannelType)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options addPrefix:(BOOL)addPrefix;
 - (void)_release:(NSString *)name;
 
 - (instancetype)initWithDelegate:(id<ARTChannelsDelegate>)delegate dispatchQueue:(dispatch_queue_t)queue;

--- a/Source/ARTChannels+Private.h
+++ b/Source/ARTChannels+Private.h
@@ -21,11 +21,23 @@ extern NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
 
 @end
 
+@interface ARTChannelsNosyncIterable : NSObject<NSFastEnumeration>
+
+- (instancetype)init:(NSDictionary<NSString *, id> *)channels;
+
+@end
+
 @interface __GENERIC(ARTChannels, ChannelType) ()
 
 @property (nonatomic, readonly) __GENERIC(NSMutableDictionary, NSString *, ChannelType) *channels;
+@property (readonly, getter=getNosyncIterable) id<NSFastEnumeration> nosyncIterable;
 
-- (instancetype)initWithDelegate:(id<ARTChannelsDelegate>)delegate;
+- (BOOL)_exists:(NSString *)name;
+- (ChannelType)_get:(NSString *)name;
+- (ChannelType)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options;
+- (void)_release:(NSString *)name;
+
+- (instancetype)initWithDelegate:(id<ARTChannelsDelegate>)delegate dispatchQueue:(dispatch_queue_t)queue;
 
 @end
 

--- a/Source/ARTChannels.m
+++ b/Source/ARTChannels.m
@@ -17,14 +17,16 @@ NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
 
 @interface ARTChannels() {
     __weak id<ARTChannelsDelegate> _delegate;
+    dispatch_queue_t _queue;
 }
 
 @end
 
 @implementation ARTChannels
 
-- (instancetype)initWithDelegate:(id)delegate {
+- (instancetype)initWithDelegate:(id)delegate dispatchQueue:(dispatch_queue_t)queue {
     if (self = [super init]) {
+        _queue = queue;
         _channels = [[NSMutableDictionary alloc] init];
         _delegate = delegate;
     }
@@ -32,32 +34,58 @@ NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
 }
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id [])buffer count:(NSUInteger)len {
-    NSUInteger count = [self->_channels countByEnumeratingWithState:state objects:buffer count:len];
-    for (NSUInteger i = 0; i < count; i++) {
-        buffer[i] = self->_channels[buffer[i]];
-    }
-    return count;
+    __block NSUInteger ret;
+dispatch_sync(_queue, ^{
+    ret = [[self getNosyncIterable] countByEnumeratingWithState:state objects:buffer count:len];
+});
+    return ret;
+}
+
+- (id<NSFastEnumeration>)getNosyncIterable {
+    return [[ARTChannelsNosyncIterable alloc] init:_channels];
 }
 
 - (BOOL)exists:(NSString *)name {
+    __block BOOL ret;
+dispatch_sync(_queue, ^{
+    ret = [self _exists:name];
+});
+    return ret;
+}
+
+- (BOOL)_exists:(NSString *)name {
     return self->_channels[[self addPrefix:name]] != nil;
 }
 
 - (id)get:(NSString *)name {
-    return [self _getChannel:[self addPrefix:name] options:nil];
+    return [self getChannel:[self addPrefix:name] options:nil];
 }
 
 - (id)get:(NSString *)name options:(ARTChannelOptions *)options {
-    return [self _getChannel:[self addPrefix:name] options:options];
+    return [self getChannel:[self addPrefix:name] options:options];
 }
 
 - (void)release:(NSString *)name {
+dispatch_sync(_queue, ^{
+    [self _release:name];
+});
+}
+
+- (void)_release:(NSString *)name {
     [self->_channels removeObjectForKey:[self addPrefix:name]];
+}
+
+- (ARTRestChannel *)getChannel:(NSString *)name options:(ARTChannelOptions *)options {
+    __block ARTRestChannel *channel;
+dispatch_sync(_queue, ^{
+    channel = [self _getChannel:name options:options];
+});
+    return channel;
 }
 
 - (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions *)options {
     name = [self addPrefix:name];
-    ARTRestChannel *channel = self->_channels[name];
+    ARTRestChannel *channel = [self _get:name];
     if (!channel) {
         channel = [_delegate makeChannel:name options:options];
         [self->_channels setObject:channel forKey:name];
@@ -65,6 +93,10 @@ NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
         channel.options = options;
     }
     return channel;
+}
+
+- (id)_get:(NSString *)name {
+    return self->_channels[name];
 }
 
 - (NSString *)addPrefix:(NSString *)name {
@@ -75,6 +107,27 @@ NSString* (^__art_nullable ARTChannels_getChannelNamePrefix)();
         }
     }
     return name;
+}
+
+@end
+
+@implementation ARTChannelsNosyncIterable {
+    NSDictionary *_channels;
+}
+
+- (instancetype)init:(NSDictionary<NSString *, id> *)channels {
+    if (self = [super init]) {
+        _channels = channels;
+    }
+    return self;
+}
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id [])buffer count:(NSUInteger)len {
+    NSUInteger count = [self->_channels countByEnumeratingWithState:state objects:buffer count:len];
+    for (NSUInteger i = 0; i < count; i++) {
+        buffer[i] = self->_channels[buffer[i]];
+    }
+    return count;
 }
 
 @end

--- a/Source/ARTClientOptions.h
+++ b/Source/ARTClientOptions.h
@@ -87,9 +87,25 @@ ART_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) BOOL fallbackHostsUseDefault;
 
 /**
- Report uncaught exceptions to Ably, together with the last lines of the logger. This helps Ably to fix bugs. Set to nil to disable.
+ Report uncaught exceptions to Ably, together with the last lines of the logger. This helps Ably fix bugs. Set to nil to disable.
  */
 @property (readwrite, strong, nonatomic, nullable) NSString *logExceptionReportingUrl;
+
+/**
+ The queue to which all calls to user-provided callbacks will be dispatched
+ asynchronously. It will be used as target queue for an internal, serial queue.
+
+ It defaults to the main queue.
+ */
+@property (readwrite, assign, nonatomic) dispatch_queue_t dispatchQueue;
+
+/**
+ The queue to which all internal concurrent operations will be dispatched.
+ It will be used as target queue for an internal, serial queue.
+
+ It defaults to the global queue with QOS_CLASS_BACKGROUND.
+ */
+@property (readwrite, assign, nonatomic) dispatch_queue_t internalDispatchQueue;
 
 - (BOOL)isBasicAuth;
 - (NSURL *)restUrl;

--- a/Source/ARTClientOptions.h
+++ b/Source/ARTClientOptions.h
@@ -101,9 +101,9 @@ ART_ASSUME_NONNULL_BEGIN
 
 /**
  The queue to which all internal concurrent operations will be dispatched.
- It will be used as target queue for an internal, serial queue.
+ It must be a serial queue. It shouldn't be the same queue as dispatchQueue.
 
- It defaults to the global queue with QOS_CLASS_BACKGROUND.
+ It defaults to a newly created serial queue.
  */
 @property (readwrite, assign, nonatomic) dispatch_queue_t internalDispatchQueue;
 

--- a/Source/ARTClientOptions.h
+++ b/Source/ARTClientOptions.h
@@ -97,7 +97,7 @@ ART_ASSUME_NONNULL_BEGIN
 
  It defaults to the main queue.
  */
-@property (readwrite, assign, nonatomic) dispatch_queue_t dispatchQueue;
+@property (readwrite, strong, nonatomic) dispatch_queue_t dispatchQueue;
 
 /**
  The queue to which all internal concurrent operations will be dispatched.
@@ -105,7 +105,7 @@ ART_ASSUME_NONNULL_BEGIN
 
  It defaults to a newly created serial queue.
  */
-@property (readwrite, assign, nonatomic) dispatch_queue_t internalDispatchQueue;
+@property (readwrite, strong, nonatomic) dispatch_queue_t internalDispatchQueue;
 
 - (BOOL)isBasicAuth;
 - (NSURL *)restUrl;

--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -45,6 +45,8 @@ NSString *const ARTDefaultProduction = @"production";
     _fallbackHosts = nil;
     _fallbackHostsUseDefault = false;
     _logExceptionReportingUrl = @"https://765e1fcaba404d7598d2fd5a2a43c4f0:8d469b2b0fb34c01a12ae217931c4aed@errors.ably.io/3";
+    _dispatchQueue = dispatch_get_main_queue();
+    _internalDispatchQueue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
     return self;
 }
 
@@ -118,6 +120,10 @@ NSString *const ARTDefaultProduction = @"production";
     options.httpRequestTimeout = self.httpRequestTimeout;
     options->_fallbackHosts = self.fallbackHosts; //ignore setter
     options->_fallbackHostsUseDefault = self.fallbackHostsUseDefault; //ignore setter
+    options.httpRequestTimeout = self.httpRequestTimeout;
+    options.logExceptionReportingUrl = self.logExceptionReportingUrl;
+    options.dispatchQueue = self.dispatchQueue;
+    options.internalDispatchQueue = self.internalDispatchQueue;
     
     return options;
 }

--- a/Source/ARTClientOptions.m
+++ b/Source/ARTClientOptions.m
@@ -46,7 +46,7 @@ NSString *const ARTDefaultProduction = @"production";
     _fallbackHostsUseDefault = false;
     _logExceptionReportingUrl = @"https://765e1fcaba404d7598d2fd5a2a43c4f0:8d469b2b0fb34c01a12ae217931c4aed@errors.ably.io/3";
     _dispatchQueue = dispatch_get_main_queue();
-    _internalDispatchQueue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
+    _internalDispatchQueue = dispatch_queue_create("io.ably.main", DISPATCH_QUEUE_SERIAL);
     return self;
 }
 

--- a/Source/ARTConnection+Private.h
+++ b/Source/ARTConnection+Private.h
@@ -17,6 +17,13 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTConnection ()
 
+- (NSString *)id_nosync;
+- (NSString *)key_nosync;
+- (int64_t)serial_nosync;
+- (ARTRealtimeConnectionState)state_nosync;
+- (ARTErrorInfo *)errorReason_nosync;
+- (NSString *)recoveryKey_nosync;
+
 @property (readonly, strong, nonatomic) ARTEventEmitter<ARTEvent *, ARTConnectionStateChange *> *eventEmitter;
 @property(weak, nonatomic) ARTRealtime* realtime;
 

--- a/Source/ARTConnection.h
+++ b/Source/ARTConnection.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "CompatibilityMacros.h"
 #import "ARTTypes.h"
-#import "ARTEventEmitter.h"
+#import "ARTEventEmitter+Private.h"
 
 @class ARTRealtime;
 @class ARTEventEmitter;

--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -159,16 +159,16 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 }
 
 - (NSString *)recoveryKey_nosync {
-    switch(self.state) {
+    switch(self.state_nosync) {
         case ARTRealtimeConnecting:
         case ARTRealtimeConnected:
         case ARTRealtimeDisconnected:
         case ARTRealtimeSuspended: {
-            NSString *recStr = self.key;
+            NSString *recStr = self.key_nosync;
             if (recStr == nil) {
                 return nil;
             }
-            NSString *str = [recStr stringByAppendingString:[NSString stringWithFormat:@":%ld", (long)self.serial]];
+            NSString *str = [recStr stringByAppendingString:[NSString stringWithFormat:@":%ld", (long)self.serial_nosync]];
             return str;
         } default:
             return nil;
@@ -176,54 +176,38 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 }
 
 - (ARTEventListener *)on:(ARTRealtimeConnectionEvent)event callback:(void (^)(ARTConnectionStateChange *))cb {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     return [_eventEmitter on:[ARTEvent newWithConnectionEvent:event] callback:cb];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (ARTEventListener *)on:(void (^)(ARTConnectionStateChange *))cb {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     return [_eventEmitter on:cb];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (ARTEventListener *)once:(ARTRealtimeConnectionEvent)event callback:(void (^)(ARTConnectionStateChange *))cb {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     return [_eventEmitter once:[ARTEvent newWithConnectionEvent:event] callback:cb];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (ARTEventListener *)once:(void (^)(ARTConnectionStateChange *))cb {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     return [_eventEmitter once:cb];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (void)off {
     if (_realtime && _realtime.rest) {
-        ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
-            [_eventEmitter off];
-        } ART_TRY_OR_MOVE_TO_FAILED_END
+        [_eventEmitter off];
     } else {
         [_eventEmitter off];
     }
 }
 - (void)off:(ARTRealtimeConnectionEvent)event listener:(ARTEventListener *)listener {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     [_eventEmitter off:[ARTEvent newWithConnectionEvent:event] listener:listener];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (void)off:(ARTEventListener *)listener {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     [_eventEmitter off:listener];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (void)emit:(ARTRealtimeConnectionEvent)event with:(ARTConnectionStateChange *)data {
-ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     [_eventEmitter emit:[ARTEvent newWithConnectionEvent:event] with:data];
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 @end

--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -18,14 +18,19 @@
 
 @implementation ARTConnection {
     _Nonnull dispatch_queue_t _queue;
+    NSString *_id;
+    NSString *_key;
+    int64_t _serial;
+    ARTRealtimeConnectionState _state;
+    ARTErrorInfo *_errorReason;
 }
 
 - (instancetype)initWithRealtime:(ARTRealtime *)realtime {
 ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
     if (self = [super init]) {
-        _queue = dispatch_queue_create("io.ably.realtime.connection", DISPATCH_QUEUE_SERIAL);
-        _eventEmitter = [[ARTEventEmitter alloc] initWithQueue:_queue];
+        _eventEmitter = [[ARTPublicEventEmitter alloc] initWithRest:realtime.rest];
         _realtime = realtime;
+        _queue = _realtime.rest.queue;
         _serial = -1;
     }
     return self;
@@ -48,6 +53,66 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     [_realtime ping:cb];
 } ART_TRY_OR_MOVE_TO_FAILED_END
+}
+
+- (NSString *)id {
+    __block NSString *ret;   
+dispatch_sync(_queue, ^{
+    ret = [self id_nosync];
+});
+    return ret;
+} 
+
+- (NSString *)key {
+    __block NSString *ret;   
+dispatch_sync(_queue, ^{
+    ret = [self key_nosync];
+});
+    return ret;
+} 
+
+- (int64_t)serial {
+    __block int64_t ret;   
+dispatch_sync(_queue, ^{
+    ret = [self serial_nosync];
+});
+    return ret;
+} 
+
+- (ARTRealtimeConnectionState)state {
+    __block ARTRealtimeConnectionState ret;   
+dispatch_sync(_queue, ^{
+    ret = [self state_nosync];
+});
+    return ret;
+}
+
+- (ARTErrorInfo *)errorReason {
+    __block ARTErrorInfo *ret;   
+dispatch_sync(_queue, ^{
+    ret = [self errorReason_nosync];
+});
+    return ret;
+}
+
+- (NSString *)id_nosync {
+    return _id;
+} 
+
+- (NSString *)key_nosync {
+    return _key;
+} 
+
+- (int64_t)serial_nosync {
+    return _serial;
+} 
+
+- (ARTRealtimeConnectionState)state_nosync {
+    return _state;
+}
+
+- (ARTErrorInfo *)errorReason_nosync {
+    return _errorReason;
 }
 
 - (void)setId:(NSString *)newId {
@@ -84,7 +149,16 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 }
 
 - (NSString *)getRecoveryKey {
+    __block NSString *ret;
+dispatch_sync(_queue, ^{
 ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
+    ret = [self recoveryKey_nosync];
+} ART_TRY_OR_MOVE_TO_FAILED_END
+});
+    return ret;
+}
+
+- (NSString *)recoveryKey_nosync {
     switch(self.state) {
         case ARTRealtimeConnecting:
         case ARTRealtimeConnected:
@@ -99,7 +173,6 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         } default:
             return nil;
     }
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (ARTEventListener *)on:(ARTRealtimeConnectionEvent)event callback:(void (^)(ARTConnectionStateChange *))cb {

--- a/Source/ARTCrypto.m
+++ b/Source/ARTCrypto.m
@@ -66,7 +66,7 @@
         _iv = iv;
 
         CCAlgorithm ccAlgorithm;
-        NSError *error;
+        NSError *error = nil;
         if (![self ccAlgorithm:&ccAlgorithm error:&error]) {
             [ARTException raise:NSInvalidArgumentException format:@"%@", error.userInfo[NSLocalizedFailureReasonErrorKey]];
         }

--- a/Source/ARTDataEncoder.m
+++ b/Source/ARTDataEncoder.m
@@ -147,7 +147,7 @@
             }
             if ([data isKindOfClass:[NSString class]]) {
                 NSData *jsonData = [data dataUsingEncoding:NSUTF8StringEncoding];
-                NSError *error;
+                NSError *error = nil;
                 data = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
                 if (error != nil) {
                     errorInfo = [ARTErrorInfo createFromNSError:error];

--- a/Source/ARTDataQuery+Private.h
+++ b/Source/ARTDataQuery+Private.h
@@ -13,7 +13,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTDataQuery(Private)
 
-- (NSMutableArray /* <NSURLQueryItem *> */ *)asQueryItems;
+- (NSMutableArray /* <NSURLQueryItem *> */ *)asQueryItems:(NSError *_Nullable*)error;
 
 @end
 

--- a/Source/ARTEventEmitter+Private.h
+++ b/Source/ARTEventEmitter+Private.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ARTPublicEventEmitter<EventType:id<ARTEventIdentification>, ItemType> : ARTEventEmitter<EventType, ItemType>
 
 - (instancetype)initWithRest:(ARTRest *)rest;
+- (void)off_nosync;
 
 @end
 

--- a/Source/ARTEventEmitter+Private.h
+++ b/Source/ARTEventEmitter+Private.h
@@ -7,16 +7,55 @@
 //
 
 #include "ARTEventEmitter.h"
+#include "ARTRest.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface ARTEvent : NSObject<ARTEventIdentification>
+
+- (instancetype)initWithString:(NSString *)value;
++ (instancetype)newWithString:(NSString *)value;
+
+@end
+
+#pragma mark - ARTEventListener
+
+@interface ARTEventListener ()
+
+@property (nonatomic, readonly) NSString *eventId;
+@property (weak, nonatomic, readonly) id<NSObject> token;
+@property (nonatomic, readonly) NSUInteger count;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithId:(NSString *)eventId token:(id<NSObject>)token handler:(ARTEventEmitter *)eventHandler center:(NSNotificationCenter *)center;
+
+- (ARTEventListener *)setTimer:(NSTimeInterval)timeoutDeadline onTimeout:(void (^)())timeoutBlock;
+- (void)startTimer;
+- (void)stopTimer;
+
+@end
+
 @interface ARTEventEmitter<EventType, ItemType> ()
+
+- (void)emit:(nullable EventType)event with:(nullable ItemType)data;
 
 @property (nonatomic, readonly) NSNotificationCenter *notificationCenter;
 @property (nonatomic, readonly) dispatch_queue_t queue;
 
 @property (readonly, atomic) NSMutableDictionary<NSString *, NSMutableArray<ARTEventListener *> *> *listeners;
 @property (readonly, atomic) NSMutableArray<ARTEventListener *> *anyListeners;
+
+@end
+
+@interface ARTPublicEventEmitter<EventType:id<ARTEventIdentification>, ItemType> : ARTEventEmitter<EventType, ItemType>
+
+- (instancetype)initWithRest:(ARTRest *)rest;
+
+@end
+
+@interface ARTInternalEventEmitter<EventType:id<ARTEventIdentification>, ItemType> : ARTEventEmitter<EventType, ItemType>
+
+- (instancetype)initWithQueue:(dispatch_queue_t)queue;
 
 @end
 

--- a/Source/ARTEventEmitter.h
+++ b/Source/ARTEventEmitter.h
@@ -19,36 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)identification;
 @end
 
-@interface ARTEvent : NSObject<ARTEventIdentification>
-
-- (instancetype)initWithString:(NSString *)value;
-+ (instancetype)newWithString:(NSString *)value;
-
-@end
-
-#pragma mark - ARTEventListener
-
 @interface ARTEventListener : NSObject
-
-@property (nonatomic, readonly) NSString *eventId;
-@property (weak, nonatomic, readonly) id<NSObject> token;
-@property (nonatomic, readonly) NSUInteger count;
-
-- (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithId:(NSString *)eventId token:(id<NSObject>)token handler:(ARTEventEmitter *)eventHandler center:(NSNotificationCenter *)center;
-
-- (ARTEventListener *)setTimer:(NSTimeInterval)timeoutDeadline onTimeout:(void (^)())timeoutBlock;
-- (void)startTimer;
-- (void)stopTimer;
-
 @end
 
 #pragma mark - ARTEventEmitter
 
 @interface ARTEventEmitter<EventType:id<ARTEventIdentification>, ItemType> : NSObject
 
-- (instancetype)init;
-- (instancetype)initWithQueue:(dispatch_queue_t)queue;
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
 
 - (ARTEventListener *)on:(EventType)event callback:(void (^)(ItemType __art_nullable))cb;
 - (ARTEventListener *)on:(void (^)(ItemType __art_nullable))cb;
@@ -59,8 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)off:(EventType)event listener:(ARTEventListener *)listener;
 - (void)off:(ARTEventListener *)listener;
 - (void)off;
-
-- (void)emit:(nullable EventType)event with:(nullable ItemType)data;
 
 @end
 

--- a/Source/ARTEventEmitter.m
+++ b/Source/ARTEventEmitter.m
@@ -19,9 +19,7 @@
     NSUInteger l = [self count];
     for (NSInteger i = 0; i < l; i++) {
         if (cond([self objectAtIndex:i])) {
-            @synchronized(self) {
-                [self removeObjectAtIndex:i];
-            }
+            [self removeObjectAtIndex:i];
             i--;
             l--;
         }
@@ -137,10 +135,6 @@
 
 @implementation ARTEventEmitter
 
-- (instancetype)init {
-    return [self initWithQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0)];
-}
-
 - (instancetype)initWithQueue:(dispatch_queue_t)queue {
     self = [super init];
     if (self) {
@@ -221,22 +215,16 @@
     NSString *eventId = [NSString stringWithFormat:@"%p-%@", self, [event identification]];
     if (![eventId isEqualToString:listener.eventId]) return;
     [listener removeObserver];
-    @synchronized (_listeners) {
-        [self.listeners[listener.eventId] removeObject:listener];
-        if ([self.listeners[listener.eventId] firstObject] == nil) {
-            [self.listeners removeObjectForKey:listener.eventId];
-        }
+    [self.listeners[listener.eventId] removeObject:listener];
+    if ([self.listeners[listener.eventId] firstObject] == nil) {
+        [self.listeners removeObjectForKey:listener.eventId];
     }
 }
 
 - (void)off:(ARTEventListener *)listener {
     [listener removeObserver];
-    @synchronized (_listeners) {
-        [self.listeners[listener.eventId] removeObject:listener];
-    }
-    @synchronized (_anyListeners) {
-        [self.anyListeners removeObject:listener];
-    }
+    [self.listeners[listener.eventId] removeObject:listener];
+    [self.anyListeners removeObject:listener];
 }
 
 - (void)off {
@@ -244,22 +232,18 @@
 }
 
 - (void)resetListeners {
-    @synchronized (_listeners) {
-        for (NSArray<ARTEventListener *> *items in [_listeners allValues]) {
-            for (ARTEventListener *item in items) {
-                [item removeObserver];
-            }
-        }
-        [_listeners removeAllObjects];
-    }
-    _listeners = [[NSMutableDictionary alloc] init];
-
-    @synchronized (_anyListeners) {
-        for (ARTEventListener *item in _anyListeners) {
+    for (NSArray<ARTEventListener *> *items in [_listeners allValues]) {
+        for (ARTEventListener *item in items) {
             [item removeObserver];
         }
-        [_anyListeners removeAllObjects];
     }
+    [_listeners removeAllObjects];
+    _listeners = [[NSMutableDictionary alloc] init];
+
+    for (ARTEventListener *item in _anyListeners) {
+        [item removeObserver];
+    }
+    [_anyListeners removeAllObjects];
     _anyListeners = [[NSMutableArray alloc] init];
 }
 
@@ -277,42 +261,131 @@
 }
 
 - (void)addObject:(id)obj toArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict {
-    @synchronized (dict) {
-        NSMutableArray *array = [dict objectForKey:key];
-        if (array == nil) {
-            array = [[NSMutableArray alloc] init];
-            [dict setObject:array forKey:key];
-        }
-        if ([array indexOfObject:obj] == NSNotFound) {
-            [array addObject:obj];
-        }
+    NSMutableArray *array = [dict objectForKey:key];
+    if (array == nil) {
+        array = [[NSMutableArray alloc] init];
+        [dict setObject:array forKey:key];
+    }
+    if ([array indexOfObject:obj] == NSNotFound) {
+        [array addObject:obj];
     }
 }
 
 - (void)removeObject:(id)obj fromArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict {
-    @synchronized (dict) {
-        NSMutableArray *array = [dict objectForKey:key];
-        if (array == nil) {
-            return;
-        }
-        [array removeObject:obj];
-        if ([array count] == 0) {
-            [dict removeObjectForKey:key];
-        }
+    NSMutableArray *array = [dict objectForKey:key];
+    if (array == nil) {
+        return;
+    }
+    [array removeObject:obj];
+    if ([array count] == 0) {
+        [dict removeObjectForKey:key];
     }
 }
 
 - (void)removeObject:(id)obj fromArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict where:(BOOL(^)(id))cond {
-    @synchronized (dict) {
-        NSMutableArray *array = [dict objectForKey:key];
-        if (array == nil) {
-            return;
-        }
-        [array artRemoveWhere:cond];
-        if ([array count] == 0) {
-            [dict removeObjectForKey:key];
-        }
+    NSMutableArray *array = [dict objectForKey:key];
+    if (array == nil) {
+        return;
     }
+    [array artRemoveWhere:cond];
+    if ([array count] == 0) {
+        [dict removeObjectForKey:key];
+    }
+}
+
+@end
+
+@implementation ARTPublicEventEmitter {
+    __weak ARTRest *_rest;
+    dispatch_queue_t _queue;
+}
+
+- (instancetype)initWithRest:(ARTRest *)rest {
+    if (self = [super initWithQueue:rest.queue]) {
+        _rest = rest;
+        _queue = rest.queue;
+    }
+    return self;
+}
+
+- (ARTEventListener *)on:(id)event callback:(void (^)(id __art_nullable))cb {
+    if (cb) {
+        void (^userCallback)(id __art_nullable) = cb;
+        cb = ^(id __art_nullable v) {
+            ART_EXITING_ABLY_CODE(_rest);
+            dispatch_async(_rest.userQueue, ^{
+                userCallback(v);
+            });
+        };
+    }
+    
+    __block ARTEventListener *listener;
+dispatch_sync(_queue, ^{
+    listener = [super on:event callback:cb];
+});
+    return listener;
+}
+
+- (ARTEventListener *)on:(void (^)(id __art_nullable))cb {
+    if (cb) {
+        void (^userCallback)(id __art_nullable) = cb;
+        cb = ^(id __art_nullable v) {
+            ART_EXITING_ABLY_CODE(_rest);
+            dispatch_async(_rest.userQueue, ^{
+                userCallback(v);
+            });
+        };
+    }
+    
+    __block ARTEventListener *listener;
+dispatch_sync(_queue, ^{
+    listener = [super on:cb];
+});
+    return listener;
+}
+
+- (ARTEventListener *)once:(id)event callback:(void (^)(id __art_nullable))cb {
+    if (cb) {
+        void (^userCallback)(id __art_nullable) = cb;
+        cb = ^(id __art_nullable v) {
+            ART_EXITING_ABLY_CODE(_rest);
+            dispatch_async(_rest.userQueue, ^{
+                userCallback(v);
+            });
+        };
+    }
+
+    __block ARTEventListener *listener;
+dispatch_sync(_queue, ^{
+    listener = [super once:event callback:cb];
+});
+    return listener;
+}
+
+- (ARTEventListener *)once:(void (^)(id __art_nullable))cb {
+    if (cb) {
+        void (^userCallback)(id __art_nullable) = cb;
+        cb = ^(id __art_nullable v) {
+            ART_EXITING_ABLY_CODE(_rest);
+            dispatch_async(_rest.userQueue, ^{
+                userCallback(v);
+            });
+        };
+    }
+
+    __block ARTEventListener *listener;
+dispatch_sync(_queue, ^{
+    listener = [super once:cb];
+});
+    return listener;
+}
+
+@end
+
+@implementation ARTInternalEventEmitter
+
+- (instancetype)initWithQueue:(dispatch_queue_t)queue {
+   return [super initWithQueue:queue];
 }
 
 @end

--- a/Source/ARTEventEmitter.m
+++ b/Source/ARTEventEmitter.m
@@ -248,16 +248,10 @@
 }
 
 - (void)emit:(id<ARTEventIdentification>)event with:(id)data {
-    NSString *eventId;
     if (event) {
-        eventId = [NSString stringWithFormat:@"%p-%@", self, [event identification]];
-        [self.notificationCenter postNotificationName:eventId object:data];
-        [self.notificationCenter postNotificationName:[NSString stringWithFormat:@"%p", self] object:data];
+        [self.notificationCenter postNotificationName:[NSString stringWithFormat:@"%p-%@", self, [event identification]] object:data];
     }
-    else {
-        eventId = [NSString stringWithFormat:@"%p", self];
-        [self.notificationCenter postNotificationName:eventId object:data];
-    }
+    [self.notificationCenter postNotificationName:[NSString stringWithFormat:@"%p", self] object:data];
 }
 
 - (void)addObject:(id)obj toArrayWithKey:(id)key inDictionary:(NSMutableDictionary *)dict {
@@ -380,6 +374,28 @@ dispatch_sync(_queue, ^{
     listener = [super once:cb];
 });
     return listener;
+}
+
+- (void)off:(id<ARTEventIdentification>)event listener:(ARTEventListener *)listener {
+dispatch_sync(_queue, ^{
+    [super off:event listener:listener];
+});
+}
+
+- (void)off:(ARTEventListener *)listener {
+dispatch_sync(_queue, ^{
+    [super off:listener];
+});
+}
+
+- (void)off {
+dispatch_sync(_queue, ^{
+    [super off];
+});
+}
+
+- (void)off_nosync {
+    [super off];
 }
 
 @end

--- a/Source/ARTEventEmitter.m
+++ b/Source/ARTEventEmitter.m
@@ -298,12 +298,14 @@
 @implementation ARTPublicEventEmitter {
     __weak ARTRest *_rest;
     dispatch_queue_t _queue;
+    dispatch_queue_t _userQueue;
 }
 
 - (instancetype)initWithRest:(ARTRest *)rest {
     if (self = [super initWithQueue:rest.queue]) {
         _rest = rest;
         _queue = rest.queue;
+        _userQueue = rest.userQueue;
     }
     return self;
 }
@@ -313,7 +315,7 @@
         void (^userCallback)(id __art_nullable) = cb;
         cb = ^(id __art_nullable v) {
             ART_EXITING_ABLY_CODE(_rest);
-            dispatch_async(_rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(v);
             });
         };
@@ -331,7 +333,7 @@ dispatch_sync(_queue, ^{
         void (^userCallback)(id __art_nullable) = cb;
         cb = ^(id __art_nullable v) {
             ART_EXITING_ABLY_CODE(_rest);
-            dispatch_async(_rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(v);
             });
         };
@@ -349,7 +351,7 @@ dispatch_sync(_queue, ^{
         void (^userCallback)(id __art_nullable) = cb;
         cb = ^(id __art_nullable v) {
             ART_EXITING_ABLY_CODE(_rest);
-            dispatch_async(_rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(v);
             });
         };
@@ -367,7 +369,7 @@ dispatch_sync(_queue, ^{
         void (^userCallback)(id __art_nullable) = cb;
         cb = ^(id __art_nullable v) {
             ART_EXITING_ABLY_CODE(_rest);
-            dispatch_async(_rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(v);
             });
         };

--- a/Source/ARTGCD.h
+++ b/Source/ARTGCD.h
@@ -11,13 +11,7 @@
 
 #import <Foundation/Foundation.h>
 
-void artDispatchSpecifyMainQueue();
-void artDispatchMainQueue(dispatch_block_t block);
-void artDispatchGlobalQueue(dispatch_block_t block);
-dispatch_block_t artDispatchScheduledOnMainQueue(NSTimeInterval seconds, dispatch_block_t block);
-dispatch_block_t artDispatchScheduledOnGlobalQueue(NSTimeInterval seconds, dispatch_block_t block);
 dispatch_block_t artDispatchScheduled(NSTimeInterval seconds, dispatch_queue_t queue, dispatch_block_t block);
 void artDispatchCancel(dispatch_block_t block);
-void artDispatchSync(dispatch_queue_t queue, dispatch_block_t block);
 
 #endif /* ARTGCD_h */

--- a/Source/ARTGCD.m
+++ b/Source/ARTGCD.m
@@ -8,36 +8,6 @@
 
 #import "ARTGCD.h"
 
-// Use `dispatch_queue_set_specific` and `dispatch_get_specific` to check if our code is running on the main queue over using NSThread.isMainThread()
-static NSString *const ARTGCDMainQueueKey = @"io.ably.cocoa.mainQueue";
-static int ARTGCDMainQueueValue = 99;
-
-void artDispatchSpecifyMainQueue() {
-    dispatch_queue_set_specific(dispatch_get_main_queue(), (__bridge const void *)ARTGCDMainQueueKey, &ARTGCDMainQueueValue, nil);
-}
-
-void artDispatchMainQueue(dispatch_block_t block) {
-    int *result = (int*)dispatch_get_specific((__bridge const void *)(ARTGCDMainQueueKey));
-    if (result && *result == ARTGCDMainQueueValue) {
-        block();
-    }
-    else {
-        dispatch_async(dispatch_get_main_queue(), block);
-    }
-}
-
-void artDispatchGlobalQueue(dispatch_block_t block) {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
-}
-
-dispatch_block_t artDispatchScheduledOnMainQueue(NSTimeInterval seconds, dispatch_block_t block) {
-    return artDispatchScheduled(seconds, dispatch_get_main_queue(), block);
-}
-
-dispatch_block_t artDispatchScheduledOnGlobalQueue(NSTimeInterval seconds, dispatch_block_t block) {
-    return artDispatchScheduled(seconds, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
-}
-
 dispatch_block_t artDispatchScheduled(NSTimeInterval seconds, dispatch_queue_t queue, dispatch_block_t block) {
     dispatch_block_t work = dispatch_block_create(0, block);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NSEC_PER_SEC * seconds)), queue, work);
@@ -46,55 +16,4 @@ dispatch_block_t artDispatchScheduled(NSTimeInterval seconds, dispatch_queue_t q
 
 void artDispatchCancel(dispatch_block_t block) {
     if (block) dispatch_block_cancel(block);
-}
-
-// artDispatchSync is like dispatch_sync, but if the a thread attempts to
-// dispatch_sync to a queue to which it already is dispatch_syncinc, it calls
-// the block right away.
-void artDispatchSync(dispatch_queue_t queue, dispatch_block_t block) {
-    NSString *queueName = [NSString stringWithUTF8String:dispatch_queue_get_label(queue)];
-    
-    static NSMutableDictionary<NSString *, NSMutableSet<NSThread *> *> *threadsUsingQueues;
-    // threadsUsingQueuesOps is the serial queue we use to operate on threadsUsingQueues,
-    // to avoid concurrent operations on it.
-    static dispatch_queue_t threadsUsingQueuesOps;
-
-    // Initialize locks set and its queue.
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        threadsUsingQueues = [[NSMutableDictionary alloc] init];
-        threadsUsingQueuesOps = dispatch_queue_create("io.ably.artDispatchSync.threadsUsingQueuesOps", DISPATCH_QUEUE_SERIAL);
-    });
-
-    bool __block queueIsUsedByThisThread = false;
-
-    dispatch_sync(threadsUsingQueuesOps, ^{
-        NSMutableSet<NSThread *> *threads = threadsUsingQueues[queueName];
-        if (!threads) {
-            threads = [[NSMutableSet alloc] init];
-            threadsUsingQueues[queueName] = threads;
-        } else if ([threads containsObject:[NSThread currentThread]]) {
-            queueIsUsedByThisThread = true;
-            return;
-        }
-        [threads addObject:[NSThread currentThread]];
-    });
-
-    if (queueIsUsedByThisThread) {
-        block();
-    } else {
-        dispatch_sync(queue, ^{
-            @try {
-                block();
-            } @finally {
-                dispatch_sync(threadsUsingQueuesOps, ^{
-                    NSMutableSet<NSThread *> *threads = threadsUsingQueues[queueName];
-                    [threads removeObject:[NSThread currentThread]];
-                    if ([threads count] == 0) {
-                        [threadsUsingQueues removeObjectForKey:queueName];
-                    }
-                });
-            }
-        });
-    }
 }

--- a/Source/ARTHttp.h
+++ b/Source/ARTHttp.h
@@ -22,45 +22,12 @@ ART_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface ARTHttpRequest : NSObject
-
-@property (readonly, strong, nonatomic) NSString *method;
-@property (readonly, strong, nonatomic) NSURL *url;
-@property (art_nullable, readonly, strong, nonatomic) NSDictionary *headers;
-@property (art_nullable, readonly, strong, nonatomic) NSData *body;
-
-- (instancetype)init UNAVAILABLE_ATTRIBUTE;
-- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body;
-- (ARTHttpRequest *)requestWithRelativeUrl:(NSString *)relUrl;
-
-@end
-
-@interface ARTHttpResponse : NSObject
-
-@property (readonly, assign, nonatomic) int status;
-@property (nullable, readwrite, nonatomic) ARTErrorInfo *error;
-@property (nullable, readonly, nonatomic) NSDictionary *headers;
-@property (nullable, readonly, nonatomic) NSData *body;
-
-- (instancetype)init;
-- (instancetype)initWithStatus:(int)status headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body;
-
-+ (instancetype)response;
-+ (instancetype)responseWithStatus:(int)status headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body;
-
-- (NSString *)contentType;
-- (NSDictionary *)links;
-
-@end
-
 @interface ARTHttp : NSObject<ARTHTTPExecutor>
 
 @property (nonatomic, weak) ARTLog *logger;
 
-- (instancetype)init;
-
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(art_nullable NSDictionary *)headers body:(art_nullable NSData *)body callback:(void (^)(ARTHttpResponse *))cb;
-
+- (instancetype)init UNAVAILABLE_ATTRIBUTE;
+- (instancetype)init:(dispatch_queue_t)queue;
 
 @end
 

--- a/Source/ARTHttp.m
+++ b/Source/ARTHttp.m
@@ -11,168 +11,22 @@
 
 @interface ARTHttp ()
 
-@property (readonly, copy, nonatomic) NSURL *baseUrl;
 @property (readonly, strong, nonatomic) ARTURLSessionServerTrust *urlSession;
 
 @end
 
-@interface ARTHttpRequestHandle : NSObject <ARTCancellable>
+@implementation ARTHttp
 
-@property (readonly, nonatomic, strong) NSURLSessionDataTask *dataTask;
-
-- (instancetype)initWithDataTask:(NSURLSessionDataTask *)dataTask;
-+ (instancetype)requestHandleWithDataTask:(NSURLSessionDataTask *)dataTask;
-
-@end
-
-
-#pragma mark - ARTHttpRequest
-
-@implementation ARTHttpRequest
-
-- (instancetype)initWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body {
+- (instancetype)init:(dispatch_queue_t)queue {
     self = [super init];
     if (self) {
-        _method = method;
-        _url = url;
-        _headers = headers;
-        _body = body;
-    }
-    return self;
-}
-
-- (ARTHttpRequest *)requestWithRelativeUrl:(NSString *)relUrl {
-    if (!relUrl) {
-        return nil;
-    }
-    NSURL *newUrl = [NSURL URLWithString:relUrl relativeToURL:self.url];
-    return [[ARTHttpRequest alloc] initWithMethod:self.method url:newUrl headers:self.headers body:self.body];
-}
-
-@end
-
-
-#pragma mark - ARTHttpResponse
-
-@implementation ARTHttpResponse
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        _status = 0;
-        _error = nil;
-        _headers = nil;
-        _body = nil;
-    }
-    return self;
-}
-
-- (instancetype)initWithStatus:(int)status headers:(NSDictionary *)headers body:(NSData *)body {
-    self = [super init];
-    if (self) {
-        _status = status;
-        _error = nil;
-        _headers = headers;
-        _body = body;
-    }
-    return self;
-}
-
-+ (instancetype)response {
-    return [[ARTHttpResponse alloc] init];
-}
-
-+ (instancetype)responseWithStatus:(int)status headers:(NSDictionary *)headers body:(NSData *)body {
-    return [[ARTHttpResponse alloc] initWithStatus:status headers:headers body:body];
-}
-
-- (NSString *)contentType {
-    return [self.headers objectForKey:@"Content-Type"];
-}
-
-- (NSDictionary *)links {
-    NSString *linkHeader = [self.headers objectForKey:@"Link"];
-    if (!linkHeader) {
-        return [NSDictionary dictionary];
-    }
-
-    NSMutableDictionary *links = [NSMutableDictionary dictionary];
-
-    static NSRegularExpression *linkRegex = nil;
-
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        linkRegex = [NSRegularExpression regularExpressionWithPattern:@"\\s*<([^>]*)>;\\s*rel=\"([^\"]*)\"" options:0 error:nil];
-    });
-
-    NSArray *matches = [linkRegex matchesInString:linkHeader options:0 range:NSMakeRange(0, linkHeader.length)];
-    for (NSTextCheckingResult *match in matches) {
-        NSRange linkUrlRange = [match rangeAtIndex:1];
-        NSRange linkRelRange = [match rangeAtIndex:2];
-
-        NSString *linkUrl = [linkHeader substringWithRange:linkUrlRange];
-        NSString *linkRels = [linkHeader substringWithRange:linkRelRange];
-
-        for (NSString *linkRel in [linkRels componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]) {
-            [links setObject:linkUrl forKey:linkRel];
-        }
-    }
-
-    return links;
-}
-
-@end
-
-
-#pragma mark - ARTHttpRequestHandle
-
-@implementation ARTHttpRequestHandle
-
-- (instancetype)initWithDataTask:(NSURLSessionDataTask *)dataTask {
-    self = [super init];
-    if (self) {
-        _dataTask = dataTask;
-    }
-    return self;
-}
-
-+ (instancetype)requestHandleWithDataTask:(NSURLSessionDataTask *)dataTask {
-    return [[ARTHttpRequestHandle alloc] initWithDataTask:dataTask];
-}
-
-- (void)cancel {
-    [self.dataTask cancel];
-}
-
-@end
-
-
-#pragma mark - ARTHttp
-
-@implementation ARTHttp {
-    _Nullable dispatch_queue_t _queue;
-}
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        _queue = dispatch_queue_create("io.ably.rest.http", DISPATCH_QUEUE_SERIAL);
-        _urlSession = [[ARTURLSessionServerTrust alloc] init];
-        _baseUrl = nil;
+        _urlSession = [[ARTURLSessionServerTrust alloc] init:queue];
     }
     return self;
 }
 
 - (void)dealloc {
     [_urlSession finishTasksAndInvalidate];
-}
-
-- (instancetype)initWithBaseUrl:(NSURL *)baseUrl {
-    self = [self init];
-    if (self) {
-        _baseUrl = baseUrl;
-    }
-    return self;
 }
 
 - (void)executeRequest:(NSMutableURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
@@ -182,80 +36,18 @@
     [_urlSession get:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
 
-        dispatch_async(_queue, ^{
-            if (error) {
-                [self.logger error:@"%@ %@: error %@", request.HTTPMethod, request.URL.absoluteString, error];
-            } else {
-                [self.logger debug:@"%@ %@: statusCode %ld", request.HTTPMethod, request.URL.absoluteString, (long)httpResponse.statusCode];
-                [self.logger verbose:@"Headers %@", httpResponse.allHeaderFields];
-                NSString *headerErrorMessage = httpResponse.allHeaderFields[@"X-Ably-ErrorMessage"];
-                if (headerErrorMessage && ![headerErrorMessage isEqualToString:@""]) {
-                    [self.logger warn:@"%@", headerErrorMessage];
-                }
-            }
-            callback(httpResponse, data, error);
-        });
-    }];
-}
-
-- (id<ARTCancellable>)makeRequestWithMethod:(NSString *)method url:(NSURL *)url headers:(NSDictionary *)headers body:(NSData *)body callback:(void (^)(ARTHttpResponse *))cb {
-    return [self makeRequest:[[ARTHttpRequest alloc] initWithMethod:method url:url headers:headers body:body] callback:cb];
-}
-
-- (id<ARTCancellable>)makeRequest:(ARTHttpRequest *)artRequest callback:(void (^)(ARTHttpResponse *))cb {
-
-    if(![artRequest.method isEqualToString:@"GET"] && ![artRequest.method isEqualToString:@"POST"]){
-        [ARTException raise:@"Http method must be GET or POST" format:@""];
-    }
-
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:artRequest.url];
-    request.HTTPMethod = artRequest.method;
-    [self.logger verbose:@"ARTHttp request URL is %@", artRequest.url];
-
-    for (NSString *headerName in artRequest.headers) {
-        NSString *headerValue = [artRequest.headers objectForKey:headerName];
-        [request setValue:headerValue forHTTPHeaderField:headerName];
-    }
-
-    request.HTTPBody = artRequest.body;
-    [self.logger debug:@"ARTHttp: makeRequest %@", [request allHTTPHeaderFields]];
-
-    [_urlSession get:request completion:^(NSHTTPURLResponse *response, NSData *data, NSError *error) {
-        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-        [self.logger verbose:@"ARTHttp: Got response %@, err %@", response, error];
-
-        if(error) {
-            [self.logger error:@"ARTHttp receieved error: %@", error];
-            cb([ARTHttpResponse responseWithStatus:500 headers:nil body:nil]);
-        }
-        else {
-            if (httpResponse) {
-                int status = (int)httpResponse.statusCode;
-                [self.logger debug:@"ARTHttp response status is %d", status];
-                [self.logger verbose:@"ARTHttp received response %@",[NSJSONSerialization JSONObjectWithData:data options:0 error:nil]];
-
-                dispatch_async(_queue, ^{
-                    cb([ARTHttpResponse responseWithStatus:status headers:httpResponse.allHeaderFields body:data]);
-                });
-            } else {
-                dispatch_async(_queue, ^{
-                    cb([ARTHttpResponse response]);
-                });
+        if (error) {
+            [self.logger error:@"%@ %@: error %@", request.HTTPMethod, request.URL.absoluteString, error];
+        } else {
+            [self.logger debug:@"%@ %@: statusCode %ld", request.HTTPMethod, request.URL.absoluteString, (long)httpResponse.statusCode];
+            [self.logger verbose:@"Headers %@", httpResponse.allHeaderFields];
+            NSString *headerErrorMessage = httpResponse.allHeaderFields[@"X-Ably-ErrorMessage"];
+            if (headerErrorMessage && ![headerErrorMessage isEqualToString:@""]) {
+                [self.logger warn:@"%@", headerErrorMessage];
             }
         }
+        callback(httpResponse, data, error);
     }];
-    return nil;
-}
-
-+ (NSDictionary *)getErrorDictionary {
-    NSString * path =[[[[NSBundle bundleForClass: [self class]] resourcePath] stringByAppendingString:@"/"] stringByAppendingString:@"ably-common/protocol/errors.json"];
-    NSString * errorsString =[NSString stringWithContentsOfFile:path
-                                      encoding:NSUTF8StringEncoding
-                                         error:NULL];
-    NSData *data = [errorsString dataUsingEncoding:NSUTF8StringEncoding];
-    NSError * error;
-    NSDictionary * topLevel =[NSJSONSerialization JSONObjectWithData:data  options:NSJSONReadingMutableContainers error:&error];
-    return  topLevel;
 }
 
 @end

--- a/Source/ARTOSReachability.m
+++ b/Source/ARTOSReachability.m
@@ -21,11 +21,13 @@
     NSString *_host;
     void (^_callback)(BOOL);
     SCNetworkReachabilityRef _reachabilityRef;
+    dispatch_queue_t _queue;
 }
 
-- (instancetype)initWithLogger:(ARTLog *)logger {
+- (instancetype)initWithLogger:(ARTLog *)logger queue:(dispatch_queue_t)queue {
     if (self = [super init]) {
         _logger = logger;
+        _queue = queue;
         if (ARTOSReachability_instances == nil) {
             ARTOSReachability_instances = [[NSMutableDictionary alloc] init];
         }
@@ -83,7 +85,9 @@ static void ARTOSReachability_Callback(SCNetworkReachabilityRef target, SCNetwor
 
 - (void)internalCallback:(BOOL)reachable {
     [_logger info:@"Reachability: host %@: %d", _host, reachable];
-    _callback(reachable);
+    dispatch_async(_queue, ^{
+        _callback(reachable);
+    });
 }
 
 - (void)dealloc {

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -14,6 +14,8 @@
 
 @implementation ARTPaginatedResult {
     __weak ARTRest *_rest;
+    dispatch_queue_t _userQueue;
+    dispatch_queue_t _queue;
     NSMutableURLRequest *_relFirst;
     NSMutableURLRequest *_relCurrent;
     NSMutableURLRequest *_relNext;
@@ -38,6 +40,8 @@
         _isLast = !_hasNext;
         
         _rest = rest;
+        _userQueue = rest.userQueue;
+        _queue = rest.queue;
         _responseProcessor = responseProcessor;
     }
     
@@ -50,7 +54,7 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_rest);
-            dispatch_async(_rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(result, error);
             });
         };
@@ -66,7 +70,7 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_rest);
-            dispatch_async(_rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(result, error);
             });
         };

--- a/Source/ARTPaginatedResult.m
+++ b/Source/ARTPaginatedResult.m
@@ -50,7 +50,9 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_rest);
-            userCallback(result, error);
+            dispatch_async(_rest.userQueue, ^{
+                userCallback(result, error);
+            });
         };
     }
 
@@ -64,7 +66,9 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, id) *__art_nullable result, ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_rest);
-            userCallback(result, error);
+            dispatch_async(_rest.userQueue, ^{
+                userCallback(result, error);
+            });
         };
     }
 

--- a/Source/ARTPresenceMap.m
+++ b/Source/ARTPresenceMap.m
@@ -9,7 +9,7 @@
 #import "ARTPresenceMap.h"
 #import "ARTPresenceMessage.h"
 #import "ARTPresenceMessage+Private.h"
-#import "ARTEventEmitter.h"
+#import "ARTEventEmitter+Private.h"
 #import "ARTLog.h"
 
 typedef NS_ENUM(NSUInteger, ARTPresenceSyncState) {
@@ -63,7 +63,7 @@ NSString *ARTPresenceSyncStateToStr(ARTPresenceSyncState state) {
         [self reset];
         _syncSessionId = 0;
         _syncState = ARTPresenceSyncInitialized;
-        _syncEventEmitter = [[ARTEventEmitter alloc] initWithQueue:queue];
+        _syncEventEmitter = [[ARTInternalEventEmitter alloc] initWithQueue:queue];
     }
     return self;
 }

--- a/Source/ARTPresenceMessage.h
+++ b/Source/ARTPresenceMessage.h
@@ -7,7 +7,7 @@
 //
 
 #import "ARTBaseMessage.h"
-#import "ARTEventEmitter.h"
+#import "ARTEventEmitter+Private.h"
 
 /// Presence action type
 typedef NS_ENUM(NSUInteger, ARTPresenceAction) {

--- a/Source/ARTReachability.h
+++ b/Source/ARTReachability.h
@@ -16,7 +16,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @protocol ARTReachability <NSObject>
 
-- (instancetype)initWithLogger:(ARTLog *)logger;
+- (instancetype)initWithLogger:(ARTLog *)logger queue:(dispatch_queue_t)queue;
 
 - (void)listenForHost:(NSString *)host callback:(void (^)(BOOL))callback;
 - (void)off;

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -205,27 +205,17 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 }
 
 - (void)dealloc {
-ART_TRY_OR_MOVE_TO_FAILED_START(self) {
     [self.logger verbose:__FILE__ line:__LINE__ message:@"R:%p dealloc", self];
 
-    if (_connection) {
-        [_connection off];
-    }
-
-    if (_internalEventEmitter) {
-        [_internalEventEmitter off];
-    }
-
     self.rest.prioritizedHost = nil;
-} ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
 - (void)connect {
-ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 dispatch_sync(_queue, ^{
+ART_TRY_OR_MOVE_TO_FAILED_START(self) {
     [self _connect];
-});
 } ART_TRY_OR_MOVE_TO_FAILED_END
+});
 }
 
 - (void)_connect {
@@ -237,11 +227,11 @@ dispatch_sync(_queue, ^{
 }
 
 - (void)close {
-ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 dispatch_sync(_queue, ^{
+ART_TRY_OR_MOVE_TO_FAILED_START(self) {
     [self _close];
-});
 } ART_TRY_OR_MOVE_TO_FAILED_END
+});
 }
 
 - (void)_close {
@@ -385,7 +375,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
             _connectingTimeoutListener = stateChangeEventListener;
 
             if (!_reachability) {
-                _reachability = [[_reachabilityClass alloc] initWithLogger:self.logger];
+                _reachability = [[_reachabilityClass alloc] initWithLogger:self.logger queue:_queue];
             }
 
             if (!_transport) {
@@ -510,8 +500,8 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
         [self sendQueuedMessages];
         // For every Channel
         for (ARTRealtimeChannel* channel in self.channels.nosyncIterable) {
-            if (channel.state == ARTRealtimeChannelSuspended) {
-                [channel attach];
+            if (channel.state_nosync == ARTRealtimeChannelSuspended) {
+                [channel _attach:nil];
             }
         }
     } else if (![self shouldQueueEvents]) {
@@ -871,7 +861,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
     if (message.channel == nil) {
         return;
     }
-    ARTRealtimeChannel *channel = [self.channels _getChannel:message.channel options:nil];
+    ARTRealtimeChannel *channel = [self.channels _getChannel:message.channel options:nil addPrefix:false];
     [channel onChannelMessage:message];
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -919,7 +919,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
         msg.msgSerial = [NSNumber numberWithLongLong:self.msgSerial];
     }
 
-    NSError *error;
+    NSError *error = nil;
     NSData *data = [self.rest.defaultEncoder encodeProtocolMessage:msg error:&error];
 
     if (error) {

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -18,6 +18,9 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTRealtimeChannel () <ARTPresenceMapDelegate>
 
+- (ARTRealtimeChannelState)state_nosync;
+- (ARTErrorInfo *)errorReason_nosync;
+
 @property (readonly, weak, nonatomic) ARTRealtime *realtime;
 @property (readonly, strong, nonatomic) ARTRestChannel *restChannel;
 @property (readwrite, strong, nonatomic) NSMutableArray *queuedMessages;
@@ -36,6 +39,9 @@ ART_ASSUME_NONNULL_BEGIN
 - (bool)isLastChannelSerial:(NSString *)channelSerial;
 
 - (void)reattachWithReason:(nullable ARTErrorInfo *)reason callback:(nullable void (^)(ARTErrorInfo *))callback;
+
+- (void)_attach:(void (^)(ARTErrorInfo * _Nullable))callback;
+- (void)_detach:(void (^)(ARTErrorInfo * _Nullable))callback;
 
 @end
 

--- a/Source/ARTRealtimeChannel+Private.h
+++ b/Source/ARTRealtimeChannel+Private.h
@@ -20,12 +20,13 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (ARTRealtimeChannelState)state_nosync;
 - (ARTErrorInfo *)errorReason_nosync;
+- (NSString *_Nullable)clientId_nosync;
 
 @property (readonly, weak, nonatomic) ARTRealtime *realtime;
 @property (readonly, strong, nonatomic) ARTRestChannel *restChannel;
 @property (readwrite, strong, nonatomic) NSMutableArray *queuedMessages;
 @property (readwrite, strong, nonatomic, art_nullable) NSString *attachSerial;
-@property (readonly, getter=getClientId) NSString *clientId;
+@property (readonly, nullable, getter=getClientId) NSString *clientId;
 @property (readonly, strong, nonatomic) ARTEventEmitter<ARTEvent *, ARTChannelStateChange *> *internalEventEmitter;
 @property (readonly, strong, nonatomic) ARTEventEmitter<ARTEvent *, ARTChannelStateChange *> *statesEventEmitter;
 @property (readonly, strong, nonatomic) ARTEventEmitter<id<ARTEventIdentification>, ARTMessage *> *messagesEventEmitter;
@@ -40,8 +41,11 @@ ART_ASSUME_NONNULL_BEGIN
 
 - (void)reattachWithReason:(nullable ARTErrorInfo *)reason callback:(nullable void (^)(ARTErrorInfo *))callback;
 
-- (void)_attach:(void (^)(ARTErrorInfo * _Nullable))callback;
-- (void)_detach:(void (^)(ARTErrorInfo * _Nullable))callback;
+- (void)_attach:(void (^_Nullable)(ARTErrorInfo * _Nullable))callback;
+- (void)_detach:(void (^_Nullable)(ARTErrorInfo * _Nullable))callback;
+
+- (void)_unsubscribe;
+- (void)off_nosync;
 
 @end
 

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -43,6 +43,7 @@
 
 @implementation ARTRealtimeChannel {
     dispatch_queue_t _queue;
+    dispatch_queue_t _userQueue;
     ARTErrorInfo *_errorReason;
 }
 
@@ -52,6 +53,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(realtime) {
     if (self) {
         _realtime = realtime;
         _queue = realtime.rest.queue;
+        _userQueue = realtime.rest.userQueue;
         _restChannel = [_realtime.rest.channels _getChannel:self.name options:options];
         _state = ARTRealtimeChannelInitialized;
         _queuedMessages = [NSMutableArray array];
@@ -120,7 +122,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_realtime.rest);
-            dispatch_async(_realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -344,7 +346,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         void (^userCallback)(ARTMessage *__art_nullable m) = cb;
         cb = ^(ARTMessage *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_realtime.rest);
-            dispatch_async(_realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(m);
             });
         };
@@ -353,7 +355,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         void (^userOnAttach)(ARTErrorInfo *__art_nullable m) = onAttach;
         onAttach = ^(ARTErrorInfo *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_realtime.rest);
-            dispatch_async(_realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userOnAttach(m);
             });
         };
@@ -384,7 +386,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         void (^userCallback)(ARTMessage *__art_nullable m) = cb;
         cb = ^(ARTMessage *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_realtime.rest);
-            dispatch_async(_realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(m);
             });
         };
@@ -780,7 +782,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_realtime.rest);
-            dispatch_async(_realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -894,7 +896,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = callback;
         callback = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_realtime.rest);
-            dispatch_async(_realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };

--- a/Source/ARTRealtimeChannels+Private.h
+++ b/Source/ARTRealtimeChannels+Private.h
@@ -15,7 +15,9 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTRealtimeChannels ()
 
+@property (readonly, getter=getNosyncIterable) id<NSFastEnumeration> nosyncIterable;
 @property (nonatomic, readonly, getter=getCollection) __GENERIC(NSMutableDictionary, NSString *, ARTRealtimeChannel *) *collection;
+- (ARTRealtimeChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options;
 
 @end
 

--- a/Source/ARTRealtimeChannels+Private.h
+++ b/Source/ARTRealtimeChannels+Private.h
@@ -17,7 +17,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @property (readonly, getter=getNosyncIterable) id<NSFastEnumeration> nosyncIterable;
 @property (nonatomic, readonly, getter=getCollection) __GENERIC(NSMutableDictionary, NSString *, ARTRealtimeChannel *) *collection;
-- (ARTRealtimeChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options;
+- (ARTRealtimeChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options addPrefix:(BOOL)addPrefix;
 
 @end
 

--- a/Source/ARTRealtimePresence+Private.h
+++ b/Source/ARTRealtimePresence+Private.h
@@ -14,6 +14,8 @@
 @interface ARTRealtimePresence ()
 
 - (instancetype)initWithChannel:(ARTRealtimeChannel *)channel;
+- (void)_unsubscribe;
+- (BOOL)getSyncComplete_nosync;
 
 @end
 

--- a/Source/ARTRealtimePresence.m
+++ b/Source/ARTRealtimePresence.m
@@ -35,6 +35,7 @@
 
 @implementation ARTRealtimePresence {
     __weak ARTRealtimeChannel *_channel;
+    dispatch_queue_t _userQueue;
     dispatch_queue_t _queue;
 }
 
@@ -42,6 +43,7 @@
 ART_TRY_OR_MOVE_TO_FAILED_START(channel.realtime) {
     if (self = [super init]) {
         _channel = channel;
+        _userQueue = channel.realtime.rest.userQueue;
         _queue = channel.realtime.rest.queue;
     }
     return self;
@@ -59,7 +61,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(NSArray<ARTPresenceMessage *> *, ARTErrorInfo *) = callback;
         callback = ^(NSArray<ARTPresenceMessage *> *m, ARTErrorInfo *e) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(m, e);
             });
         };
@@ -130,7 +132,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = cb;
         cb = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -154,7 +156,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = cb;
         cb = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -194,7 +196,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = cb;
         cb = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -218,7 +220,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = cb;
         cb = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -258,7 +260,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = cb;
         cb = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -286,7 +288,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTErrorInfo *__art_nullable error) = cb;
         cb = ^(ARTErrorInfo *__art_nullable error) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(error);
             });
         };
@@ -340,7 +342,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTPresenceMessage *__art_nullable m) = cb;
         cb = ^(ARTPresenceMessage *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(m);
             });
         };
@@ -349,7 +351,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userOnAttach)(ARTErrorInfo *__art_nullable m) = onAttach;
         onAttach = ^(ARTErrorInfo *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userOnAttach(m);
             });
         };
@@ -380,7 +382,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userCallback)(ARTPresenceMessage *__art_nullable m) = cb;
         cb = ^(ARTPresenceMessage *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(m);
             });
         };
@@ -389,7 +391,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_channel.realtime) {
         void (^userOnAttach)(ARTErrorInfo *__art_nullable m) = onAttach;
         onAttach = ^(ARTErrorInfo *__art_nullable m) {
             ART_EXITING_ABLY_CODE(_channel.realtime.rest);
-            dispatch_async(_channel.realtime.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userOnAttach(m);
             });
         };

--- a/Source/ARTRealtimeTransport.h
+++ b/Source/ARTRealtimeTransport.h
@@ -51,6 +51,8 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 
 @protocol ARTRealtimeTransportDelegate
 
+// All methods must be called from rest's serial queue.
+
 - (void)realtimeTransport:(id<ARTRealtimeTransport>)transport didReceiveMessage:(ARTProtocolMessage *)message;
 
 - (void)realtimeTransportAvailable:(id<ARTRealtimeTransport>)transport;
@@ -66,6 +68,8 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 @end
 
 @protocol ARTRealtimeTransport
+
+// All methods must be called from rest's serial queue.
 
 - (instancetype)initWithRest:(ARTRest *)rest options:(ARTClientOptions *)options resumeKey:(nullable NSString *)resumeKey connectionSerial:(nullable NSNumber *)connectionSerial;
 

--- a/Source/ARTRest+Private.h
+++ b/Source/ARTRest+Private.h
@@ -25,8 +25,8 @@ ART_ASSUME_NONNULL_BEGIN
 @property (readonly, strong, nonatomic) NSString *defaultEncoding; //Content-Type
 @property (readonly, strong, nonatomic) NSDictionary<NSString *, id<ARTEncoder>> *encoders;
 
-// Private prioritized host for testing only (overrides the current `restHost`)
-@property (readwrite, strong, nonatomic, art_nullable) NSString *prioritizedHost;
+// Must be atomic!
+@property (readwrite, strong, atomic, art_nullable) NSString *prioritizedHost;
 
 @property (nonatomic, weak) id<ARTHTTPExecutor> httpExecutor;
 
@@ -34,12 +34,16 @@ ART_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly) ARTLog *logger;
 
+@property (nonatomic, strong) dispatch_queue_t queue;
+@property (nonatomic, strong) dispatch_queue_t userQueue;
+
 // MARK: Not accessible by tests
 @property (readonly, strong, nonatomic) ARTHttp *http;
 @property (strong, nonatomic) ARTAuth *auth;
 @property (readwrite, assign, nonatomic) int fallbackCount;
 
 - (instancetype)initWithOptions:(ARTClientOptions *)options realtime:(ARTRealtime *_Nullable)realtime;
+- (void)_time:(void (^)(NSDate *__art_nullable, NSError *__art_nullable))callback;
 
 // MARK: ARTHTTPExecutor
 

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -74,8 +74,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
         }
 
     ART_TRY_OR_REPORT_CRASH_START(self) {
-        _queue = dispatch_queue_create("io.ably.main", DISPATCH_QUEUE_SERIAL);
-        dispatch_set_target_queue(_queue, options.internalDispatchQueue);
+        _queue = options.internalDispatchQueue;
         _userQueue = options.dispatchQueue;
         _http = [[ARTHttp alloc] init:_queue];
         [_logger verbose:__FILE__ line:__LINE__ message:@"RS:%p %p alloc HTTP", self, _http];
@@ -206,7 +205,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
         }
         else {
             // New Token
-            [self.auth authorize:nil options:self.options callback:^(ARTTokenDetails *tokenDetails, NSError *error) {
+            [self.auth _authorize:nil options:self.options callback:^(ARTTokenDetails *tokenDetails, NSError *error) {
                 if (error) {
                     [self.logger debug:__FILE__ line:__LINE__ message:@"RS:%p ARTRest reissuing token failed %@", self, error];
                     if (callback) callback(nil, nil, error);

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -459,7 +459,14 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
     }
 
     NSURLComponents *requestUrl = [NSURLComponents componentsWithString:@"/stats"];
-    requestUrl.queryItems = [query asQueryItems];
+    NSError *error = nil;
+    requestUrl.queryItems = [query asQueryItems:&error];
+    if (error) {
+        if (errorPtr) {
+            *errorPtr = error;
+        }
+        return NO;
+    }
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[requestUrl URLRelativeToURL:self.baseUrl]];
     
     ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **errorPtr) {

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -269,7 +269,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
 
         if (response.statusCode >= 400) {
             if (data) {
-                NSError *decodeError;
+                NSError *decodeError = nil;
                 NSError *dataError = [self->_encoders[response.MIMEType] decodeErrorInfo:data error:&decodeError];
                 if ([self shouldRenewToken:&dataError]) {
                     [self.logger debug:__FILE__ line:__LINE__ message:@"RS:%p retry request %@", self, request];

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -377,7 +377,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
         void (^userCallback)(NSDate *time, NSError *error) = callback;
         callback = ^(NSDate *time, NSError *error) {
             ART_EXITING_ABLY_CODE(self);
-            dispatch_async(self.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(time, error);
             });
         };
@@ -436,7 +436,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, ARTStats *) *, ARTErrorInfo *) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, ARTStats *) *r, ARTErrorInfo *e) {
             ART_EXITING_ABLY_CODE(self);
-            dispatch_async(self.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(r, e);
             });
         };

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -120,7 +120,7 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
     ARTPaginatedResultResponseProcessor responseProcessor = ^NSArray<ARTMessage *> *(NSHTTPURLResponse *response, NSData *data, NSError **errorPtr) {
         id<ARTEncoder> encoder = [_rest.encoders objectForKey:response.MIMEType];
         return [[encoder decodeMessages:data error:errorPtr] artMap:^(ARTMessage *message) {
-            NSError *error;
+            NSError *error = nil;
             message = [message decodeWithEncoder:self.dataEncoder error:&error];
             if (error != nil) {
                 ARTErrorInfo *errorInfo = [ARTErrorInfo wrap:[ARTErrorInfo createFromNSError:error] prepend:@"Failed to decode data: "];

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -105,7 +105,15 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
     }
 
     NSURLComponents *componentsUrl = [NSURLComponents componentsWithString:[_basePath stringByAppendingPathComponent:@"messages"]];
-    componentsUrl.queryItems = [query asQueryItems];
+    NSError *error = nil;
+    componentsUrl.queryItems = [query asQueryItems:&error];
+    if (error) {
+        if (errorPtr) {
+            *errorPtr = error;
+        }
+        ret = NO;
+        return;
+    }
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:componentsUrl.URL];
 

--- a/Source/ARTRestChannel.m
+++ b/Source/ARTRestChannel.m
@@ -57,10 +57,9 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
 
 - (ARTRestPresence *)getPresence {
 ART_TRY_OR_REPORT_CRASH_START(_rest) {
-    static dispatch_once_t once;
-    dispatch_once(&once, ^{
+    if (!_restPresence) {
         _restPresence = [[ARTRestPresence alloc] initWithChannel:self];
-    });
+    }
     return _restPresence;
 } ART_TRY_OR_REPORT_CRASH_END
 }

--- a/Source/ARTRestChannels+Private.h
+++ b/Source/ARTRestChannels+Private.h
@@ -17,7 +17,7 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTRestChannels ()
 
-- (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options;
+- (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options addPrefix:(BOOL)addPrefix;
 
 @end
 

--- a/Source/ARTRestChannels+Private.h
+++ b/Source/ARTRestChannels+Private.h
@@ -1,0 +1,27 @@
+//
+//  ARTRestChannels+Private.h
+//  Ably
+//
+//  Created by Toni Cárdenas on 21/07/2017.
+//  Copyright © 2017 Ably. All rights reserved.
+//
+
+#ifndef ARTRestChannels_Private_h
+#define ARTRestChannels_Private_h
+
+#import "ARTRestChannels.h"
+
+@class ARTRestChannel;
+
+ART_ASSUME_NONNULL_BEGIN
+
+@interface ARTRestChannels ()
+
+- (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions * _Nullable)options;
+
+@end
+
+ART_ASSUME_NONNULL_END
+
+
+#endif /* ARTRestChannels_Private_h */

--- a/Source/ARTRestChannels.m
+++ b/Source/ARTRestChannels.m
@@ -71,8 +71,8 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
 } ART_TRY_OR_REPORT_CRASH_END
 }
 
-- (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions *)options {
-    return [_channels _getChannel:name options:options];
+- (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions *)options addPrefix:(BOOL)addPrefix {
+    return [_channels _getChannel:name options:options addPrefix:addPrefix];
 }
 
 @end

--- a/Source/ARTRestChannels.m
+++ b/Source/ARTRestChannels.m
@@ -28,8 +28,8 @@
 - (instancetype)initWithRest:(ARTRest *)rest {
 ART_TRY_OR_REPORT_CRASH_START(rest) {
     if (self = [super init]) {
-        _channels = [[ARTChannels alloc] initWithDelegate:self];
         _rest = rest;
+        _channels = [[ARTChannels alloc] initWithDelegate:self dispatchQueue:_rest.queue];
     }
     return self;
 } ART_TRY_OR_REPORT_CRASH_END
@@ -69,6 +69,10 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
 ART_TRY_OR_REPORT_CRASH_START(_rest) {
     [_channels release:name];
 } ART_TRY_OR_REPORT_CRASH_END
+}
+
+- (ARTRestChannel *)_getChannel:(NSString *)name options:(ARTChannelOptions *)options {
+    return [_channels _getChannel:name options:options];
 }
 
 @end

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -180,7 +180,7 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
     ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **errorPtr) {
         id<ARTEncoder> encoder = [_channel.rest.encoders objectForKey:response.MIMEType];
         return [[encoder decodePresenceMessages:data error:errorPtr] artMap:^(ARTPresenceMessage *message) {
-            NSError *error;
+            NSError *error = nil;
             message = [message decodeWithEncoder:_channel.dataEncoder error:&error];
             if (error != nil) {
                 ARTErrorInfo *errorInfo = [ARTErrorInfo wrap:[ARTErrorInfo createFromNSError:error] prepend:@"Failed to decode data: "];

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -167,7 +167,14 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
     }
 
     NSURLComponents *requestUrl = [NSURLComponents componentsWithString:[_channel.basePath stringByAppendingPathComponent:@"presence/history"]];
-    requestUrl.queryItems = [query asQueryItems];
+    NSError *error = nil;
+    requestUrl.queryItems = [query asQueryItems:&error];
+    if (error) {
+        if (errorPtr) {
+            *errorPtr = error;
+        }
+        return NO;
+    }
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestUrl.URL];
 
     ARTPaginatedResultResponseProcessor responseProcessor = ^(NSHTTPURLResponse *response, NSData *data, NSError **errorPtr) {

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -60,12 +60,16 @@
 
 @implementation ARTRestPresence {
     __weak ARTRestChannel *_channel;
+    dispatch_queue_t _userQueue;
+    dispatch_queue_t _queue;
 }
 
 - (instancetype)initWithChannel:(ARTRestChannel *)channel {
 ART_TRY_OR_REPORT_CRASH_START(channel.rest) {
     if (self = [super init]) {
         _channel = channel;
+        _userQueue = channel.rest.userQueue;
+        _queue = channel.rest.queue;
     }
     return self;
 } ART_TRY_OR_REPORT_CRASH_END
@@ -89,7 +93,7 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         void (^userCallback)(ARTPaginatedResult<ARTPresenceMessage *> *, ARTErrorInfo *) = callback;
         callback = ^(ARTPaginatedResult<ARTPresenceMessage *> *m, ARTErrorInfo *e) {
             ART_EXITING_ABLY_CODE(_channel.rest);
-            dispatch_async(_channel.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(m, e);
             });
         };
@@ -120,7 +124,7 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         }];
     };
 
-dispatch_async(_channel.rest.queue, ^{
+dispatch_async(_queue, ^{
     [ARTPaginatedResult executePaginated:_channel.rest withRequest:request andResponseProcessor:responseProcessor callback:callback];
 });
     return YES;
@@ -139,7 +143,7 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, ARTErrorInfo *error) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, ARTErrorInfo *error) {
             ART_EXITING_ABLY_CODE(_channel.rest);
-            dispatch_async(_channel.rest.userQueue, ^{
+            dispatch_async(_userQueue, ^{
                 userCallback(result, error);
             });
         };
@@ -179,7 +183,7 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         }];
     };
 
-dispatch_async(_channel.rest.queue, ^{
+dispatch_async(_queue, ^{
     [ARTPaginatedResult executePaginated:_channel.rest withRequest:request andResponseProcessor:responseProcessor callback:callback];
 });
     return YES;

--- a/Source/ARTRestPresence.m
+++ b/Source/ARTRestPresence.m
@@ -89,7 +89,9 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         void (^userCallback)(ARTPaginatedResult<ARTPresenceMessage *> *, ARTErrorInfo *) = callback;
         callback = ^(ARTPaginatedResult<ARTPresenceMessage *> *m, ARTErrorInfo *e) {
             ART_EXITING_ABLY_CODE(_channel.rest);
-            userCallback(m, e);
+            dispatch_async(_channel.rest.userQueue, ^{
+                userCallback(m, e);
+            });
         };
     }
 
@@ -118,7 +120,9 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         }];
     };
 
+dispatch_async(_channel.rest.queue, ^{
     [ARTPaginatedResult executePaginated:_channel.rest withRequest:request andResponseProcessor:responseProcessor callback:callback];
+});
     return YES;
 } ART_TRY_OR_REPORT_CRASH_END
 }
@@ -135,7 +139,9 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         void (^userCallback)(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, ARTErrorInfo *error) = callback;
         callback = ^(__GENERIC(ARTPaginatedResult, ARTPresenceMessage *) *result, ARTErrorInfo *error) {
             ART_EXITING_ABLY_CODE(_channel.rest);
-            userCallback(result, error);
+            dispatch_async(_channel.rest.userQueue, ^{
+                userCallback(result, error);
+            });
         };
     }
 
@@ -173,7 +179,9 @@ ART_TRY_OR_REPORT_CRASH_START(_channel.rest) {
         }];
     };
 
+dispatch_async(_channel.rest.queue, ^{
     [ARTPaginatedResult executePaginated:_channel.rest withRequest:request andResponseProcessor:responseProcessor callback:callback];
+});
     return YES;
 } ART_TRY_OR_REPORT_CRASH_END
 }

--- a/Source/ARTSentry.m
+++ b/Source/ARTSentry.m
@@ -45,11 +45,13 @@ void ART_withKSCrash(void (^f)(KSCrash *)) {
 
 @implementation ARTKSCrashReportFilter {
     NSString *_dns;
+    dispatch_queue_t _queue;
 }
 
 - (instancetype)init:(NSString *)dns {
     if (self = [super init]) {
         _dns = dns;
+        _queue = dispatch_queue_create("io.ably.sentry", nil);
     }
     return self;
 }
@@ -61,7 +63,7 @@ void ART_withKSCrash(void (^f)(KSCrash *)) {
         return;
     }
 
-    dispatch_sync(dispatch_queue_create("io.ably.sentry", nil), ^{
+    dispatch_sync(_queue, ^{
         NSMutableArray<NSMutableDictionary *> *events = [[NSMutableArray alloc] init];
         for (NSDictionary __strong *report in reports) {
             id recrash = report[@"recrash_report"];

--- a/Source/ARTStats.m
+++ b/Source/ARTStats.m
@@ -33,8 +33,11 @@ static NSString *statsUnitToString(ARTStatsGranularity unit) {
     }
 }
 
-- (NSMutableArray *)asQueryItems {
-    NSMutableArray *items = [super asQueryItems];
+- (NSMutableArray *)asQueryItems:(NSError **)error {
+    NSMutableArray *items = [super asQueryItems:error];
+    if (*error) {
+        return nil;
+    }
     [items addObject:[NSURLQueryItem queryItemWithName:@"unit" value:statsUnitToString(self.unit)]];
     return items;
 }

--- a/Source/ARTTokenDetails.m
+++ b/Source/ARTTokenDetails.m
@@ -44,7 +44,7 @@
 }
 
 + (ARTTokenDetails *__art_nullable)fromJson:(id<ARTJsonCompatible>)json error:(NSError *__art_nullable *__art_nullable)error {
-    NSError *e;
+    NSError *e = nil;
     NSDictionary *dict = [json toJSON:&e];
     if (e) {
         if (error) {

--- a/Source/ARTTokenParams.h
+++ b/Source/ARTTokenParams.h
@@ -17,7 +17,7 @@ ART_ASSUME_NONNULL_BEGIN
 /**
  Type that provided parameters of a token request.
  */
-@interface ARTTokenParams : NSObject
+@interface ARTTokenParams : NSObject<NSCopying>
 
 /**
  Represents time to live (expiry) of this token as a NSTimeInterval.

--- a/Source/ARTTokenParams.m
+++ b/Source/ARTTokenParams.m
@@ -57,6 +57,16 @@
             self.ttl, self.capability, self.timestamp];
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+    ARTTokenParams *token = [[[self class] allocWithZone:zone] initWithClientId:_clientId nonce:_nonce];
+
+    token.ttl = _ttl;
+    token.capability = _capability;
+    token.timestamp = _timestamp;
+
+    return token;
+}
+
 - (NSMutableArray *)toArray {
     NSMutableArray *params = [[NSMutableArray alloc] init];
     

--- a/Source/ARTTokenRequest.m
+++ b/Source/ARTTokenRequest.m
@@ -36,7 +36,7 @@
 }
 
 + (ARTTokenRequest *__art_nullable)fromJson:(id<ARTJsonCompatible>)json error:(NSError *__art_nullable *__art_nullable)error {
-    NSError *e;
+    NSError *e = nil;
     NSDictionary *dict = [json toJSON:&e];
     if (e) {
         if (error) {

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -158,7 +158,7 @@ NSString *ARTRealtimeConnectionEventToStr(ARTRealtimeConnectionEvent event) {
 
 - (NSDictionary *)toJSON:(NSError *__art_nullable *__art_nullable)error {
     NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
-    NSError *jsonError;
+    NSError *jsonError = nil;
     id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
     if (jsonError) {
         if (error) {

--- a/Source/ARTURLSessionServerTrust.h
+++ b/Source/ARTURLSessionServerTrust.h
@@ -13,6 +13,8 @@ ART_ASSUME_NONNULL_BEGIN
 
 @interface ARTURLSessionServerTrust : NSObject<NSURLSessionDelegate, NSURLSessionTaskDelegate>
 
+- (instancetype)init:(dispatch_queue_t)queue;
+
 - (void)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback;
 
 - (void)finishTasksAndInvalidate;

--- a/Source/ARTURLSessionServerTrust.m
+++ b/Source/ARTURLSessionServerTrust.m
@@ -10,15 +10,17 @@
 
 @interface ARTURLSessionServerTrust() {
     NSURLSession *_session;
+    dispatch_queue_t _queue;
 }
 
 @end
 
 @implementation ARTURLSessionServerTrust
 
-- (instancetype)init {
+- (instancetype)init:(dispatch_queue_t)queue {
     if (self = [super init]) {
         _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration] delegate:self delegateQueue:nil];
+        _queue = queue;
     }
     return self;
 }
@@ -29,7 +31,9 @@
 
 - (void)get:(NSURLRequest *)request completion:(void (^)(NSHTTPURLResponse *__art_nullable, NSData *__art_nullable, NSError *__art_nullable))callback {
     NSURLSessionDataTask *task = [_session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        callback((NSHTTPURLResponse *)response, data, error);
+        dispatch_async(_queue, ^{
+            callback((NSHTTPURLResponse *)response, data, error);
+        });
     }];
     [task resume];
 }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -302,7 +302,7 @@ class Auth : QuickSpec {
                 }
 
                 // RSA4b
-                it("in Realtime, if the connection fails due to a terminal token error, then the connection should move to the FAILED state and reports the error") {
+                itt("in Realtime, if the connection fails due to a terminal token error, then the connection should move to the FAILED state and reports the error") {
                     let options = AblyTests.commonAppSetup()
                     options.authCallback = { tokenParams, completion in
                         let token = getTestToken()
@@ -836,10 +836,12 @@ class Auth : QuickSpec {
                 expect(tokenParams.capability) == "{\"*\":[\"*\"]}"
                 
                 let options = AblyTests.setupOptions(AblyTests.jsonRestOptions)
-                
+                options.logLevel = .debug
+                let rest = ARTRest(options: options)
+
                 waitUntil(timeout: testTimeout) { done in
                     // Token
-                    ARTRest(options: options).auth.requestToken(tokenParams, with: options) { tokenDetails, error in
+                    rest.auth.requestToken(tokenParams, with: options) { tokenDetails, error in
                         if let e = error {
                             XCTFail((e as! ARTErrorInfo).description)
                         }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -559,7 +559,7 @@ class Auth : QuickSpec {
 
                             // Token should renew and fail
                             let invalidToken = String(token.characters.reversed())
-                                AblyTests.queue.sync {
+                            AblyTests.queue.sync {
                                 realtime.options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
                                 realtime.options.authParams?.append(NSURLQueryItem(name: "type", value: "json") as URLQueryItem)
                                 let invalidTokenFormat = "{secret_token:xxx}"

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -302,7 +302,7 @@ class Auth : QuickSpec {
                 }
 
                 // RSA4b
-                itt("in Realtime, if the connection fails due to a terminal token error, then the connection should move to the FAILED state and reports the error") {
+                it("in Realtime, if the connection fails due to a terminal token error, then the connection should move to the FAILED state and reports the error") {
                     let options = AblyTests.commonAppSetup()
                     options.authCallback = { tokenParams, completion in
                         let token = getTestToken()
@@ -403,8 +403,10 @@ class Auth : QuickSpec {
                                 }
                             }
 
-                            // Token reauth will fail
-                            realtime.options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
+                            AblyTests.queue.sync {
+                                // Token reauth will fail
+                                realtime.options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
+                            }
 
                             // Inject AUTH
                             let authMessage = ARTProtocolMessage()
@@ -556,10 +558,12 @@ class Auth : QuickSpec {
 
                             // Token should renew and fail
                             let invalidToken = String(token.characters.reversed())
-                            realtime.options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
-                            realtime.options.authParams?.append(NSURLQueryItem(name: "type", value: "json") as URLQueryItem)
-                            let invalidTokenFormat = "{secret_token:xxx}"
-                            realtime.options.authParams?.append(NSURLQueryItem(name: "body", value: invalidTokenFormat) as URLQueryItem)
+                                AblyTests.queue.sync {
+                                realtime.options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
+                                realtime.options.authParams?.append(NSURLQueryItem(name: "type", value: "json") as URLQueryItem)
+                                let invalidTokenFormat = "{secret_token:xxx}"
+                                realtime.options.authParams?.append(NSURLQueryItem(name: "body", value: invalidTokenFormat) as URLQueryItem)
+                            }
 
                             realtime.connection.on() { stateChange in
                                 guard let stateChange = stateChange else {
@@ -656,7 +660,9 @@ class Auth : QuickSpec {
                             // Inject AUTH
                             let authMessage = ARTProtocolMessage()
                             authMessage.action = ARTProtocolMessageAction.auth
-                            realtime.transport?.receive(authMessage)
+                            AblyTests.queue.sync {
+                                realtime.transport?.receive(authMessage)
+                            }
 
                             expect(realtime.connection.errorReason).toEventuallyNot(beNil(), timeout: testTimeout)
                             guard let errorInfo = realtime.connection.errorReason else {
@@ -918,7 +924,8 @@ class Auth : QuickSpec {
                     options.clientId = "john"
                     options.authCallback = { tokenParams, completion in
                         expect(tokenParams.clientId).to(equal(options.clientId))
-                        completion(getTestToken(clientId: tokenParams.clientId) as ARTTokenDetailsCompatible?, nil)
+                        let token = getTestToken(clientId: tokenParams.clientId) as ARTTokenDetailsCompatible?
+                        completion(token, nil)
                     }
                     options.defaultTokenParams = ARTTokenParams(clientId: "tester")
                     let client = ARTRest(options: options)
@@ -1193,7 +1200,7 @@ class Auth : QuickSpec {
                 it("query will provide a token string") {
                     let testToken = getTestToken()
 
-                    let options = ARTClientOptions()
+                    let options = AblyTests.clientOptions()
                     options.authUrl = NSURL(string: "http://echo.ably.io") as URL?
                     expect(options.authUrl).toNot(beNil())
                     // Plain text
@@ -1530,9 +1537,10 @@ class Auth : QuickSpec {
                         expect(tokenParams.clientId).to(beNil())
                         completion("token_string" as ARTTokenDetailsCompatible?, nil)
                     }
+                    let rest = ARTRest(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
+                        rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
                             expect(error).to(beNil())
                             expect(tokenDetails!.token).to(equal("token_string"))
                             done()
@@ -1548,9 +1556,10 @@ class Auth : QuickSpec {
                         expect(tokenParams.clientId).to(beNil())
                         completion(ARTTokenDetails(token: "token_from_details"), nil)
                     }
+                    let rest = ARTRest(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
+                        rest.auth.requestToken(expectedTokenParams, with: nil) { tokenDetails, error in
                             expect(error).to(beNil())
                             expect(tokenDetails!.token).to(equal("token_from_details"))
                             done()
@@ -1734,7 +1743,7 @@ class Auth : QuickSpec {
                 rest.auth.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate as Date)
 
                 var serverTimeRequestCount = 0
-                let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                     serverTimeRequestCount += 1
                 }
                 defer { hook.remove() }
@@ -1874,7 +1883,7 @@ class Auth : QuickSpec {
                 authOptions.key = options.key
 
                 var serverTimeRequestCount = 0
-                let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                     serverTimeRequestCount += 1
                 }
                 defer { hook.remove() }
@@ -1914,16 +1923,19 @@ class Auth : QuickSpec {
                 let expectedClientId = "client_string"
                 let tokenParams = ARTTokenParams(clientId: expectedClientId)
 
-                rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                    expect(error).to(beNil())
-                    guard let tokenRequest = tokenRequest else {
-                        XCTFail("TokenRequest is nil"); return
-                    }
-                    expect(tokenRequest).to(beAnInstanceOf(ARTTokenRequest.self))
-                    expect(tokenRequest.clientId).to(equal(expectedClientId))
-                    expect(tokenRequest.mac).toNot(beNil())
-                    expect(tokenRequest.nonce).toNot(beNil())
-                })
+                waitUntil(timeout: testTimeout) { done in
+                    rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                        defer { done() }
+                        expect(error).to(beNil())
+                        guard let tokenRequest = tokenRequest else {
+                            XCTFail("TokenRequest is nil"); return
+                        }
+                        expect(tokenRequest).to(beAnInstanceOf(ARTTokenRequest.self))
+                        expect(tokenRequest.clientId).to(equal(expectedClientId))
+                        expect(tokenRequest.mac).toNot(beNil())
+                        expect(tokenRequest.nonce).toNot(beNil())
+                    })
+                }
             }
 
             // RSA9b
@@ -1933,13 +1945,16 @@ class Auth : QuickSpec {
 
                 let authOptions = ARTAuthOptions(key: "key:secret")
 
-                auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
-                    expect(error).to(beNil())
-                    guard let tokenRequest = tokenRequest else {
-                        XCTFail("TokenRequest is nil"); return
-                    }
-                    expect(tokenRequest.keyName).to(equal("key"))
-                })
+                waitUntil(timeout: testTimeout) { done in
+                    auth.createTokenRequest(nil, options: authOptions, callback: { tokenRequest, error in
+                        defer { done() }
+                        expect(error).to(beNil())
+                        guard let tokenRequest = tokenRequest else {
+                            XCTFail("TokenRequest is nil"); return
+                        }
+                        expect(tokenRequest.keyName).to(equal("key"))
+                    })
+                }
             }
 
             // RSA9c
@@ -1977,13 +1992,16 @@ class Auth : QuickSpec {
                 it("from current time if not provided") {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                    rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        expect(tokenRequest.timestamp).to(beCloseTo(NSDate(), within: 1.0))
-                    })
+                    waitUntil(timeout: testTimeout) { done in
+                        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
+                            defer { done() }
+                            expect(error).to(beNil())
+                            guard let tokenRequest = tokenRequest else {
+                                XCTFail("TokenRequest is nil"); return
+                            }
+                            expect(tokenRequest.timestamp).to(beCloseTo(NSDate(), within: 1.0))
+                        })
+                    }
                 }
 
                 it("will retrieve the server time if queryTime is true") {
@@ -1996,7 +2014,7 @@ class Auth : QuickSpec {
 
                     let hook = ARTRest.aspect_hook(rest)
                     // Adds a block of code after `time` is triggered
-                    let _ = try? hook(#selector(ARTRest.time(_:)), .positionBefore, unsafeBitCast(block, to: ARTRest.self))
+                    let _ = try? hook(#selector(ARTRest._time(_:)), .positionBefore, unsafeBitCast(block, to: ARTRest.self))
 
                     let authOptions = ARTAuthOptions()
                     authOptions.queryTime = true
@@ -2022,14 +2040,17 @@ class Auth : QuickSpec {
                 it("should be optional") {
                     let rest = ARTRest(options: AblyTests.commonAppSetup())
 
-                    rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        //In Seconds because TTL property is a NSTimeInterval but further it does the conversion to milliseconds
-                        expect(tokenRequest.ttl).to(beNil())
-                    })
+                    waitUntil(timeout: testTimeout) { done in
+                        rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
+                            defer { done() }
+                            expect(error).to(beNil())
+                            guard let tokenRequest = tokenRequest else {
+                                XCTFail("TokenRequest is nil"); return
+                            }
+                            //In Seconds because TTL property is a NSTimeInterval but further it does the conversion to milliseconds
+                            expect(tokenRequest.ttl).to(beNil())
+                        })
+                    }
 
                     let tokenParams = ARTTokenParams()
                     expect(tokenParams.ttl).to(beNil())
@@ -2037,13 +2058,16 @@ class Auth : QuickSpec {
                     let expectedTtl = TimeInterval(10)
                     tokenParams.ttl = NSNumber(value: expectedTtl)
 
-                    rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
-                    })
+                    waitUntil(timeout: testTimeout) { done in
+                        rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                            defer { done() }
+                            expect(error).to(beNil())
+                            guard let tokenRequest = tokenRequest else {
+                                XCTFail("TokenRequest is nil"); return
+                            }
+                            expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
+                        })
+                    }
                 }
 
                 it("should be specified in milliseconds") {
@@ -2051,24 +2075,27 @@ class Auth : QuickSpec {
 
                     let params = ARTTokenParams()
                     params.ttl = NSNumber(value: 42)
-                    rest.auth.createTokenRequest(params, options: nil, callback: { tokenRequest, error in
-                        expect(error).to(beNil())
-                        guard let tokenRequest = tokenRequest else {
-                            XCTFail("TokenRequest is nil"); return
-                        }
-                        expect(tokenRequest.ttl as? TimeInterval).to(equal(42))
+                    waitUntil(timeout: testTimeout) { done in
+                        rest.auth.createTokenRequest(params, options: nil, callback: { tokenRequest, error in
+                            defer { done() }
+                            expect(error).to(beNil())
+                            guard let tokenRequest = tokenRequest else {
+                                XCTFail("TokenRequest is nil"); return
+                            }
+                            expect(tokenRequest.ttl as? TimeInterval).to(equal(42))
 
-                        // Check if the encoder changes the TTL to milliseconds
-                        let encoder = rest.defaultEncoder as! ARTJsonLikeEncoder
-                        let data = try! encoder.encode(tokenRequest)
-                        let jsonObject = (try! encoder.delegate!.decode(data)) as! NSDictionary
-                        let ttl = jsonObject["ttl"] as! NSNumber
-                        expect(ttl as? Int64).to(equal(42 * 1000))
-                        
-                        // Make sure it comes back the same.
-                        let decoded = try! encoder.decodeTokenRequest(data)
-                        expect(decoded.ttl as? TimeInterval).to(equal(42))
-                    })
+                            // Check if the encoder changes the TTL to milliseconds
+                            let encoder = rest.defaultEncoder as! ARTJsonLikeEncoder
+                            let data = try! encoder.encode(tokenRequest)
+                            let jsonObject = (try! encoder.delegate!.decode(data)) as! NSDictionary
+                            let ttl = jsonObject["ttl"] as! NSNumber
+                            expect(ttl as? Int64).to(equal(42 * 1000))
+                            
+                            // Make sure it comes back the same.
+                            let decoded = try! encoder.decodeTokenRequest(data)
+                            expect(decoded.ttl as? TimeInterval).to(equal(42))
+                        })
+                    }
                 }
 
                 it("should be valid to request a token for 24 hours") {
@@ -2098,13 +2125,16 @@ class Auth : QuickSpec {
                 let tokenParams = ARTTokenParams()
                 tokenParams.capability = "{ - }"
 
-                rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
-                    guard let error = error else {
-                        XCTFail("Error is nil"); return
-                    }
-                    expect(error.localizedDescription).to(contain("Capability"))
-                    expect(tokenRequest?.capability).to(beNil())
-                })
+                waitUntil(timeout: testTimeout) { done in
+                    rest.auth.createTokenRequest(tokenParams, options: nil, callback: { tokenRequest, error in
+                        defer { done() }
+                        guard let error = error else {
+                            XCTFail("Error is nil"); return
+                        }
+                        expect(error.localizedDescription).to(contain("Capability"))
+                        expect(tokenRequest?.capability).to(beNil())
+                    })
+                }
 
                 let expectedCapability = "{ \"cansubscribe:*\":[\"subscribe\"] }"
                 tokenParams.capability = expectedCapability
@@ -2169,18 +2199,21 @@ class Auth : QuickSpec {
                 }
                 expect(serverTime).toNot(beNil(), description: "Server time is nil")
 
-                rest.auth.createTokenRequest(tokenParams, options: authOptions, callback: { tokenRequest, error in
-                    expect(error).to(beNil())
-                    guard let tokenRequest = tokenRequest else {
-                        XCTFail("TokenRequest is nil"); return
-                    }
-                    expect(tokenRequest.clientId).to(equal(expectedClientId))
-                    expect(tokenRequest.mac).toNot(beNil())
-                    expect(tokenRequest.nonce.characters).to(haveCount(16))
-                    expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
-                    expect(tokenRequest.capability).to(equal(expectedCapability))
-                    expect(tokenRequest.timestamp).to(beCloseTo(serverTime!, within: 6.0))
-                })
+                waitUntil(timeout: testTimeout) { done in
+                    rest.auth.createTokenRequest(tokenParams, options: authOptions, callback: { tokenRequest, error in
+                        defer { done() }
+                        expect(error).to(beNil())
+                        guard let tokenRequest = tokenRequest else {
+                            XCTFail("TokenRequest is nil"); return
+                        }
+                        expect(tokenRequest.clientId).to(equal(expectedClientId))
+                        expect(tokenRequest.mac).toNot(beNil())
+                        expect(tokenRequest.nonce.characters).to(haveCount(16))
+                        expect(tokenRequest.ttl as? TimeInterval).to(equal(expectedTtl))
+                        expect(tokenRequest.capability).to(equal(expectedCapability))
+                        expect(tokenRequest.timestamp).to(beCloseTo(serverTime!, within: 6.0))
+                    })
+                }
             }
 
         }
@@ -2320,7 +2353,7 @@ class Auth : QuickSpec {
 
                 let hook = ARTAuth.aspect_hook(rest.auth)
                 // Adds a block of code after `requestToken` is triggered
-                let token = try? hook(#selector(ARTAuth.requestToken(_:with:callback:)), [], unsafeBitCast(block, to: ARTAuth.self))
+                let token = try? hook(#selector(ARTAuth._requestToken(_:with:callback:)), [], unsafeBitCast(block, to: ARTAuth.self))
 
                 expect(token).toNot(beNil())
 
@@ -2444,7 +2477,7 @@ class Auth : QuickSpec {
                     authOptions.queryTime = true
 
                     var serverTimeRequestWasMade = false
-                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                         serverTimeRequestWasMade = true
                     }
                     defer { hook.remove() }
@@ -2545,10 +2578,11 @@ class Auth : QuickSpec {
             // RSA10h
             it("should use the configured Auth#clientId, if not null, by default") {
                 let options = AblyTests.commonAppSetup()
+                var rest = ARTRest(options: options)
 
                 // ClientId null
                 waitUntil(timeout: testTimeout) { done in
-                    ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                    rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                         expect(error).to(beNil())
                         guard let tokenDetails = tokenDetails else {
                             XCTFail("TokenDetails is nil"); done(); return
@@ -2559,10 +2593,11 @@ class Auth : QuickSpec {
                 }
 
                 options.clientId = "client_string"
+                rest = ARTRest(options: options)
 
                 // ClientId not null
                 waitUntil(timeout: testTimeout) { done in
-                    ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                    rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                         expect(error).to(beNil())
                         guard let tokenDetails = tokenDetails else {
                             XCTFail("TokenDetails is nil"); done(); return
@@ -2605,7 +2640,7 @@ class Auth : QuickSpec {
                 it("authCallback") {
                     var currentTokenRequest: ARTTokenRequest? = nil
 
-                    let rest = ARTRest(options: AblyTests.commonAppSetup())
+                    var rest = ARTRest(options: AblyTests.commonAppSetup())
                     rest.auth.createTokenRequest(nil, options: nil, callback: { tokenRequest, error in
                         currentTokenRequest = tokenRequest
                     })
@@ -2620,8 +2655,9 @@ class Auth : QuickSpec {
                         completion(currentTokenRequest!, nil)
                     }
 
+                    rest = ARTRest(options: options)
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             expect(error).to(beNil())
                             guard let tokenDetails = tokenDetails else {
                                 XCTFail("TokenDetails is nil"); done(); return
@@ -2638,8 +2674,9 @@ class Auth : QuickSpec {
                     let options = ARTClientOptions()
                     options.authUrl = NSURL(string: "http://echo.ably.io")! as URL
 
+                    let rest = ARTRest(options: options)
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             guard let error = error as? ARTErrorInfo else {
                                 fail("Error is nil"); done(); return
                             }
@@ -2669,10 +2706,11 @@ class Auth : QuickSpec {
                     options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
                     options.authParams?.append(NSURLQueryItem(name: "type", value: "json") as URLQueryItem)
                     options.authParams?.append(NSURLQueryItem(name: "body", value: "[]") as URLQueryItem)
+                    var rest = ARTRest(options: options)
 
                     // Invalid TokenDetails
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             guard let error = error else {
                                 fail("Error is nil"); done(); return
                             }
@@ -2684,10 +2722,11 @@ class Auth : QuickSpec {
 
                     options.authParams?.removeLast()
                     options.authParams?.append(NSURLQueryItem(name: "body", value: tokenDetailsJSON as String) as URLQueryItem)
+                    rest = ARTRest(options: options)
 
                     // Valid token
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             expect(error).to(beNil())
                             expect(tokenDetails).toNot(beNil())
                             done()
@@ -2699,7 +2738,7 @@ class Auth : QuickSpec {
                 it("authUrl returning TokenRequest decodes TTL as expected") {
                     let options = AblyTests.commonAppSetup()
 
-                    let rest = ARTRest(options: options)
+                    var rest = ARTRest(options: options)
                     var tokenRequest: ARTTokenRequest!
                     waitUntil(timeout: testTimeout) { done in
                         let params = ARTTokenParams(clientId: "myClientId", nonce: "12345")
@@ -2723,9 +2762,10 @@ class Auth : QuickSpec {
                     options.authParams?.append(NSURLQueryItem(name: "type", value: "json") as URLQueryItem)
                     options.authParams?.append(NSURLQueryItem(name: "body", value: tokenRequestJSON as String) as URLQueryItem)
                     options.key = nil
+                    rest = ARTRest(options: options)
 
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             expect(error).to(beNil())
                             expect(tokenDetails).toNot(beNil())
                             expect(tokenDetails?.clientId).to(equal("myClientId"))
@@ -2742,10 +2782,11 @@ class Auth : QuickSpec {
                     options.authParams = [NSURLQueryItem]() as [URLQueryItem]?
                     options.authParams?.append(NSURLQueryItem(name: "type", value: "text") as URLQueryItem)
                     options.authParams?.append(NSURLQueryItem(name: "body", value: "") as URLQueryItem)
+                    var rest = ARTRest(options: options)
 
                     // Invalid token
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             expect(error).toNot(beNil())
                             expect(tokenDetails).to(beNil())
                             done()
@@ -2754,10 +2795,11 @@ class Auth : QuickSpec {
 
                     options.authParams?.removeLast()
                     options.authParams?.append(NSURLQueryItem(name: "body", value: token) as URLQueryItem)
+                    rest = ARTRest(options: options)
 
                     // Valid token
                     waitUntil(timeout: testTimeout) { done in
-                        ARTRest(options: options).auth.authorize(nil, options: nil) { tokenDetails, error in
+                        rest.auth.authorize(nil, options: nil) { tokenDetails, error in
                             expect(error).to(beNil())
                             expect(tokenDetails).toNot(beNil())
                             done()
@@ -3007,7 +3049,7 @@ class Auth : QuickSpec {
                     authOptions.queryTime = true
 
                     var serverTimeRequestCount = 0
-                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                         serverTimeRequestCount += 1
                     }
                     defer { hook.remove() }
@@ -3111,7 +3153,7 @@ class Auth : QuickSpec {
                     let currentDate = NSDate()
 
                     var serverTimeRequestCount = 0
-                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                         serverTimeRequestCount += 1
                     }
                     defer { hook.remove() }
@@ -3159,7 +3201,7 @@ class Auth : QuickSpec {
                     rest.auth.testSuite_returnValue(for: NSSelectorFromString("handleServerTime:"), with: mockServerDate as Date)
 
                     var serverTimeRequestCount = 0
-                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                         serverTimeRequestCount += 1
                     }
                     defer { hook.remove() }
@@ -3189,7 +3231,7 @@ class Auth : QuickSpec {
                     let rest = ARTRest(options: options)
 
                     var serverTimeRequestCount = 0
-                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time(_:))) {
+                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time(_:))) {
                         serverTimeRequestCount += 1
                     }
                     defer { hook.remove() }
@@ -3256,7 +3298,7 @@ class Auth : QuickSpec {
                     let rest = ARTRest(options: options)
 
                     var serverTimeRequestCount = 0
-                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest.time)) {
+                    let hook = rest.testSuite_injectIntoMethod(after: #selector(rest._time)) {
                         serverTimeRequestCount += 1
                     }
                     defer { hook.remove() }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -305,9 +305,10 @@ class Auth : QuickSpec {
                 it("in Realtime, if the connection fails due to a terminal token error, then the connection should move to the FAILED state and reports the error") {
                     let options = AblyTests.commonAppSetup()
                     options.authCallback = { tokenParams, completion in
-                        let token = getTestToken()
-                        let invalidToken = String(token.characters.reversed())
-                        completion(invalidToken as ARTTokenDetailsCompatible?, nil)
+                        getTestToken() { token in
+                            let invalidToken = String(token.characters.reversed())
+                            completion(invalidToken as ARTTokenDetailsCompatible?, nil)
+                        }
                     }
                     options.autoConnect = false
 
@@ -464,7 +465,7 @@ class Auth : QuickSpec {
                         it("if the connection is CONNECTED, then the connection should remain CONNECTED") {
                             let options = AblyTests.clientOptions()
                             options.authCallback = { tokenParams, completion in
-                                completion(getTestTokenDetails(), nil)
+                                getTestTokenDetails(completion: completion)
                             }
                             let realtime = ARTRealtime(options: options)
                             defer { realtime.dispose(); realtime.close() }
@@ -634,7 +635,7 @@ class Auth : QuickSpec {
                             let options = AblyTests.clientOptions()
                             options.autoConnect = false
                             options.authCallback = { tokenParams, completion in
-                                completion(getTestTokenDetails(), nil)
+                                getTestTokenDetails(completion: completion)
                             }
 
                             let realtime = ARTRealtime(options: options)
@@ -924,8 +925,9 @@ class Auth : QuickSpec {
                     options.clientId = "john"
                     options.authCallback = { tokenParams, completion in
                         expect(tokenParams.clientId).to(equal(options.clientId))
-                        let token = getTestToken(clientId: tokenParams.clientId) as ARTTokenDetailsCompatible?
-                        completion(token, nil)
+                        getTestToken(clientId: tokenParams.clientId) { token in
+                            completion(token as ARTTokenDetailsCompatible?, nil)
+                        }
                     }
                     options.defaultTokenParams = ARTTokenParams(clientId: "tester")
                     let client = ARTRest(options: options)
@@ -2551,7 +2553,7 @@ class Auth : QuickSpec {
                         expect(tokenParams.ttl as? TimeInterval) == ExpectedTokenParams.ttl
                         expect(tokenParams.capability) == ExpectedTokenParams.capability
                         authCallbackCalled += 1
-                        completion(getTestTokenDetails(key: options.key), nil)
+                        getTestTokenDetails(key: options.key, completion: completion)
                     }
 
                     waitUntil(timeout: testTimeout) { done in

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -255,10 +255,12 @@ class RealtimeClient: QuickSpec {
                     // Async
                     waitUntil(timeout: testTimeout) { done in
                         // Proxy from `client.rest.stats`
-                        try! client.stats(query, callback: { paginated, error in
-                            expect(paginated).toNot(beNil())
-                            done()
-                        })
+                        expect {
+                            try client.stats(query, callback: { paginated, error in
+                                expect(paginated).toNot(beNil())
+                                done()
+                            })
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                 }
 
@@ -269,12 +271,14 @@ class RealtimeClient: QuickSpec {
                     var paginatedResult: ARTPaginatedResult<AnyObject>?
 
                     // Realtime
-                    try! client.stats(query, callback: { paginated, error in
-                        if let e = error {
-                            XCTFail(e.localizedDescription)
-                        }
-                        paginatedResult = paginated as! ARTPaginatedResult<AnyObject>?
-                    })
+                    expect {
+                        try client.stats(query, callback: { paginated, error in
+                            if let e = error {
+                                XCTFail(e.localizedDescription)
+                            }
+                            paginatedResult = paginated as! ARTPaginatedResult<AnyObject>?
+                        })
+                    }.toNot(throwError())
                     expect(paginatedResult).toEventuallyNot(beNil(), timeout: testTimeout)
                     if paginatedResult == nil {
                         return
@@ -282,18 +286,20 @@ class RealtimeClient: QuickSpec {
 
                     // Rest
                     waitUntil(timeout: testTimeout) { done in
-                        try! client.rest.stats(query, callback: { paginated, error in
-                            defer { done() }
-                            if let e = error {
-                                XCTFail(e.localizedDescription)
-                                return
-                            }
-                            guard let paginated = paginated else {
-                                XCTFail("both paginated and error are nil")
-                                return
-                            } 
-                            expect(paginated.items.count).to(equal(paginatedResult!.items.count))
-                        })
+                        expect {
+                            try client.rest.stats(query, callback: { paginated, error in
+                                defer { done() }
+                                if let e = error {
+                                    XCTFail(e.localizedDescription)
+                                    return
+                                }
+                                guard let paginated = paginated else {
+                                    XCTFail("both paginated and error are nil")
+                                    return
+                                } 
+                                expect(paginated.items.count).to(equal(paginatedResult!.items.count))
+                            })
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                 }
             }

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -721,7 +721,7 @@ class RealtimeClient: QuickSpec {
 
                         let authOptions = ARTAuthOptions()
                         authOptions.authCallback = { tokenParams, completion in
-                            completion(getTestTokenDetails(clientId: "tester"), nil)
+                            getTestTokenDetails(clientId: "tester", completion: completion)
                         }
 
                         client.auth.authorize(tokenParams, options: authOptions) { tokenDetails, error in

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2356,7 +2356,7 @@ class RealtimeClientChannel: QuickSpec {
                     it("message should be published following authentication and received back with the clientId intact") {
                         let options = AblyTests.clientOptions()
                         options.authCallback = { tokenParams, completion in
-                            completion(getTestTokenDetails(clientId: "john"), nil)
+                            getTestTokenDetails(clientId: "john", completion: completion)
                         }
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }
@@ -2379,7 +2379,7 @@ class RealtimeClientChannel: QuickSpec {
                     it("message should be rejected by the Ably service and the message error should contain the server error") {
                         let options = AblyTests.clientOptions()
                         options.authCallback = { tokenParams, completion in
-                            completion(getTestTokenDetails(clientId: "john"), nil)
+                            getTestTokenDetails(clientId: "john", completion: completion)
                         }
                         let client = ARTRealtime(options: options)
                         defer { client.dispose(); client.close() }

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2759,17 +2759,21 @@ class RealtimeClientChannel: QuickSpec {
                     let queryRest = queryRealtime as ARTDataQuery
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channelRest.history(queryRest) { _, _ in
-                            done()
-                        }
+                        expect {
+                            try channelRest.history(queryRest) { _, _ in
+                                done()
+                            }
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                     expect(restChannelHistoryMethodWasCalled).to(beTrue())
                     restChannelHistoryMethodWasCalled = false
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channelRealtime.history(queryRealtime) { _, _ in
-                            done()
-                        }
+                        expect {
+                            try channelRealtime.history(queryRealtime) { _, _ in
+                                done()
+                            }
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                     expect(restChannelHistoryMethodWasCalled).to(beTrue())
                 }
@@ -2824,10 +2828,12 @@ class RealtimeClientChannel: QuickSpec {
                             expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
 
                             waitUntil(timeout: testTimeout) { done in
-                                try! channel.history(query) { _, errorInfo in
-                                    expect(errorInfo).to(beNil())
-                                    done()
-                                }
+                                expect {
+                                    try channel.history(query) { _, errorInfo in
+                                        expect(errorInfo).to(beNil())
+                                        done()
+                                    }
+                                }.toNot(throwError() { err in fail("\(err)"); done() })
                             }
 
                             let queryString = testHTTPExecutor.requests.last!.url!.query
@@ -2891,13 +2897,15 @@ class RealtimeClientChannel: QuickSpec {
                         query.untilAttach = true
 
                         waitUntil(timeout: testTimeout) { done in
-                            try! channel2.history(query) { result, errorInfo in
-                                expect(result!.items).to(haveCount(20))
-                                expect(result!.hasNext).to(beFalse())
-                                expect(result!.items.first?.data as? String).to(equal("message 19"))
-                                expect(result!.items.last?.data as? String).to(equal("message 0"))
-                                done()
-                            }
+                            expect {
+                                try channel2.history(query) { result, errorInfo in
+                                    expect(result!.items).to(haveCount(20))
+                                    expect(result!.hasNext).to(beFalse())
+                                    expect(result!.items.first?.data as? String).to(equal("message 19"))
+                                    expect(result!.items.last?.data as? String).to(equal("message 0"))
+                                    done()
+                                }
+                            }.toNot(throwError() { err in fail("\(err)"); done() })
                         }
                     }
 
@@ -2960,22 +2968,24 @@ class RealtimeClientChannel: QuickSpec {
                     query.limit = 10
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channel2.history(query) { result, errorInfo in
-                            expect(result!.items).to(haveCount(10))
-                            expect(result!.hasNext).to(beTrue())
-                            expect(result!.isLast).to(beFalse())
-                            expect((result!.items.first! ).data as? String).to(equal("message 19"))
-                            expect((result!.items.last! ).data as? String).to(equal("message 10"))
-
-                            result!.next { result, errorInfo in
+                        expect {
+                            try channel2.history(query) { result, errorInfo in
                                 expect(result!.items).to(haveCount(10))
-                                expect(result!.hasNext).to(beFalse())
-                                expect(result!.isLast).to(beTrue())
-                                expect((result!.items.first! ).data as? String).to(equal("message 9"))
-                                expect((result!.items.last! ).data as? String).to(equal("message 0"))
-                                done()
+                                expect(result!.hasNext).to(beTrue())
+                                expect(result!.isLast).to(beFalse())
+                                expect((result!.items.first! ).data as? String).to(equal("message 19"))
+                                expect((result!.items.last! ).data as? String).to(equal("message 10"))
+
+                                result!.next { result, errorInfo in
+                                    expect(result!.items).to(haveCount(10))
+                                    expect(result!.hasNext).to(beFalse())
+                                    expect(result!.isLast).to(beTrue())
+                                    expect((result!.items.first! ).data as? String).to(equal("message 9"))
+                                    expect((result!.items.last! ).data as? String).to(equal("message 0"))
+                                    done()
+                                }
                             }
-                        }
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                 }
 

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -245,7 +245,7 @@ class RealtimeClientChannel: QuickSpec {
 
                         let attachedMessage = ARTProtocolMessage()
                         attachedMessage.action = .attached
-                        attachedMessage.channel = "foo"
+                        attachedMessage.channel = channel.name
                         client.transport?.receive(attachedMessage)
                     }
                 }
@@ -383,7 +383,7 @@ class RealtimeClientChannel: QuickSpec {
 
                     let attachedMessage = ARTProtocolMessage()
                     attachedMessage.action = .attached
-                    attachedMessage.channel = "test"
+                    attachedMessage.channel = channel.name
                     attachedMessage.flags = 4 //Resumed
 
                     waitUntil(timeout: testTimeout) { done in
@@ -1391,7 +1391,7 @@ class RealtimeClientChannel: QuickSpec {
                     let start = NSDate()
                     expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
                     expect(channel.errorReason).toNot(beNil())
-                    expect(callbackCalled).to(beTrue())
+                    expect(callbackCalled).toEventually(beTrue(), timeout: testTimeout)
                     let end = NSDate()
                     expect(start.addingTimeInterval(1.0)).to(beCloseTo(end, within: 0.5))
                 }
@@ -2794,10 +2794,10 @@ class RealtimeClientChannel: QuickSpec {
                             try channel.history(query, callback: { _, _ in })
                         }
                         catch let error as NSError {
-                            if (error as? ARTErrorInfo)?.code == ARTRealtimeHistoryError.notAttached.rawValue {
-                                return
+                            if error.code != ARTRealtimeHistoryError.notAttached.rawValue {
+                                fail("Shouldn't raise a global error, got \(error)")
                             }
-                            fail("Shouldn't raise a global error, got \(error)")
+                            return
                         }
                         fail("Should raise an error")
                     }
@@ -3002,7 +3002,7 @@ class RealtimeClientChannel: QuickSpec {
                     waitUntil(timeout: testTimeout) { done in
                         let attachedMessage = ARTProtocolMessage()
                         attachedMessage.action = .attached
-                        attachedMessage.channel = "test"
+                        attachedMessage.channel = channel.name
 
                         hook = channel.testSuite_injectIntoMethod(after: #selector(channel.onChannelMessage(_:))) {
                             done()
@@ -3018,7 +3018,7 @@ class RealtimeClientChannel: QuickSpec {
                     waitUntil(timeout: testTimeout) { done in
                         let attachedMessageWithError = AblyTests.newErrorProtocolMessage()
                         attachedMessageWithError.action = .attached
-                        attachedMessageWithError.channel = "test"
+                        attachedMessageWithError.channel = channel.name
 
                         channel.once(.update) { stateChange in
                             guard let stateChange = stateChange else {
@@ -3061,7 +3061,7 @@ class RealtimeClientChannel: QuickSpec {
                         waitUntil(timeout: testTimeout) { done in
                             let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
                             detachedMessageWithError.action = .detached
-                            detachedMessageWithError.channel = "foo"
+                            detachedMessageWithError.channel = channel.name
 
                             channel.once(.attaching) { stateChange in
                                 guard let error = stateChange?.reason  else {
@@ -3115,7 +3115,7 @@ class RealtimeClientChannel: QuickSpec {
                         waitUntil(timeout: testTimeout) { done in
                             let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
                             detachedMessageWithError.action = .detached
-                            detachedMessageWithError.channel = "foo"
+                            detachedMessageWithError.channel = channel.name
 
                             channel.once(.attaching) { stateChange in
                                 guard let error = stateChange?.reason  else {
@@ -3158,7 +3158,7 @@ class RealtimeClientChannel: QuickSpec {
 
                         let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
                         detachedMessageWithError.action = .detached
-                        detachedMessageWithError.channel = "foo"
+                        detachedMessageWithError.channel = channel.name
 
                         waitUntil(timeout: testTimeout) { done in
                             channel.once(.attaching) { stateChange in
@@ -3204,7 +3204,7 @@ class RealtimeClientChannel: QuickSpec {
 
                         let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
                         detachedMessageWithError.action = .detached
-                        detachedMessageWithError.channel = "foo"
+                        detachedMessageWithError.channel = channel.name
 
                         waitUntil(timeout: testTimeout) { done in
                             let partialDone = AblyTests.splitDone(2, done: done)
@@ -3257,7 +3257,7 @@ class RealtimeClientChannel: QuickSpec {
                         transport.actionsIgnored = [.attached]
                         let detachedMessageWithError = AblyTests.newErrorProtocolMessage()
                         detachedMessageWithError.action = .detached
-                        detachedMessageWithError.channel = "foo"
+                        detachedMessageWithError.channel = channel.name
                         waitUntil(timeout: testTimeout) { done in
                             channel.once(.attaching) { stateChange in
                                 guard let error = stateChange?.reason  else {
@@ -3308,7 +3308,7 @@ class RealtimeClientChannel: QuickSpec {
                     waitUntil(timeout: testTimeout) { done in
                         let errorProtocolMessage = AblyTests.newErrorProtocolMessage()
                         errorProtocolMessage.action = .error
-                        errorProtocolMessage.channel = "foo"
+                        errorProtocolMessage.channel = channel.name
 
                         channel.once(.failed) { stateChange in
                             guard let error = stateChange?.reason else {

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2639,28 +2639,6 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
 
-                // RTN15g
-                it("when the connection resume has failed, all channels should be detached with an error reason") {
-                    let options = AblyTests.commonAppSetup()
-                    options.disconnectedRetryTimeout = 1.0
-
-                    let client = ARTRealtime(options: options)
-                    defer { client.dispose(); client.close() }
-                    let channel = client.channels.get("test")
-
-                    waitUntil(timeout: testTimeout) { done in
-                        channel.attach() { errorInfo in
-                            expect(errorInfo).to(beNil())
-                            done()
-                        }
-                    }
-
-                    client.simulateLostConnectionAndState()
-
-                    expect(channel.state).toEventually(equal(ARTRealtimeChannelState.detached), timeout: testTimeout)
-                    expect(channel.errorReason?.message).to(contain("Unable to recover connection"))
-                }
-
                 // RTN15h
                 context("DISCONNECTED message contains a token error") {
 

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -1463,7 +1463,6 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 expect(newTransport).toNot(beNil())
-                expect(oldTransport).to(beNil())
             }
 
             // RTN11b
@@ -1767,7 +1766,12 @@ class RealtimeClientConnection: QuickSpec {
                     var error: ARTErrorInfo?
                     func ping() {
                         error = nil
-                        client.ping() { error = $0 }
+                        waitUntil(timeout: testTimeout) { done in
+                            client.ping() { e in
+                                error = e
+                                done()
+                            }
+                        }
                     }
 
                     expect(client.connection.state).to(equal(ARTRealtimeConnectionState.initialized))
@@ -2444,6 +2448,7 @@ class RealtimeClientConnection: QuickSpec {
                         options.tokenDetails = getTestTokenDetails(ttl: 5.0)
                         let client = AblyTests.newRealtime(options)
                         defer { client.dispose(); client.close() }
+                        let rest = ARTRest(options: AblyTests.clientOptions(key: options.key!))
 
                         let channel = client.channels.get("test")
                         waitUntil(timeout: testTimeout) { done in
@@ -2505,7 +2510,6 @@ class RealtimeClientConnection: QuickSpec {
                                 partialDone()
                             }
 
-                            let rest = ARTRest(options: AblyTests.clientOptions(key: options.key!))
                             rest.channels.get("test").publish([expectedMessage]) { error in
                                 expect(error).to(beNil())
                                 partialDone()

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -1875,7 +1875,7 @@ class RealtimeClientConnection: QuickSpec {
                     options.autoConnect = false
                     options.disconnectedRetryTimeout = 0.1
                     options.authCallback = { tokenParams, callback in
-                        callback(getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl as! TimeInterval?), nil)
+                        getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: tokenParams.ttl as! TimeInterval?, completion: callback)
                     }
                     let tokenTtl = 3.0
                     options.token = getTestToken(key: options.key, ttl: tokenTtl)
@@ -2642,7 +2642,7 @@ class RealtimeClientConnection: QuickSpec {
                         options.disconnectedRetryTimeout = 1.0
                         options.autoConnect = false
                         options.authCallback = { tokenParams, callback in
-                            callback(getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: TimeInterval(60 * 60)), nil)
+                            getTestTokenDetails(key: options.key, capability: tokenParams.capability, ttl: TimeInterval(60 * 60), completion: callback)
                         }
                         let tokenTtl = 2.0
                         options.token = getTestToken(key: options.key, ttl: tokenTtl)
@@ -3743,7 +3743,9 @@ class RealtimeClientConnection: QuickSpec {
             it("the client may receive a CONNECTED ProtocolMessage from Ably at any point and should emit an UPDATE event") {
                 let options = AblyTests.commonAppSetup()
                 options.authCallback = { _, completion in
-                    completion(getTestToken(key: options.key!, ttl: 35) as NSString, nil)
+                    getTestToken(key: options.key!, ttl: 35) { token in
+                        completion(token as NSString, nil)
+                    }
                 }
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
@@ -3758,7 +3760,9 @@ class RealtimeClientConnection: QuickSpec {
                 expect(client.auth.clientId).to(beNil())
 
                 client.options.authCallback = { _, completion in
-                    completion(getTestToken(key: options.key!, clientId: "tester", ttl: 5) as NSString, nil)
+                    getTestToken(key: options.key!, clientId: "tester", ttl: 5) { token in
+                        completion(token as NSString, nil)
+                    }
                 }
 
                 client.connection.once(.connected) { stateChange in

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -981,7 +981,7 @@ class RealtimeClientPresence: QuickSpec {
                                 transport.replaceAcksWithNacks(reEnterError) { _ in }
 
                                 // Re-entered automatically should fail
-                                AblyTests.queue.async {
+                                AblyTests.extraQueue.async {
                                     channel.presence.subscribe(.enter) { enter in
                                         fail("Should not Enter the local member")
                                     }

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -3505,17 +3505,21 @@ class RealtimeClientPresence: QuickSpec {
                     let queryRest = queryRealtime as ARTDataQuery
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channelRest.presence.history(queryRest) { _, _ in
-                            done()
-                        }
+                        expect {
+                            try channelRest.presence.history(queryRest) { _, _ in
+                                done()
+                            }
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                     expect(restPresenceHistoryMethodWasCalled).to(beTrue())
                     restPresenceHistoryMethodWasCalled = false
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channelRealtime.presence.history(queryRealtime) { _, _ in
-                            done()
-                        }
+                        expect {
+                            try channelRealtime.presence.history(queryRealtime) { _, _ in
+                                done()
+                            }
+                        }.toNot(throwError() { err in fail("\(err)"); done() })
                     }
                     expect(restPresenceHistoryMethodWasCalled).to(beTrue())
                 }
@@ -3636,10 +3640,12 @@ class RealtimeClientPresence: QuickSpec {
                             expect(channel.state).toEventually(equal(ARTRealtimeChannelState.attached), timeout: testTimeout)
 
                             waitUntil(timeout: testTimeout) { done in
-                                try! channel.presence.history(query) { _, errorInfo in
-                                    expect(errorInfo).to(beNil())
-                                    done()
-                                }
+                                expect {
+                                    try channel.presence.history(query) { _, errorInfo in
+                                        expect(errorInfo).to(beNil())
+                                        done()
+                                    }
+                                }.toNot(throwError() { err in fail("\(err)"); done() })
                             }
 
                             let queryString = testHTTPExecutor.requests.last!.url!.query
@@ -3689,13 +3695,15 @@ class RealtimeClientPresence: QuickSpec {
                         query.untilAttach = true
 
                         waitUntil(timeout: testTimeout) { done in
-                            try! channel.presence.history(query) { result, errorInfo in
-                                expect(result!.items).to(haveCount(25))
-                                expect(result!.hasNext).to(beFalse())
-                                expect((result!.items.first)?.clientId).to(equal("user25"))
-                                expect((result!.items.last)?.clientId).to(equal("user1"))
-                                done()
-                            }
+                            expect {
+                                try channel.presence.history(query) { result, errorInfo in
+                                    expect(result!.items).to(haveCount(25))
+                                    expect(result!.hasNext).to(beFalse())
+                                    expect((result!.items.first)?.clientId).to(equal("user25"))
+                                    expect((result!.items.last)?.clientId).to(equal("user1"))
+                                    done()
+                                }
+                            }.toNot(throwError() { err in fail("\(err)"); done() })
                         }
                     }
 

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -811,7 +811,7 @@ class RealtimeClientPresence: QuickSpec {
                                         }
                                     }
                                     // Re-entered automatically
-                                    AblyTests.queue.async {
+                                    AblyTests.extraQueue.async {
                                         channel.presence.subscribe(.enter) { enter in
                                             // The members re-entered automatically must be removed from the internal PresenceMap,
                                             //so it must be a different object
@@ -2175,7 +2175,7 @@ class RealtimeClientPresence: QuickSpec {
                         channel.presenceMap.testSuite_injectIntoMethod(after: #selector(ARTPresenceMap.startSync)) {
                             expect(channel.presenceMap.syncInProgress).to(beTrue())
 
-                            AblyTests.queue.async {
+                            AblyTests.extraQueue.async {
                                 channel.presence.subscribe(.leave) { leave in
                                     expect(leave.clientId).to(equal("user11"))
                                     expect(channel.presenceMap.members.filter{ _, presence in presence.action == .leave }).to(beEmpty())

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -673,9 +673,7 @@ class RestClient: QuickSpec {
                     testHTTPExecutor.http = MockHTTP(network: .hostUnreachable)
                     let channel = client.channels.get("test")
 
-                    var capturedURLs = [String]()
                     testHTTPExecutor.afterRequest = { request, callback in
-                        capturedURLs.append(request.url!.absoluteString)
                         if testHTTPExecutor.requests.count == 2 {
                             // Stop
                             testHTTPExecutor.http = nil
@@ -693,6 +691,7 @@ class RestClient: QuickSpec {
                     if testHTTPExecutor.requests.count < 2 {
                         return
                     }
+                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
                     expect(NSRegularExpression.match(capturedURLs[0], pattern: "//rest.ably.io")).to(beTrue())
                     expect(NSRegularExpression.match(capturedURLs[1], pattern: "//[a-e].ably-realtime.com")).to(beTrue())
                 }
@@ -706,9 +705,7 @@ class RestClient: QuickSpec {
                     testHTTPExecutor.http = MockHTTP(network: .hostUnreachable)
                     let channel = client.channels.get("test")
                     
-                    var capturedURLs = [String]()
                     testHTTPExecutor.afterRequest = { request, callback in
-                        capturedURLs.append(request.url!.absoluteString)
                         if testHTTPExecutor.requests.count == 2 {
                             // Stop
                             testHTTPExecutor.http = nil
@@ -727,6 +724,7 @@ class RestClient: QuickSpec {
                         return
                     }
 
+                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
                     expect(NSRegularExpression.match(capturedURLs[1], pattern: "//[f-j].ably-realtime.com")).to(beTrue())
                 }
 
@@ -740,9 +738,7 @@ class RestClient: QuickSpec {
                     testHTTPExecutor.http = MockHTTP(network: .hostUnreachable)
                     let channel = client.channels.get("test")
 
-                    var capturedURLs = [String]()
                     testHTTPExecutor.afterRequest = { request, callback in
-                        capturedURLs.append(request.url!.absoluteString)
                         if testHTTPExecutor.requests.count == 2 {
                             // Stop
                             testHTTPExecutor.http = nil
@@ -761,6 +757,7 @@ class RestClient: QuickSpec {
                         return
                     }
 
+                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
                     expect(NSRegularExpression.match(capturedURLs[1], pattern: "//[a-e].ably-realtime.com")).to(beTrue())
                 }
 
@@ -793,11 +790,6 @@ class RestClient: QuickSpec {
                     testHTTPExecutor.http = MockHTTP(network: .hostUnreachable)
                     let channel = client.channels.get("test")
                     
-                    var capturedURLs = [String]()
-                    testHTTPExecutor.afterRequest = { request, callback in
-                        capturedURLs.append(request.url!.absoluteString)
-                    }
-                    
                     waitUntil(timeout: testTimeout) { done in
                         channel.publish(nil, data: "nil") { _ in
                             done()
@@ -805,6 +797,7 @@ class RestClient: QuickSpec {
                     }
                     
                     expect(testHTTPExecutor.requests).to(haveCount(1))
+                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
                     expect(NSRegularExpression.match(capturedURLs[0], pattern: "//rest.ably.io")).to(beTrue())
                 }
                 
@@ -817,9 +810,7 @@ class RestClient: QuickSpec {
                     testHTTPExecutor.http = MockHTTP(network: .hostUnreachable)
                     let channel = client.channels.get("test")
                     
-                    var capturedURLs = [String]()
                     testHTTPExecutor.afterRequest = { request, callback in
-                        capturedURLs.append(request.url!.absoluteString)
                         if testHTTPExecutor.requests.count == 2 {
                             // Stop
                             testHTTPExecutor.http = nil
@@ -838,6 +829,7 @@ class RestClient: QuickSpec {
                         return
                     }
                     
+                    let capturedURLs = testHTTPExecutor.requests.map { $0.url!.absoluteString }
                     expect(NSRegularExpression.match(capturedURLs[1], pattern: "//[a-e].ably-realtime.com")).to(beTrue())
                 }
 

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -856,7 +856,7 @@ class RestClient: QuickSpec {
                         }
                     }
 
-                    testHTTPExecutor.http = ARTHttp()
+                    testHTTPExecutor.http = ARTHttp(AblyTests.queue)
 
                     waitUntil(timeout: testTimeout) { done in
                         channel.publish(nil, data: "nil") { _ in
@@ -890,7 +890,7 @@ class RestClient: QuickSpec {
                         }
                     }
 
-                    testHTTPExecutor.http = ARTHttp()
+                    testHTTPExecutor.http = ARTHttp(AblyTests.queue)
 
                     waitUntil(timeout: testTimeout) { done in
                         channel.publish(nil, data: "nil") { _ in
@@ -1318,7 +1318,8 @@ class RestClient: QuickSpec {
             it("client should handle error messages in plaintext and HTML format") {
                 let request = NSURLRequest(url: NSURL(string: "https://www.ably.io")! as URL)
                 waitUntil(timeout: testTimeout) { done in
-                    ARTRest(key: "xxxx:xxxx").execute(request as URLRequest, completion: { response, data, error in
+                    let rest = ARTRest(key: "xxxx:xxxx")
+                    rest.execute(request as URLRequest, completion: { response, data, error in
                         guard let contentType = response?.allHeaderFields["Content-Type"] as? String else {
                             fail("Response should have a Content-Type"); done(); return
                         }

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -414,8 +414,8 @@ class RestClient: QuickSpec {
                             expect(error).to(beNil())
                             expect(result).toNot(beNil())
 
-                            guard let headerErrorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
-                                fail("X-Ably-ErrorCode not found"); done();
+                            guard let headerErrorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-Errorcode"] as? String else {
+                                fail("X-Ably-Errorcode not found"); done();
                                 return
                             }
                             expect(Int(headerErrorCode)).to(equal(40142))
@@ -444,8 +444,8 @@ class RestClient: QuickSpec {
                         expect(errorCode).to(equal(40160))
                         expect(result).to(beNil())
 
-                        guard let headerErrorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
-                            fail("X-Ably-ErrorCode not found"); done();
+                        guard let headerErrorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-Errorcode"] as? String else {
+                            fail("X-Ably-Errorcode not found"); done();
                             return
                         }
                         expect(Int(headerErrorCode)).to(equal(40160))
@@ -513,8 +513,8 @@ class RestClient: QuickSpec {
                             delay(TimeInterval(tokenParams.ttl!)) {
                                 // [40140, 40150) - token expired and will not recover because authUrl is invalid
                                 publishTestMessage(rest) { error in
-                                    guard let errorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
-                                        fail("expected X-Ably-ErrorCode header in request")
+                                    guard let errorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-Errorcode"] as? String else {
+                                        fail("expected X-Ably-Errorcode header in request")
                                         return
                                     }
                                     expect(Int(errorCode)).to(beGreaterThanOrEqualTo(40140))
@@ -562,8 +562,8 @@ class RestClient: QuickSpec {
                             delay(TimeInterval(tokenParams.ttl!)) {
                                 // [40140, 40150) - token expired and will not recover because authUrl is invalid
                                 publishTestMessage(rest) { error in
-                                    guard let errorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-ErrorCode"] as? String else {
-                                        fail("expected X-Ably-ErrorCode header in request")
+                                    guard let errorCode = testHTTPExecutor.responses.first?.allHeaderFields["X-Ably-Errorcode"] as? String else {
+                                        fail("expected X-Ably-Errorcode header in request")
                                         return
                                     }
                                     expect(Int(errorCode)).to(beGreaterThanOrEqualTo(40140))
@@ -861,9 +861,9 @@ class RestClient: QuickSpec {
                         return
                     }
 
-                    expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//\(ARTDefault.restHost())")).to(beTrue())
+                    expect(NSRegularExpression.match(testHTTPExecutor.requests[0].url!.absoluteString, pattern: "//\(ARTDefault.restHost()!)")).to(beTrue())
                     expect(NSRegularExpression.match(testHTTPExecutor.requests[1].url!.absoluteString, pattern: "//[a-e].ably-realtime.com")).to(beTrue())
-                    expect(NSRegularExpression.match(testHTTPExecutor.requests[2].url!.absoluteString, pattern: "//\(ARTDefault.restHost())")).to(beTrue())
+                    expect(NSRegularExpression.match(testHTTPExecutor.requests[2].url!.absoluteString, pattern: "//\(ARTDefault.restHost()!)")).to(beTrue())
                 }
 
                 // RSC15e
@@ -1308,7 +1308,7 @@ class RestClient: QuickSpec {
 
             // https://github.com/ably/ably-ios/issues/589
             it("client should handle error messages in plaintext and HTML format") {
-                let request = NSURLRequest(url: NSURL(string: "https://www.ably.io")! as URL)
+                let request = NSURLRequest(url: NSURL(string: "https://www.example.com")! as URL)
                 waitUntil(timeout: testTimeout) { done in
                     let rest = ARTRest(key: "xxxx:xxxx")
                     rest.execute(request as URLRequest, completion: { response, data, error in

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -252,7 +252,7 @@ class RestClientChannel: QuickSpec {
                     }
 
                     hook.remove()
-                    testHTTPExecutor.http = ARTHttp()
+                    testHTTPExecutor.http = ARTHttp(AblyTests.queue)
 
                     // Remains available
                     waitUntil(timeout: testTimeout) { done in
@@ -281,7 +281,7 @@ class RestClientChannel: QuickSpec {
                         channel.publish([message]) { error in
                             expect(error!.code).to(equal(Int(ARTState.mismatchedClientId.rawValue)))
 
-                            testHTTPExecutor.http = ARTHttp()
+                            testHTTPExecutor.http = ARTHttp(AblyTests.queue)
                             channel.history { page, error in
                                 expect(error).to(beNil())
                                 expect(page!.items).to(haveCount(0))

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -308,7 +308,8 @@ class RestClientChannel: QuickSpec {
             }
 
             // RSL1h, RSL6a2
-            it("should provide an optional argument that allows the extras value to be specified") {
+            pending("should provide an optional argument that allows the extras value to be specified") {
+                // TODO: pushenabled doesn't appear to be working.
                 let client = ARTRest(options: AblyTests.commonAppSetup())
                 let channel = client.channels.get("pushenabled:test")
                 let extras = ["push": ["key": "value"]] as ARTJsonCompatible

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -611,7 +611,14 @@ class RestClientChannel: QuickSpec {
                                 XCTFail("HTTPBody is nil");
                                 done(); return
                             }
-                            expect(AblyTests.msgpackToJSON(httpBody as NSData)).to(equal(caseTest.expected))
+                            var json = AblyTests.msgpackToJSON(httpBody as NSData)
+                            if let s = json["data"].string, let data = try? JSONSerialization.jsonObject(with: s.data(using: .utf8)!) {
+                                // Make sure the formatting is the same by parsing
+                                // and reformatting in the same way as the test
+                                // case.
+                                json["data"] = JSON(JSON(data).rawString()!)
+                            }
+                            expect(json).to(equal(caseTest.expected))
                             done()
                         }
                     }

--- a/Spec/RestClientChannels.swift
+++ b/Spec/RestClientChannels.swift
@@ -36,6 +36,7 @@ class RestClientChannels: QuickSpec {
         beforeEach {
             client = ARTRest(key: "fake:key")
             channelName = ProcessInfo.processInfo.globallyUniqueString
+            ARTChannels_getChannelNamePrefix = { "RestClientChannels-" }
         }
 
         let cipherParams: ARTCipherParams? = nil
@@ -52,7 +53,7 @@ class RestClientChannels: QuickSpec {
                     // RSN3a
                     it("should return a channel") {
                         let channel = client.channels.get(channelName)
-                        expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName)"))
+                        expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName!)"))
 
                         let sameChannel = client.channels.get(channelName)
                         expect(sameChannel).to(beIdenticalTo(channel))
@@ -63,7 +64,7 @@ class RestClientChannels: QuickSpec {
                         let options = ARTChannelOptions(cipher: cipherParams)
                         let channel = client.channels.get(channelName, options: options)
 
-                        expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName)"))
+                        expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName!)"))
                         expect(channel.options).to(beIdenticalTo(options))
                     }
 
@@ -111,7 +112,7 @@ class RestClientChannels: QuickSpec {
                         autoreleasepool {
                             channel = client.channels.get(channelName)
 
-                            expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName)"))
+                            expect(channel).to(beAChannel(named: "\(ARTChannels_getChannelNamePrefix!())-\(channelName!)"))
                             client.channels.release(channel.name)
                         }
 

--- a/Spec/RestClientPresence.swift
+++ b/Spec/RestClientPresence.swift
@@ -112,14 +112,16 @@ class RestClientPresence: QuickSpec {
                     query.clientId = "john"
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channel.presence.get(query) { membersPage, error in
-                            expect(error).to(beNil())
-                            expect(membersPage!.items).to(haveCount(1))
-                            let member = membersPage!.items[0]
-                            expect(member.clientId).to(equal("john"))
-                            expect(member.data as? NSObject).to(equal("web" as NSObject?))
-                            done()
-                        }
+                        expect {
+                            try channel.presence.get(query) { membersPage, error in
+                                expect(error).to(beNil())
+                                expect(membersPage!.items).to(haveCount(1))
+                                let member = membersPage!.items[0]
+                                expect(member.clientId).to(equal("john"))
+                                expect(member.data as? NSObject).to(equal("web" as NSObject?))
+                                done()
+                            }
+                        }.toNot(throwError())
                     }
                 }
 
@@ -156,17 +158,19 @@ class RestClientPresence: QuickSpec {
                     query.connectionId = disposable.last!.connection.id!
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channel.presence.get(query) { membersPage, error in
-                            expect(error).to(beNil())
-                            expect(membersPage!.items).to(haveCount(3))
-                            expect(membersPage!.hasNext).to(beFalse())
-                            expect(membersPage!.isLast).to(beTrue())
-                            expect(membersPage!.items).to(allPass({ member in
-                                let member = member!
-                                return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
-                            }))
-                            done()
-                        }
+                        expect {
+                            try channel.presence.get(query) { membersPage, error in
+                                expect(error).to(beNil())
+                                expect(membersPage!.items).to(haveCount(3))
+                                expect(membersPage!.hasNext).to(beFalse())
+                                expect(membersPage!.isLast).to(beTrue())
+                                expect(membersPage!.items).to(allPass({ member in
+                                    let member = member!
+                                    return NSRegularExpression.match(member.clientId, pattern: "^user(7|8|9)")
+                                }))
+                                done()
+                            }
+                        }.toNot(throwError())
                     }
                 }
 
@@ -261,27 +265,31 @@ class RestClientPresence: QuickSpec {
                         expect(query.direction).to(equal(ARTQueryDirection.backwards))
 
                         waitUntil(timeout: testTimeout) { done in
-                            try! channel.presence.history(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                let firstMember = membersPage!.items.first!
-                                expect(firstMember.clientId).to(equal("user10"))
-                                let lastMember = membersPage!.items.last!
-                                expect(lastMember.clientId).to(equal("user1"))
-                                done()
-                            }
+                            expect {
+                                try channel.presence.history(query) { membersPage, error in
+                                    expect(error).to(beNil())
+                                    let firstMember = membersPage!.items.first!
+                                    expect(firstMember.clientId).to(equal("user10"))
+                                    let lastMember = membersPage!.items.last!
+                                    expect(lastMember.clientId).to(equal("user1"))
+                                    done()
+                                }
+                            }.toNot(throwError())
                         }
 
                         query.direction = .forwards
 
                         waitUntil(timeout: testTimeout) { done in
-                            try! channel.presence.history(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                let firstMember = membersPage!.items.first!
-                                expect(firstMember.clientId).to(equal("user1"))
-                                let lastMember = membersPage!.items.last!
-                                expect(lastMember.clientId).to(equal("user10"))
-                                done()
-                            }
+                            expect {
+                                try channel.presence.history(query) { membersPage, error in
+                                    expect(error).to(beNil())
+                                    let firstMember = membersPage!.items.first!
+                                    expect(firstMember.clientId).to(equal("user1"))
+                                    let lastMember = membersPage!.items.last!
+                                    expect(lastMember.clientId).to(equal("user10"))
+                                    done()
+                                }
+                            }.toNot(throwError())
                         }
                     }
 
@@ -315,13 +323,15 @@ class RestClientPresence: QuickSpec {
                         query.limit = 1
 
                         waitUntil(timeout: testTimeout) { done in
-                            try! channel.presence.history(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                expect(membersPage!.items).to(haveCount(1))
-                                expect(membersPage!.hasNext).to(beFalse())
-                                expect(membersPage!.isLast).to(beTrue())
-                                done()
-                            }
+                            expect {
+                                try channel.presence.history(query) { membersPage, error in
+                                    expect(error).to(beNil())
+                                    expect(membersPage!.items).to(haveCount(1))
+                                    expect(membersPage!.hasNext).to(beFalse())
+                                    expect(membersPage!.isLast).to(beTrue())
+                                    done()
+                                }
+                            }.toNot(throwError())
                         }
 
                         query.limit = 1001
@@ -365,17 +375,19 @@ class RestClientPresence: QuickSpec {
                     query.connectionId = disposable.last!.connection.id!
 
                     waitUntil(timeout: testTimeout) { done in
-                        try! channel.presence.get(query) { membersPage, error in
-                            expect(error).to(beNil())
-                            expect(membersPage!.items).to(haveCount(3))
-                            expect(membersPage!.hasNext).to(beFalse())
-                            expect(membersPage!.isLast).to(beTrue())
-                            expect(membersPage!.items).to(allPass({ member in
-                                let member = member 
-                                return NSRegularExpression.match(member!.clientId, pattern: "^user(7|8|9)")
-                            }))
-                            done()
-                        }
+                        expect {
+                            try channel.presence.get(query) { membersPage, error in
+                                expect(error).to(beNil())
+                                expect(membersPage!.items).to(haveCount(3))
+                                expect(membersPage!.hasNext).to(beFalse())
+                                expect(membersPage!.isLast).to(beTrue())
+                                expect(membersPage!.items).to(allPass({ member in
+                                    let member = member 
+                                    return NSRegularExpression.match(member!.clientId, pattern: "^user(7|8|9)")
+                                }))
+                                done()
+                            }
+                        }.toNot(throwError())
                     }
                 }
 
@@ -442,11 +454,13 @@ class RestClientPresence: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            try! channel.presence.history(query) { membersPage, error in
-                                expect(error).to(beNil())
-                                expect(membersPage!.items).to(haveCount(3))
-                                done()
-                            }
+                            expect {
+                                try channel.presence.history(query) { membersPage, error in
+                                    expect(error).to(beNil())
+                                    expect(membersPage!.items).to(haveCount(3))
+                                    done()
+                                }
+                            }.toNot(throwError())
                         }
                     }
 

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -230,6 +230,17 @@ class AblyTests {
         }
     }
 
+    class func waitFor<T>(timeout: TimeInterval, f: @escaping (@escaping (T?) -> Void) -> Void) -> T? {
+        var value: T?
+        waitUntil(timeout: timeout) { done in
+            f() { v in
+                value = v
+                done()
+            }
+        }
+        return value
+    }
+
     // MARK: Crypto
 
     struct CryptoTestItem {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -94,6 +94,7 @@ class AblyTests {
 
     static var queue = DispatchQueue(label: "io.ably.tests", qos: .userInitiated)
     static var userQueue = DispatchQueue(label: "io.ably.tests.callbacks", qos: .userInitiated)
+    static var extraQueue = DispatchQueue(label: "io.ably.tests.extra", qos: .userInitiated)
 
     class func setupOptions(_ options: ARTClientOptions, forceNewApp: Bool = false, debug: Bool = false) -> ARTClientOptions {
         ARTChannels_getChannelNamePrefix = { "test-\(setupOptionsCounter)" }

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -203,7 +203,7 @@ class Utilities: QuickSpec {
             context("EventEmitter") {
                 
 
-                var eventEmitter = ARTEventEmitter<NSString, AnyObject>()
+                var eventEmitter = ARTInternalEventEmitter<NSString, AnyObject>(queue: AblyTests.queue)
                 var receivedFoo1: Int?
                 var receivedFoo2: Int?
                 var receivedBar: Int?
@@ -214,7 +214,7 @@ class Utilities: QuickSpec {
                 weak var listenerAll: ARTEventListener?
                 
                 beforeEach {
-                    eventEmitter = ARTEventEmitter()
+                    eventEmitter = ARTInternalEventEmitter(queue: AblyTests.queue)
                     receivedFoo1 = nil
                     receivedFoo2 = nil
                     receivedBar = nil

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -49,7 +49,7 @@ class Utilities: QuickSpec {
                     expect{ result = try jsonEncoder.encode(pm) }.to(throwError { error in
                         let e = error as NSError
                         expect(e.domain).to(equal(ARTAblyErrorDomain))
-                        expect((e as! ARTErrorInfo).code).to(equal(Int(ARTClientCodeError.invalidType.rawValue)))
+                        expect(e.code).to(equal(Int(ARTClientCodeError.invalidType.rawValue)))
                         expect(e.localizedDescription).to(contain("Invalid type in JSON write"))
                         })
                     expect(result).to(beNil())


### PR DESCRIPTION
**Work in progress!** There are still some deadlocks around. The test suite is pretty broken right now.

This change makes the library thread-safe. Users can call all methods and access
all properties from whatever thread they want.

To achieve this, this is the general strategy used:

* We have a serial queue where all our code runs.
* To ensure all our code runs in the serial queue, we need to dispatch to it
  from all entry points, namely:
  - User code: all public methods use
  - HTTP requests: all HTTP responses are handled at the same place and dispatched there.
  - Reachability callback from the OS.
  - Events dispatches/timeouts from ARTEventEmitter, which use NSNotificationCenter under the hood: all are dispatched to the queue.
  - WebSocket incoming messages: we set the queue as delegate using SocketRocket's `setDelegateQueue`.
* By default, the queue's delegate is the global queue with QOS_CLASS_BACKGROUND. So all our operations will be very low-priority, which I think is the right choice for Ably. The user can change this by specifying `ARTClientOptions.internalDispatchQueue`.
* Additionally, callbacks provided from the user are dispatched to another queue, which by default is the main queue. This is a convenience, since they probably want to react to Ably's callbacks by updating the UI, which only can be done from the main queue. This can be overriden too, with `ARTClientOptions.dispatchQueue`.
* Public, mutable properties (e. g. connection and channel state) need always to be read and written to from the queue. This is pretty annoying since those reads need to be synchronous, since we're offering a synchronous interface. A synchronous dispatch to a queue is annoying since you can't do it if you're in the queue already, so, from within the queue (ie. from our code) we need to read those properties without the sync dispatch. So those get an additional `<property name>_nosync` getter. Pretty clumsy but, well, this is Objective-C.
* Some public methods don't go async right away, since they have some effects that need to be done right after the call, or need to return something. For instance, `attach` leaves the channel in the ATTACHING state synchronously. Similarly to public, mutable properties as described above, those method get an additional method without the sync dispatch, to use from inside our code.