### PR TITLE
Add max message size

### DIFF
--- a/Source/ARTBaseMessage.h
+++ b/Source/ARTBaseMessage.h
@@ -36,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description;
 
+- (NSInteger)messageSize;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTBaseMessage.h
+++ b/Source/ARTBaseMessage.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <Ably/ARTTypes.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +29,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic, nullable) NSString *encoding;
 
 @property (strong, nonatomic, nullable) id data;
+
+/// The event name, if available
+@property (nullable, readwrite, strong, nonatomic) NSString *name;
+@property (nullable, nonatomic) id<ARTJsonCompatible> extras;
 
 - (NSString *)description;
 

--- a/Source/ARTBaseMessage.m
+++ b/Source/ARTBaseMessage.m
@@ -69,4 +69,29 @@
     return description;
 }
 
+- (NSInteger)messageSize {
+    // TO3l8*
+    NSInteger finalResult = 0;
+    finalResult += [self.name lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+    finalResult += [[self.extras toJSONString] lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+    finalResult += [self.clientId lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+    if (self.data) {
+        if ([self.data isKindOfClass:[NSString class]]) {
+            finalResult += [self.data lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        }
+        else if ([self.data isKindOfClass:[NSData class]]) {
+            finalResult += [self.data length];
+        } else {
+            NSError *error = nil;
+            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self.data
+                                                               options:NSJSONWritingPrettyPrinted
+                                                                 error:&error];
+            if (!error) {
+                finalResult += [jsonData length];
+            }
+        }
+    }
+    return finalResult;
+}
+
 @end

--- a/Source/ARTChannel.h
+++ b/Source/ARTChannel.h
@@ -15,6 +15,7 @@
 @class ARTRest;
 @class ARTChannelOptions;
 @class ARTMessage;
+@class ARTBaseMessage;
 @class ARTPaginatedResult<ItemType>;
 @class ARTDataQuery;
 
@@ -43,6 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)history:(void(^)(ARTPaginatedResult<ARTMessage *> *_Nullable result, ARTErrorInfo *_Nullable error))callback;
 
+- (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/ARTConnection+Private.h
+++ b/Source/ARTConnection+Private.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setId:(NSString *_Nullable)newId;
 - (void)setKey:(NSString *_Nullable)key;
 - (void)setSerial:(int64_t)serial;
+- (void)setMaxMessageSize:(NSInteger)maxMessageSize;
 - (void)setState:(ARTRealtimeConnectionState)state;
 - (void)setErrorReason:(ARTErrorInfo *_Nullable)errorReason;
 

--- a/Source/ARTConnection.h
+++ b/Source/ARTConnection.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, readonly, strong, nonatomic) NSString *key;
 @property (nullable, readonly, getter=getRecoveryKey) NSString *recoveryKey;
 @property (readonly, assign, nonatomic) int64_t serial;
+@property (readonly, assign, nonatomic) NSInteger maxMessageSize;
 @property (readonly, assign, nonatomic) ARTRealtimeConnectionState state;
 @property (nullable, readonly, strong, nonatomic) ARTErrorInfo *errorReason;
 

--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -20,6 +20,7 @@
     _Nonnull dispatch_queue_t _queue;
     NSString *_id;
     NSString *_key;
+    NSInteger _maxMessageSize;
     int64_t _serial;
     ARTRealtimeConnectionState _state;
     ARTErrorInfo *_errorReason;
@@ -132,6 +133,12 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
 ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     _serial = serial;
     [ARTSentry setExtras:@"connectionSerial" value: [NSNumber numberWithLongLong:serial]];
+} ART_TRY_OR_MOVE_TO_FAILED_END
+}
+
+- (void)setMaxMessageSize:(NSInteger)maxMessageSize {
+ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
+    _maxMessageSize = maxMessageSize;
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }
 

--- a/Source/ARTMessage.h
+++ b/Source/ARTMessage.h
@@ -15,10 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTMessage : ARTBaseMessage
 
