### PR TITLE
Enforce new connection when last activity > than (idle interval + TTL)

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -388,7 +388,6 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
                     [self.connection setId:nil];
                     [self.connection setKey:nil];
                     [self.connection setSerial:0];
-                    _transport = nil;
                 }
             }
             

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -227,7 +227,10 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 }
 
 - (void)_connect {
-    if(self.connection.state_nosync == ARTRealtimeClosing) {
+    NSTimeInterval intervalSinceLast = [[NSDate date] timeIntervalSinceDate:_lastActivity];
+    
+    // We want to enforce a new connection also when there hasn't been activity for longer than (idle interval + TTL)
+    if(self.connection.state_nosync == ARTRealtimeClosing || intervalSinceLast > (_maxIdleInterval + _connectionStateTtl)) {
         // New connection
         _transport = nil;
     }

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -227,12 +227,17 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 }
 
 - (void)_connect {
-    NSTimeInterval intervalSinceLast = [[NSDate date] timeIntervalSinceDate:_lastActivity];
-    
-    // We want to enforce a new connection also when there hasn't been activity for longer than (idle interval + TTL)
-    if(self.connection.state_nosync == ARTRealtimeClosing || intervalSinceLast > (_maxIdleInterval + _connectionStateTtl)) {
+    if(self.connection.state_nosync == ARTRealtimeClosing) {
         // New connection
         _transport = nil;
+    }
+    
+    // We want to enforce a new connection also when there hasn't been activity for longer than (idle interval + TTL)
+    NSTimeInterval intervalSinceLast = [[NSDate date] timeIntervalSinceDate:_lastActivity];
+    if (intervalSinceLast > (_maxIdleInterval + _connectionStateTtl)) {
+        [self.connection setId:nil];
+        [self.connection setKey:nil];
+        [self.connection setSerial:0];
     }
     [self transition:ARTRealtimeConnecting];
 }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2712,8 +2712,7 @@ class RealtimeClientConnection: QuickSpec {
                                     client.connection.once(.connecting) { _ in
                                         client.connection.once(.connected) { _ in
                                             expect(client.connection.id).toNot(equal(connectionId))
-                                            let newChannel = client.channels.get(channelName)
-                                            newChannel.once(.attached) { _ in
+                                            channel.once(.attached) { _ in
                                                 done()
                                             }
                                         }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2653,12 +2653,12 @@ class RealtimeClientConnection: QuickSpec {
                 // RTN15g RTN15g1
                 context("when connection (ttl + idle interval) period has passed since last activity") {
                     let options = AblyTests.commonAppSetup()
+                    // We want this to be > than the sum of customTtlInterval and customIdleInterval
+                    options.disconnectedRetryTimeout = 5.0
                     var client: ARTRealtime!
                     var connectionId = ""
                     let customTtlInterval: TimeInterval = 1.0
                     let customIdleInterval: TimeInterval = 1.0
-                    // We want this to be > than the sum of the two above
-                    let reconnectAfterInterval: TimeInterval = 5.0
                     
                     it("uses a new connection") {
                         client = AblyTests.newRealtime(options)
@@ -2682,9 +2682,6 @@ class RealtimeClientConnection: QuickSpec {
                                             expect(client.connection.id).toNot(equal(connectionId))
                                             done()
                                         }
-                                    }
-                                    delay(reconnectAfterInterval) {
-                                        client.connect()
                                     }
                                 }
                                 client.onDisconnected()
@@ -2719,9 +2716,6 @@ class RealtimeClientConnection: QuickSpec {
                                             }
                                         }
                                     }
-                                    delay(reconnectAfterInterval) {
-                                        client.connect()
-                                    }
                                 }
                                 client.onDisconnected()
                             }
@@ -2731,14 +2725,12 @@ class RealtimeClientConnection: QuickSpec {
                 
                 // RTN15g2
                 context("when connection (ttl + idle interval) period has NOT passed since last activity") {
-                    
                     let options = AblyTests.commonAppSetup()
+                    options.disconnectedRetryTimeout = 5.0
                     var client: ARTRealtime!
                     var connectionId = ""
                     let customTtlInterval: TimeInterval = 20.0
                     let customIdleInterval: TimeInterval = 20.0
-                    // We want this to be < than the sum of the two above and < testTimeout
-                    let reconnectAfterInterval: TimeInterval = 5.0
                     
                     it("uses the same connection") {
                         client = AblyTests.newRealtime(options)
@@ -2762,9 +2754,6 @@ class RealtimeClientConnection: QuickSpec {
                                             expect(client.connection.id).to(equal(connectionId))
                                             done()
                                         }
-                                    }
-                                    delay(reconnectAfterInterval) {
-                                        client.connect()
                                     }
                                 }
                                 client.onDisconnected()

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2650,7 +2650,7 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
                 
-                // RTN15g
+                // RTN15g RTN15g1
                 context("when connection (ttl + idle interval) period has passed since last activity") {
                     let options = AblyTests.commonAppSetup()
                     var client: ARTRealtime!
@@ -2690,7 +2690,7 @@ class RealtimeClientConnection: QuickSpec {
                             }
                         }
                     }
-                    
+                    // RTN15g3
                     it("reattaches to the same channels after a new connection has been established") {
                         client = AblyTests.newRealtime(options)
                         client.connect()
@@ -2728,7 +2728,7 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
                 
-                // RTN15g
+                // RTN15g2
                 context("when connection (ttl + idle interval) period has NOT passed since last activity") {
                     
                     let options = AblyTests.commonAppSetup()

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3425,7 +3425,7 @@ class RealtimeClientConnection: QuickSpec {
                             guard let error = stateChange?.reason else {
                                 fail("Error is nil"); done(); return
                             }
-                            expect(error.message).to(contain("bad response"))
+                            expect(error.message).to(contain("Invalid key"))
                             done()
                         }
                     }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2663,6 +2663,7 @@ class RealtimeClientConnection: QuickSpec {
                     it("uses a new connection") {
                         client = AblyTests.newRealtime(options)
                         client.connect()
+                        defer { client.close() }
                         
                         waitUntil(timeout: testTimeout) { done in
                             client.connection.once(.connected) { _ in
@@ -2694,6 +2695,7 @@ class RealtimeClientConnection: QuickSpec {
                     it("reattaches to the same channels after a new connection has been established") {
                         client = AblyTests.newRealtime(options)
                         client.connect()
+                        defer { client.close() }
                         let channelName = "test-reattach-after-ttl"
                         let channel = client.channels.get(channelName)
                         
@@ -2741,6 +2743,7 @@ class RealtimeClientConnection: QuickSpec {
                     it("uses the same connection") {
                         client = AblyTests.newRealtime(options)
                         client.connect()
+                        defer { client.close() }
                         
                         waitUntil(timeout: testTimeout) { done in
                             client.connection.once(.connected) { _ in


### PR DESCRIPTION
Enforces a new connection when the last activity is > than `(_maxIdleInterval + _connectionStateTtl)`

Mimics [this behavior in JS](https://github.com/ably/ably-js/blob/c55b4518d6f096e4bde90afcd04c5ba35d466f3c/common/lib/transport/connectionmanager.js#L702-L712), called when [a connection gets started](https://github.com/ably/ably-js/blob/master/common/lib/transport/connectionmanager.js#L1039).

cc @paddybyers 