### PR TITLE
Add jwt tests

### DIFF
--- a/Source/ARTAuth.m
+++ b/Source/ARTAuth.m
@@ -359,7 +359,7 @@ ART_TRY_OR_REPORT_CRASH_START(_rest) {
             callback(tokenDetails, nil);
         }
     }
-    else if ([response.MIMEType isEqualToString:@"text/plain"]) {
+    else if ([response.MIMEType isEqualToString:@"text/plain"] || [response.MIMEType isEqualToString:@"application/jwt"]) {
         NSString *token = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         if ([token isEqualToString:@""]) {
             callback(nil, [NSError errorWithDomain:ARTAblyErrorDomain code:NSURLErrorCancelled userInfo:@{NSLocalizedDescriptionKey:@"authUrl: token is empty"}]);

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -706,7 +706,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
             return;
         }
         [self.connection setId:nil];
-        [self transition:ARTRealtimeFailed withErrorInfo:error];
+        [self transition:ARTRealtimeFailed withErrorInfo:message.error];
     }
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3718,20 +3718,14 @@ class Auth : QuickSpec {
                     it ("receives a 40142 error from the server") {
                         waitUntil(timeout: testTimeout) { done in
                             client.connection.once(.connected) { stateChange in
-                                delay(tokenDuration + 1) {
+                                client.connection.once(.disconnected) { stateChange in
+                                    expect(stateChange!.reason!.code).to(equal(40142))
+                                    expect(stateChange!.reason!.description).to(contain("Key/token status changed (expire)"))
                                     done()
                                 }
                             }
                             client.connect()
                         }
-                        waitUntil(timeout: testTimeout) { done in
-                            client.connection.once(.disconnected) { stateChange in
-                                expect(stateChange!.reason!.code).to(equal(40142))
-                                expect(stateChange!.reason!.description).to(contain("Key/token status changed (expire)"))
-                                done()
-                            }
-                        }
-
                     }
                 }
                 

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3849,5 +3849,38 @@ class Auth : QuickSpec {
                 }
             }
         }