-/// The event name, if available
-@property (nullable, readwrite, strong, nonatomic) NSString *name;
-@property (nullable, nonatomic) id<ARTJsonCompatible> extras;
-
 - (instancetype)initWithName:(nullable NSString *)name data:(id)data;
 - (instancetype)initWithName:(nullable NSString *)name data:(id)data clientId:(NSString *)clientId;
 

--- a/Source/ARTMessage.m
+++ b/Source/ARTMessage.m
@@ -12,7 +12,7 @@
 
 - (instancetype)initWithName:(NSString *)name data:(id)data {
     if (self = [self init]) {
-        _name = [name copy];
+        self.name = [name copy];
         if (data) {
             self.data = data;
             self.encoding = @"";
@@ -42,8 +42,8 @@
 
 - (id)copyWithZone:(NSZone *)zone {
     ARTMessage *message = [super copyWithZone:zone];
-    message->_name = self.name;
-    message->_extras = self.extras;
+    message.name = self.name;
+    message.extras = self.extras;
     return message;
 }
 

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -613,6 +613,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
         case ARTRealtimeConnecting:
             [self.connection setId:message.connectionId];
             [self.connection setKey:message.connectionKey];
+            [self.connection setMaxMessageSize:message.connectionDetails.maxMessageSize];
             if (!_resuming) {
                 [self.connection setSerial:message.connectionSerial];
                 [self.logger debug:@"RT:%p msgSerial of connection \"%@\" has been reset", self, self.connection.id_nosync];

--- a/Source/ARTRealtimeChannel.m
+++ b/Source/ARTRealtimeChannel.m
@@ -178,6 +178,16 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
         if (cb) cb([ARTErrorInfo createWithCode:ARTStateNoClientId message:@"attempted to publish presence message without clientId"]);
         return;
     }
+    
+    if ([self exceedMaxSize:@[msg]]) {
+        if (cb) {
+            ARTErrorInfo *sizeError = [ARTErrorInfo createWithCode:40009
+                                                           message:@"maximum message length exceeded"];
+            cb(sizeError);
+        }
+        return;
+    }
+    
     _lastPresenceAction = msg.action;
     
     if (msg.data && self.dataEncoder) {
@@ -1094,6 +1104,18 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
     }];
     [self.logger debug:__FILE__ line:__LINE__ message:@"R:%p C:%p (%@) re-entering local member \"%@\"", _realtime, self, self.name, presence.memberKey];
 } ART_TRY_OR_MOVE_TO_FAILED_END
+}
+
+- (BOOL)exceedMaxSize:(NSArray<ARTBaseMessage *> *)messages {
+    NSInteger size = 0;
+    for (ARTMessage *message in messages) {
+        size += [message messageSize];
+    }
+    NSInteger maxSize = [ARTDefault maxMessageSize];
+    if (self.realtime.connection.maxMessageSize) {
+        maxSize = self.realtime.connection.maxMessageSize;
+    }
+    return size > maxSize;
 }
 
 @end

--- a/Source/ARTTypes.h
+++ b/Source/ARTTypes.h
@@ -178,6 +178,7 @@ NSString *generateNonce(void);
 
 @protocol ARTJsonCompatible <NSObject>
 - (NSDictionary *_Nullable)toJSON:(NSError *_Nullable *_Nullable)error;
+- (NSString *_Nullable)toJSONString;
 @end
 
 @interface NSString (ARTEventIdentification) <ARTEventIdentification>

--- a/Source/ARTTypes.m
+++ b/Source/ARTTypes.m
@@ -175,6 +175,10 @@ NSString *ARTRealtimeConnectionEventToStr(ARTRealtimeConnectionEvent event) {
     return (NSDictionary *)json;
 }
 
+- (NSString *)toJSONString {
+    return self;
+}
+
 @end
 
 @implementation NSDictionary (ARTJsonCompatible)
@@ -184,6 +188,16 @@ NSString *ARTRealtimeConnectionEventToStr(ARTRealtimeConnectionEvent event) {
         *error = nil;
     }
     return self;
