### PR TITLE
Move name property to ARTMessage

### DIFF
--- a/Source/ARTBaseMessage.h
+++ b/Source/ARTBaseMessage.h
@@ -30,8 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (strong, nonatomic, nullable) id data;
 
-/// The event name, if available
-@property (nullable, readwrite, strong, nonatomic) NSString *name;
 @property (nullable, nonatomic) id<ARTJsonCompatible> extras;
 
 - (NSString *)description;

--- a/Source/ARTBaseMessage.m
+++ b/Source/ARTBaseMessage.m
@@ -72,7 +72,6 @@
 - (NSInteger)messageSize {
     // TO3l8*
     NSInteger finalResult = 0;
-    finalResult += [self.name lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
     finalResult += [[self.extras toJSONString] lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
     finalResult += [self.clientId lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
     if (self.data) {

--- a/Source/ARTMessage.h
+++ b/Source/ARTMessage.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ARTMessage : ARTBaseMessage
 
+/// The event name, if available
+@property (nullable, readwrite, strong, nonatomic) NSString *name;
+
 - (instancetype)initWithName:(nullable NSString *)name data:(id)data;
 - (instancetype)initWithName:(nullable NSString *)name data:(id)data clientId:(NSString *)clientId;
 

--- a/Source/ARTMessage.m
+++ b/Source/ARTMessage.m
@@ -47,4 +47,9 @@
     return message;
 }
 
+- (NSInteger)messageSize {
+    // TO3l8*
+    return [super messageSize] + [self.name lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+}
+
 @end


### PR DESCRIPTION
So that a presence message doesn't inherit the `name` property
Fix #762 