### PR TITLE
Build Carthage dependencies only for iOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   # CocoaPods
   - pod install
   # Carthage
-  - carthage bootstrap
+  - carthage bootstrap --platform iOS
   # Update fastlane
   - gem install fastlane -v '2.80.0'
 before_script:


### PR DESCRIPTION
This should speed up quite a lot the bootstrap of Carthage dependencies.