+}
+
+- (NSString *)toJSONString {
+    NSError *err = nil;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self options:0 error:&err];
+    if (err) {
+        return nil;
+    }
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    return jsonString;
 }
 
 @end

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -1461,5 +1461,115 @@ class RealtimeClient: QuickSpec {
                 expect(received).toEventually(beTrue(), timeout: testTimeout)
             }
         }
+        
+        // RSL1i
+        context("If the total size of message(s) exceeds the maxMessageSize") {
+            let channelName = "test-message-size"
+            let presenceData = buildStringThatExceedMaxMessageSize()
+            let clientId = "testMessageSizeClientId"
+            
+            it("the client library should reject the publish and indicate an error") {
+                let options = AblyTests.commonAppSetup()
+                let client = ARTRealtime(options: options)
+                let channel = client.channels.get(channelName)
+                let messages = buildMessagesThatExceedMaxMessageSize()
+                
+                waitUntil(timeout: testTimeout, action: { done in
+                    // Wait for connected so that maxMessageSize is loaded from connection details
+                    client.connection.once(.connected) { _ in
+                        channel.publish(messages, callback: { err in
+                            expect(err?.code).to(equal(40009))
+                            expect(err?.message).to(contain("maximum message length exceeded"))
+                            done()
+                        })
+                    }
+                })
+            }
+            
+            it("the client library should reject also presence messages (enter)") {
+                let options = AblyTests.commonAppSetup()
+                options.clientId = clientId
+                let client = ARTRealtime(options: options)
+                let channel = client.channels.get(channelName)
+                
+                waitUntil(timeout: testTimeout, action: { done in
+                    client.connection.once(.connected) { _ in
+                        channel.presence.enter(presenceData, callback: { err in
+                            expect(err?.code).to(equal(40009))
+                            expect(err?.message).to(contain("maximum message length exceeded"))
+                            done()
+                        })
+                    }
+                })
+            }
+            
+            it("the client library should reject also presence messages (leave)") {
+                let options = AblyTests.commonAppSetup()
+                options.clientId = clientId
+                let client = ARTRealtime(options: options)
+                let channel = client.channels.get(channelName)
+                
+                waitUntil(timeout: testTimeout, action: { done in
+                    client.connection.once(.connected) { _ in
+                        channel.presence.leave(presenceData, callback: { err in
+                            expect(err?.code).to(equal(40009))
+                            expect(err?.message).to(contain("maximum message length exceeded"))
+                            done()
+                        })
+                    }
+                })
+            }
+            
+            it("the client library should reject also presence messages (update)") {
+                let options = AblyTests.commonAppSetup()
+                options.clientId = clientId
+                let client = ARTRealtime(options: options)
+                let channel = client.channels.get(channelName)
+                
+                waitUntil(timeout: testTimeout, action: { done in
+                    client.connection.once(.connected) { _ in
+                        channel.presence.update(presenceData, callback: { err in
+                            expect(err?.code).to(equal(40009))
+                            expect(err?.message).to(contain("maximum message length exceeded"))
+                            done()
+                        })
+                    }
+                })
+            }
+            
+            it("the client library should reject also presence messages (updateClient)") {
+                let options = AblyTests.commonAppSetup()
+                options.clientId = clientId
+                let client = ARTRealtime(options: options)
+                let channel = client.channels.get(channelName)
+                
+                waitUntil(timeout: testTimeout, action: { done in
+                    client.connection.once(.connected) { _ in
+                        channel.presence.updateClient(clientId, data: presenceData, callback: { err in
+                            expect(err?.code).to(equal(40009))
+                            expect(err?.message).to(contain("maximum message length exceeded"))
+                            done()
+                        })
+                    }
+                })
+            }
+            
+            it("the client library should reject also presence messages (leaveClient)") {
+                let options = AblyTests.commonAppSetup()
+                options.clientId = clientId
+                let client = ARTRealtime(options: options)
+                let channel = client.channels.get(channelName)
+                
+                waitUntil(timeout: testTimeout, action: { done in
+                    client.connection.once(.connected) { _ in
+                        channel.presence.leaveClient(clientId, data: presenceData, callback: { err in
+                            expect(err?.code).to(equal(40009))
+                            expect(err?.message).to(contain("maximum message length exceeded"))
+                            done()
+                        })
+                    }
+                })
+            }
+        }
     }
 }

