### PR TITLE
Add rtn15h2

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -706,6 +706,10 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
             return;
         }
         [self.connection setId:nil];
+        if (error.code >= 40140 && error.code < 40150) {
+            [self transition:ARTRealtimeDisconnected withErrorInfo:message.error];
+            return;
+        }
         [self transition:ARTRealtimeFailed withErrorInfo:message.error];
     }
 } ART_TRY_OR_MOVE_TO_FAILED_END

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2842,7 +2842,8 @@ class RealtimeClientConnection: QuickSpec {
                         }                        
                     }
 
-                    it("should transition to Failed when the token renewal fails and the error should be emitted") {
+                    // RTN15h2
+                    it("should transition to disconnected when the token renewal fails and the error should be emitted") {
                         let options = AblyTests.commonAppSetup()
                         options.disconnectedRetryTimeout = 1.0
                         options.autoConnect = false
@@ -2864,7 +2865,6 @@ class RealtimeClientConnection: QuickSpec {
 
                         client.connect()
                         expect(client.connection.state).toEventually(equal(ARTRealtimeConnectionState.connected), timeout: testTimeout)
-                        weak var firstTransport = client.transport as? TestProxyTransport
 
                         waitUntil(timeout: testTimeout) { done in
                             // Wait for token to expire
@@ -2878,8 +2878,8 @@ class RealtimeClientConnection: QuickSpec {
                         }
 
                         waitUntil(timeout: testTimeout) { done in
-                            // Renewal will fail
-                            client.connection.once(.failed) { stateChange in
+                            // Renewal will lead to a disconnect (again)
+                            client.connection.once(.disconnected) { stateChange in
                                 guard let error = stateChange?.reason else {
                                     fail("Error is nil"); done(); return
                                 }
@@ -2888,8 +2888,6 @@ class RealtimeClientConnection: QuickSpec {
                                 done()
                             }
                         }
-
-                        expect(client.connection.state).to(equal(ARTRealtimeConnectionState.failed))
                     }
 
                 }


### PR DESCRIPTION
`(RTN15h2) If the DISCONNECTED message contains a token error (statusCode value of 401 and error code value in the range 40140 <= code < 40150) and the library has the means to renew the token, a single attempt to create a new token should be made and a new connection attempt initiated using the new token. If the token creation fails or the next connection attempt fails due to a token error, the connection will transition to the DISCONNECTED state and the Connection#errorReason will be set.`

While working on this I got a bunch of failures related to presence. Addressed here: https://github.com/ably/ably-ios/pull/751