### PR TITLE
Add test for RTE6a

### DIFF
--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -393,7 +393,7 @@ class Utilities: QuickSpec {
                 context("set of listeners") {
                     
                     // RTE6a
-                    fit("should not change over the course of the emit") {
+                    it("should not change over the course of the emit") {
                         var firstCallbackCalled = false;
                         var secondCallbackCalled = false;
                         eventEmitter.on("a", callback: { _ in

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -389,6 +389,24 @@ class Utilities: QuickSpec {
                         }
                     }
                 }
+                
+                context("set of listeners") {
+                    
+                    // RTE6a
+                    fit("should not change over the course of the emit") {
+                        var firstCallbackCalled = false;
+                        var secondCallbackCalled = false;
+                        eventEmitter.on("a", callback: { _ in
+                            firstCallbackCalled = true
+                            eventEmitter.on("b", callback: { _ in
+                                secondCallbackCalled = true
+                            })
+                        })
+                        eventEmitter.emit("a", with: "123" as AnyObject?)
+                        expect(firstCallbackCalled).to(beTrue())
+                        expect(secondCallbackCalled).to(beFalse())
+                    }
+                }
             }
 
             context("Logger") {


### PR DESCRIPTION
`(RTE6a) The set of listeners called by emit must not change over the course of the emit. That is: If a listener being called by emit registers another listener, that second listener should not be called by that invocation of emit (even if it would have been called had it already been present); and if a listener being called by emit removes other listeners, but those other listeners would otherwise have been called during that emit invocation, they should still be called. Tests should exist for both adding and removing. See https://goo.gl/OVTtjO`