+        
+        describe("JWT and rest") {
+            let options = AblyTests.clientOptions()
+            
+            context("when the JWT token embeds an Ably token") {
+                options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded")!)
+                let client = ARTRest(options: options)
+                
+                it ("pulls stats successfully") {
+                    waitUntil(timeout: testTimeout) { done in
+                        client.stats{ stats, error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                }
+            }
+            
+            context("when the JWT token embeds an Ably token and it is requested as encrypted") {
+                options.tokenDetails = ARTTokenDetails(token: getJWTToken(jwtType: "embedded", encrypted: 1)!)
+                let client = ARTRest(options: options)
+                
+                it ("pulls stats successfully") {
+                    waitUntil(timeout: testTimeout) { done in
+                        client.stats{ stats, error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                }
+            }
+            
+        }
     }
 }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3906,6 +3906,26 @@ class Auth : QuickSpec {
                 }
             }
             
+            context("when the JWT token is returned with application/jwt content tye") {
+                
+                it("the client successfully connects and pulls stats") {
+                    let options = AblyTests.clientOptions()
+                    let keys = getKeys()
+                    options.authUrl = NSURL(string: echoServerAddress)! as URL
+                    options.authParams = [URLQueryItem]() as [URLQueryItem]?
+                    options.authParams?.append(URLQueryItem(name: "keyName", value: keys["keyName"]) as URLQueryItem)
+                    options.authParams?.append(URLQueryItem(name: "keySecret", value: keys["keySecret"]) as URLQueryItem)
+                    options.authParams?.append(URLQueryItem(name: "returnType", value: "jwt") as URLQueryItem)
+                    let client = ARTRest(options: options)
+                    
+                    waitUntil(timeout: testTimeout) { done in
+                        client.stats{ stats, error in
+                            expect(error).to(beNil())
+                            done()
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3662,7 +3662,7 @@ class Auth : QuickSpec {
             }
 
             // RSA8g RSA8c
-            context("when using auth_url") {
+            context("when using authUrl") {
                 let options = AblyTests.clientOptions()
                 let keys = getKeys()
                 options.autoConnect = false
@@ -3908,7 +3908,7 @@ class Auth : QuickSpec {
             }
             
             // RSA4f, RSA8c
-            context("when the JWT token is returned with application/jwt content tye") {
+            context("when the JWT token is returned with application/jwt content type") {
                 let options = AblyTests.clientOptions()
                 let keys = getKeys()
                 options.authUrl = NSURL(string: echoServerAddress)! as URL

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3634,7 +3634,7 @@ class Auth : QuickSpec {
 
                     it("pulls stats successfully") {
                         waitUntil(timeout: testTimeout) { done in
-                            client.stats{ stats, error in
+                            client.stats { stats, error in
                                 expect(error).to(beNil())
                                 done()
                             }
@@ -3776,7 +3776,7 @@ class Auth : QuickSpec {
 
                     it("pulls stats successfully") {
                         waitUntil(timeout: testTimeout) { done in
-                            client.stats{ stats, error in
+                            client.stats { stats, error in
                                 expect(error).to(beNil())
                                 done()
                             }
@@ -3887,7 +3887,7 @@ class Auth : QuickSpec {
                 
                 it ("pulls stats successfully") {
                     waitUntil(timeout: testTimeout) { done in
-                        client.stats{ stats, error in
+                        client.stats { stats, error in
                             expect(error).to(beNil())
                             done()
                         }
@@ -3901,7 +3901,7 @@ class Auth : QuickSpec {
                 
                 it ("pulls stats successfully") {
                     waitUntil(timeout: testTimeout) { done in
-                        client.stats{ stats, error in
+                        client.stats { stats, error in
                             expect(error).to(beNil())
                             done()
                         }
@@ -3922,7 +3922,7 @@ class Auth : QuickSpec {
                 
                 it("the client successfully connects and pulls stats") {
                     waitUntil(timeout: testTimeout) { done in
-                        client.stats{ stats, error in
+                        client.stats { stats, error in
                             expect(error).to(beNil())
                             done()
                         }
@@ -3935,7 +3935,7 @@ class Auth : QuickSpec {
                             let newClientOptions = AblyTests.clientOptions()
                             newClientOptions.token = tokenDetails!.token
                             let newClient = ARTRest(options: newClientOptions)
-                            newClient.stats{ stats, error in
+                            newClient.stats { stats, error in
                                 expect(error).to(beNil())
                                 done()
                             }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3677,9 +3677,13 @@ class Auth : QuickSpec {
                     defer { client.dispose(); client.close() }
 
                     it("fetches a channels and posts a message") {
-                        client.channels.get(channelName).publish(messageName, data: nil, callback: { error in
-                            expect(error).to(beNil())
-                        })
+                        waitUntil(timeout: testTimeout) { done in
+                            client.channels.get(channelName).publish(messageName, data: nil, callback: { error in
+                                expect(error).to(beNil())
+                                done()
+                            })
+                            client.connect()
+                        }
                     }
                 }
 

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -239,7 +239,7 @@ class Auth : QuickSpec {
                             guard let error = error else {
                                 fail("Error is nil"); done(); return
                             }
-                            expect(UInt(error.code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                            expect(error.code).to(equal(40142))
                             expect(realtime.connection.state).to(equal(ARTRealtimeConnectionState.failed))
                             done()
                         }
@@ -3617,6 +3617,8 @@ class Auth : QuickSpec {
                 it("rejects non-object JSON") {
                     expect{try ARTTokenDetails.fromJson("[]" as ARTJsonCompatible)}.to(throwError())
                 }
+            }
+        }
             }
         }
     }

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3842,7 +3842,6 @@ class Auth : QuickSpec {
                 let clientId = "JWTClientId"
                 let options = AblyTests.clientOptions()
                 options.tokenDetails = ARTTokenDetails(token: getJWTToken(clientId: clientId)!)
-                options.autoConnect = false
                 let client = ARTRealtime(options: options)
                 defer { client.dispose(); client.close() }
                 

--- a/Spec/Auth.swift
+++ b/Spec/Auth.swift
@@ -3661,6 +3661,7 @@ class Auth : QuickSpec {
                 }
             }
 
+            // RSA8g RSA8c
             context("when using auth_url") {
                 let options = AblyTests.clientOptions()
                 let keys = getKeys()
@@ -3730,6 +3731,7 @@ class Auth : QuickSpec {
                     }
                 }
                 
+                // RTC8a4
                 context("when the server sends and AUTH protocol message") {
                     it("client reauths correctly without going through a disconnection") {
                         // The server sends an AUTH protocol message 30 seconds before a token expires
@@ -3760,6 +3762,7 @@ class Auth : QuickSpec {
                 }
             }
 
+            // RSA8g
             context("when using authCallback") {
                 let options = AblyTests.clientOptions()
 
@@ -3875,6 +3878,7 @@ class Auth : QuickSpec {
             }
         }
         
+        // RSC1 RSC1a RSC1c RSA3d
         describe("JWT and rest") {
             let options = AblyTests.clientOptions()
             
@@ -3906,6 +3910,7 @@ class Auth : QuickSpec {
                 }
             }
             
+            // RSA4f, RSA8c
             context("when the JWT token is returned with application/jwt content tye") {
                 let options = AblyTests.clientOptions()
                 let keys = getKeys()

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2011,7 +2011,7 @@ class RealtimeClientConnection: QuickSpec {
                                 guard let errorInfo = errorInfo else {
                                     fail("ErrorInfo is nil"); done(); return
                                 }
-                                expect(UInt(errorInfo.code)).to(equal(ARTState.requestTokenFailed.rawValue))
+                                expect(errorInfo.code).to(equal(40142))
                                 done()
                             default:
                                 break

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -505,8 +505,8 @@ func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String 
         keySecret = "invalid"
     }
 
-    var URLCcomponents = URLComponents(string: echoServerAddress)
-    URLCcomponents?.queryItems = [
+    var urlComponents = URLComponents(string: echoServerAddress)
+    urlComponents?.queryItems = [
         URLQueryItem(name: "keyName", value: keyName),
         URLQueryItem(name: "keySecret", value: keySecret),
         URLQueryItem(name: "expiresIn", value: String(expiresIn)),
@@ -516,7 +516,7 @@ func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String 
         URLQueryItem(name: "encrypted", value: String(encrypted)),
     ]
     
-    let request = NSMutableURLRequest(url: URLCcomponents!.url!)
+    let request = NSMutableURLRequest(url: urlComponents!.url!)
     let (responseData, responseError, _) = NSURLSessionServerTrustSync().get(request)
     if let error = responseError {
         fail(error.localizedDescription)

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -43,7 +43,7 @@ let appSetupJson = JSON(parseJSON: try! String(contentsOfFile: pathForTestResour
 
 let testTimeout: TimeInterval = 10.0
 let testResourcesPath = "ably-common/test-resources/"
-let echoServerAddress = "https://shrouded-plains-50367.herokuapp.com/createJWT" // TODO: change this
+let echoServerAddress = "https://echo.ably.io/createJWT"
 
 /// Common test utilities.
 class AblyTests {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -518,7 +518,7 @@ func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String 
         URLQueryItem(name: "keyName", value: keyName),
         URLQueryItem(name: "keySecret", value: keySecret),
         URLQueryItem(name: "expiresIn", value: String(expiresIn)),
-        URLQueryItem(name: "client_id", value: clientId),
+        URLQueryItem(name: "clientId", value: clientId),
         URLQueryItem(name: "capability", value: capability),
         URLQueryItem(name: "jwtType", value: jwtType),
         URLQueryItem(name: "encrypted", value: String(encrypted)),

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -503,7 +503,7 @@ func encodeString(_ input: String) -> String? {
     return nil
 }
 
-func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String = "testClientIDiOS", capability: String = "{\"*\":[\"*\"]}", jwtType: String = "", embedded: Int = 0) -> String? {
+func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String = "testClientIDiOS", capability: String = "{\"*\":[\"*\"]}", jwtType: String = "", encrypted: Int = 0) -> String? {
     let options = AblyTests.commonAppSetup()
     guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, var keySecret = components.last else {
         fail("Invalid API key: \(options.key ?? "nil")")
@@ -521,7 +521,7 @@ func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String 
         URLQueryItem(name: "client_id", value: clientId),
         URLQueryItem(name: "capability", value: capability),
         URLQueryItem(name: "jwtType", value: jwtType),
-        URLQueryItem(name: "embedded", value: String(embedded)),
+        URLQueryItem(name: "encrypted", value: String(encrypted)),
     ]
     
     let request = NSMutableURLRequest(url: URLCcomponents!.url!)

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -495,14 +495,6 @@ func getTestTokenDetails(key: String? = nil, clientId: String? = nil, capability
     return tokenDetails
 }
 
-func encodeString(_ input: String) -> String? {
-    let allowedQueryParamAndKey =  CharacterSet(charactersIn: "{}[]*: ")
-   if let encodedString_ = input.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) {
-        return encodedString_
-    }
-    return nil
-}
-
 func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String = "testClientIDiOS", capability: String = "{\"*\":[\"*\"]}", jwtType: String = "", encrypted: Int = 0) -> String? {
     let options = AblyTests.commonAppSetup()
     guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, var keySecret = components.last else {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -43,6 +43,7 @@ let appSetupJson = JSON(parseJSON: try! String(contentsOfFile: pathForTestResour
 
 let testTimeout: TimeInterval = 10.0
 let testResourcesPath = "ably-common/test-resources/"
+let echoServerAddress = "https://shrouded-plains-50367.herokuapp.com/createJWT" // TODO: change this
 
 /// Common test utilities.
 class AblyTests {
@@ -492,6 +493,52 @@ func getTestTokenDetails(key: String? = nil, clientId: String? = nil, capability
         fail(e.localizedDescription, file: file, line: line)
     }
     return tokenDetails
+}
+
+func encodeString(_ input: String) -> String? {
+    let allowedQueryParamAndKey =  CharacterSet(charactersIn: "{}[]*: ")
+   if let encodedString_ = input.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey) {
+        return encodedString_
+    }
+    return nil
+}
+
+func getJWTToken(invalid: Bool = false, expiresIn: Int = 3600, clientId: String = "testClientIDiOS", capability: String = "{\"*\":[\"*\"]}", jwtType: String = "", embedded: Int = 0) -> String? {
+    let options = AblyTests.commonAppSetup()
+    guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, var keySecret = components.last else {
+        fail("Invalid API key: \(options.key ?? "nil")")
+        return nil
+    }
+    if (invalid) {
+        keySecret = "invalid"
+    }
+
+    var URLCcomponents = URLComponents(string: echoServerAddress)
+    URLCcomponents?.queryItems = [
+        URLQueryItem(name: "keyName", value: keyName),
+        URLQueryItem(name: "keySecret", value: keySecret),
+        URLQueryItem(name: "expiresIn", value: String(expiresIn)),
+        URLQueryItem(name: "client_id", value: clientId),
+        URLQueryItem(name: "capability", value: capability),
+        URLQueryItem(name: "jwtType", value: jwtType),
+        URLQueryItem(name: "embedded", value: String(embedded)),
+    ]
+    
+    let request = NSMutableURLRequest(url: URLCcomponents!.url!)
+    let (responseData, responseError, _) = NSURLSessionServerTrustSync().get(request)
+    if let error = responseError {
+        fail(error.localizedDescription)
+        return nil
+    }
+    return String(data: responseData!, encoding: String.Encoding.utf8)
+}
+
+func getKeys() -> Dictionary<String, String> {
+    let options = AblyTests.commonAppSetup()
+    guard let components = options.key?.components(separatedBy: ":"), let keyName = components.first, let keySecret = components.last else {
+        fatalError("Invalid API key)")
+    }
+    return ["keyName": keyName, "keySecret": keySecret]
 }
 
 public func delay(_ seconds: TimeInterval, closure: @escaping ()->()) {


### PR DESCRIPTION
Fix #713 

- [x] Remove old test
- [x] Add tests that use `authURL`
- [x] Add tests that use `ClientOptions`
- [x] Add tests that use `authCallback`
- [x] Add tests for automatic renewal
- [x] Add tests with JWT wrapping an Ably native token `x-ably-token`
- [x] Add tests with encrypted token
- [x] Add tests with JWT that includes TokenDetails in `x-ably-capability`
- [x] Add test for token returned with `application/jwt` content type
- [x] Add refs to spec items
- [x] Investigate RSA4b issue. See https://github.com/ably/ably-ios/pull/714#discussion_r192783902
- [x] Change URL of `auth_url` when echo server is deployed. See TODOs