### PR TITLE
Reuse connection when receiving an AUTH.

### DIFF
--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -412,6 +412,9 @@ class RealtimeClient: QuickSpec {
                             expect(accessToken).toNot(equal(firstToken))
                             expect(tokenDetails.token).toNot(equal(firstToken))
                             expect(tokenDetails.token).to(equal(accessToken))
+
+                            expect(client.transport).to(beIdenticalTo(transport))
+
                             done()
                         }
                     }


### PR DESCRIPTION
Fixes #622.

The test suite has a few broken tests. I don't think they're caused by
this change, although I haven't checked. We probably should take a
deeper look at them before doing a release.