### PR TITLE
Add tp3a test

### DIFF
--- a/Source/ARTDefault+Private.h
+++ b/Source/ARTDefault+Private.h
@@ -12,5 +12,6 @@
 
 + (void)setRealtimeRequestTimeout:(NSTimeInterval)value;
 + (void)setConnectionStateTtl:(NSTimeInterval)value;
++ (void)setMaxMessageSize:(NSInteger)value;
 
 @end

--- a/Source/ARTDefault.h
+++ b/Source/ARTDefault.h
@@ -37,4 +37,6 @@
 
 + (NSString *)libraryVersion;
 
++ (NSInteger)maxMessageSize;
+
 @end

--- a/Source/ARTDefault.m
+++ b/Source/ARTDefault.m
@@ -20,6 +20,7 @@ NSString *const ARTDefault_platform = @"ios-";
 
 static NSTimeInterval _realtimeRequestTimeout = 10.0;
 static NSTimeInterval _connectionStateTtl = 60.0;
+static NSInteger _maxMessageSize = 65536;
 
 + (NSArray*)fallbackHosts {
     return @[@"a.ably-realtime.com", @"b.ably-realtime.com", @"c.ably-realtime.com", @"d.ably-realtime.com", @"e.ably-realtime.com"];
@@ -57,6 +58,10 @@ static NSTimeInterval _connectionStateTtl = 60.0;
     return _realtimeRequestTimeout;
 }
 
++ (NSInteger)maxMessageSize {
+    return _maxMessageSize;
+}
+
 + (void)setRealtimeRequestTimeout:(NSTimeInterval)value {
     @synchronized (self) {
         _realtimeRequestTimeout = value;
@@ -66,6 +71,12 @@ static NSTimeInterval _connectionStateTtl = 60.0;
 + (void)setConnectionStateTtl:(NSTimeInterval)value {
     @synchronized (self) {
         _connectionStateTtl = value;
+    }
+}
+
++ (void)setMaxMessageSize:(NSInteger)value {
+    @synchronized (self) {
+        _maxMessageSize = value;
     }
 }
 

--- a/Source/ARTRest.m
+++ b/Source/ARTRest.m
@@ -238,8 +238,7 @@ ART_TRY_OR_REPORT_CRASH_START(self) {
 
     if ([request isKindOfClass:[NSMutableURLRequest class]]) {
         NSMutableURLRequest *mutableRequest = (NSMutableURLRequest *)request;
-        NSString *accept = [[_encoders.allValues valueForKeyPath:@"mimeType"] componentsJoinedByString:@","];
-        [mutableRequest setValue:accept forHTTPHeaderField:@"Accept"];
+        [mutableRequest setValue:[[self defaultEncoder] mimeType] forHTTPHeaderField:@"Accept"];
         [mutableRequest setValue:[ARTDefault version] forHTTPHeaderField:@"X-Ably-Version"];
         [mutableRequest setValue:[ARTDefault libraryVersion] forHTTPHeaderField:@"X-Ably-Lib"];
         [mutableRequest setTimeoutInterval:_options.httpRequestTimeout];

--- a/Spec/RealtimeClientPresence.swift
+++ b/Spec/RealtimeClientPresence.swift
@@ -4135,7 +4135,35 @@ class RealtimeClientPresence: QuickSpec {
                     }
 
                 }
-
+            }
+            
+            context("presence message attributes") {
+                
+                // TP3a
+                it ("if the presence message does not contain an id, it should be set to protocolMsgId:index") {
+                    let options = AblyTests.commonAppSetup()
+                    options.autoConnect = false
+                    let client = ARTRealtime(options: options)
+                    defer { client.dispose(); client.close() }
+                    let protocolMessage = ARTProtocolMessage()
+                    protocolMessage.id = "protocolId"
+                    let presenceMessage = ARTPresenceMessage()
+                    presenceMessage.clientId = "clientId"
+                    presenceMessage.action = .enter
+                    protocolMessage.presence = [presenceMessage]
+                    
+                    waitUntil(timeout: testTimeout) { done in
+                        client.connection.once(.connected) { _ in
+                            let channel = client.channels.get(NSUUID().uuidString)
+                            channel.presence.subscribe(.enter) { message in
+                                expect(message.id).to(equal("protocolId:0"))
+                                done()
+                            }
+                            channel.onPresence(protocolMessage)
+                        }
+                        client.connect()
+                    }
+                }
             }
 
         }


### PR DESCRIPTION
`(TP3a) id string – unique ID for this presence message. This attribute is always populated for presence messages received over REST. For presence messages received over Realtime, if the presence message does not contain an id, it should be set to protocolMsgId:index, where protocolMsgId is the id of the ProtocolMessage encapsulating it, and index is the index of the presence message inside the presence array of the ProtocolMessage`