### PR TITLE
Remove filter on Travis branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,3 @@ script:
   - fastlane $LANE
 after_success:
   - sleep 5
-
-branches:
-  only:
-  - develop


### PR DESCRIPTION
Travis doesn't seem to kick in when PRs are made not against develop. Let's remove the filter on the branch name.