### PR TITLE
Add test for TM2a

### DIFF
--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -238,8 +238,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
 
     if ([request isKindOfClass:[NSMutableURLRequest class]]) {
         NSMutableURLRequest *mutableRequest = (NSMutableURLRequest *)request;
-        NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
-        [mutableRequest setValue:accept forHTTPHeaderField:@"Accept"];
+        [mutableRequest setValue:[[self defaultEncoder] mimeType] forHTTPHeaderField:@"Accept"];
         [mutableRequest setValue:[ARTDefault version] forHTTPHeaderField:@"X-Ably-Version"];
         [mutableRequest setValue:[ARTDefault libraryVersion] forHTTPHeaderField:@"X-Ably-Lib"];
         [mutableRequest setTimeoutInterval:_options.httpRequestTimeout];

--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -3464,7 +3464,27 @@ class RealtimeClientChannel: QuickSpec {
                     }
                 }
             }
-
+        }
+        
+        describe("message attributes") {
+            
+            // TM2a
+            it("if the message does not contain an id, it should be set to protocolMsgId:index") {
+                let client = ARTRealtime(options: AblyTests.commonAppSetup())
+                defer { client.dispose(); client.close() }
+                let p = ARTProtocolMessage()
+                p.id = "protocolId"
+                let m = ARTMessage(name: nil, data: "message without ID")
+                p.messages = [m]
+                let channel = client.channels.get(NSUUID().uuidString)
+                waitUntil(timeout: testTimeout) { done in
+                    channel.subscribe{ message in
+                        expect(message.id).to(equal("protocolId:0"))
+                        done()
+                    }
+                    channel.onMessage(p)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
```
(TM2a) id string – unique ID for this message. This attribute is always populated for messages received over REST. For messages received over Realtime, if the message does not contain an id, it should be set to protocolMsgId:index, where protocolMsgId is the id of the ProtocolMessage encapsulating it, and index is the index of the message inside the messages array of the ProtocolMessage
```