--- a/Spec/RestClient.swift
+++ b/Spec/RestClient.swift
@@ -1378,8 +1378,42 @@ class RestClient: QuickSpec {
                         done()
                     })
                 })
+            }
+        }
+        
+        // RSL1i
+        context("If the total size of message(s) exceeds the maxMessageSize") {
+            let channelName = "test-message-size"
+            it("the client library should reject the publish and indicate an error") {
+                let options = AblyTests.commonAppSetup()
+                let client = ARTRest(options: options)
+                let channel = client.channels.get(channelName)
+                let messages = buildMessagesThatExceedMaxMessageSize()
                 
+                waitUntil(timeout: testTimeout, action: { done in
+                    channel.publish(messages, callback: { err in
+                        expect(err?.code).to(equal(40009))
+                        expect(err?.message).to(contain("maximum message length exceeded"))
+                        done()
+                    })
+                })
+            }
+            
+            it("also when using publish:data:clientId:extras") {
+                let options = AblyTests.commonAppSetup()
+                let client = ARTRest(options: options)
+                let channel = client.channels.get(channelName)
+                let name = buildStringThatExceedMaxMessageSize()
                 
+                waitUntil(timeout: testTimeout, action: { done in
+                    channel.publish(name, data: nil, extras: nil, callback: {err in
+                        expect(err?.code).to(equal(40009))
+                        expect(err?.message).to(contain("maximum message length exceeded"))
+                        done()
+                    })
+                    
+                    
+                })
             }
         }
     }

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -538,6 +538,23 @@ public func delay(_ seconds: TimeInterval, closure: @escaping ()->()) {
         deadline: DispatchTime.now() + Double(Int64(seconds * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
 }
 
+public func buildMessagesThatExceedMaxMessageSize() -> [ARTMessage] {
+    var messages = [ARTMessage]()
+    for index in 0...5000 {
+        let m = ARTMessage(name: "name-\(index)", data: "data-\(index)")
+        messages.append(m)
+    }
+    return messages
+}
+
+public func buildStringThatExceedMaxMessageSize() -> String {
+    var name = ""
+    for index in 0...10000 {
+        name += "name-\(index)"
+    }
+    return name
+}
+
 class Box<T> {
     let unbox: T
     init(_ value: T) {

--- a/Spec/Utilities.swift
+++ b/Spec/Utilities.swift
@@ -431,6 +431,30 @@ class Utilities: QuickSpec {
                 }
 
             }
+            
+            context("maxMessageSize") {
+                let data = ["test": "test"]
+                let extras = ["push": ["key": "value"]]
+                let clientId = "clientId"
+                
+                it("calculates maxMessageSize of a Message with name and data") {
+                    let message = ARTMessage(name: "this is name", data: data)
+                    expect(message.messageSize()).to(equal(33))
+                }
+                
+                it("calculates maxMessageSize of a Message with name, data and extras") {
+                    let message = ARTMessage(name: "this is name", data: data)
+                    message.extras = extras as ARTJsonCompatible
+                    expect(message.messageSize()).to(equal(57))
+                }
+                
+                it("calculates maxMessageSize of a Message with name, data, clientId and extras") {
+                    let message = ARTMessage(name: "this is name", data: data)
+                    message.clientId = clientId
+                    message.extras = extras as ARTJsonCompatible
+                    expect(message.messageSize()).to(equal(65))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This addresses spec `TO3l8*` and `RSL1i` items, aka throw an error before publishing messages when the size exceeds `maxMessageSize`.

NOTE: queued messages exceeding `maxMessageSize` (`RTL6d1`) will be addressed in a separate PR