### PR TITLE
Add rsa4d

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -859,7 +859,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 - (void)handleTokenAuthError:(NSError *)error {
 ART_TRY_OR_MOVE_TO_FAILED_START(self) {
     [self.logger error:@"R:%p token auth failed with %@", self, error.description];
-    if (error.code == 40102 /*incompatible credentials*/) {
+    if (error.code == 40102 /*incompatible credentials*/ || error.code == 40300 /*auth fails with a 403 (RSA4d)*/) {
         // RSA15c
         [self transition:ARTRealtimeFailed withErrorInfo:[ARTErrorInfo createFromNSError:error]];
     }


### PR DESCRIPTION
`(RSA4d)  If a request by a realtime client to an authUrl results in an HTTP 403 response, or any of an authUrl request, an authCallback, or a request to Ably to exchange a TokenRequest for a TokenDetails result in an ErrorInfo with statusCode 403, then the client library should transition to the FAILED state, with the connection errorReason should be set to the ErrorInfo (or where there is none, as for a 403 authUrl response with no body, an ErrorInfo with code 40300 and an appropriate message)`