### PR TITLE
Fix RSL1b

### DIFF
--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -93,16 +93,19 @@ class RestClientChannel: QuickSpec {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
-                    channel.publish(nil, data: nil) { error in
-                        publishError = error
-                        channel.history { result, _ in
-                            publishedMessage = result?.items.first
+                    waitUntil(timeout: testTimeout) { done in
+                        channel.publish(nil, data: nil) { error in
+                            publishError = error
+                            channel.history { result, _ in
+                                publishedMessage = result?.items.first
+                                done()
+                            }
                         }
                     }
 
-                    expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.data).toEventually(beNil(), timeout: testTimeout)
+                    expect(publishError).to(beNil())
+                    expect(publishedMessage?.name).to(beNil())
+                    expect(publishedMessage?.data).to(beNil())
                 }
             }
 

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -114,16 +114,19 @@ class RestClientChannel: QuickSpec {
                     var publishError: ARTErrorInfo? = ARTErrorInfo.create(from: NSError(domain: "", code: -1, userInfo: nil))
                     var publishedMessage: ARTMessage?
 
-                    channel.publish([ARTMessage(name: name, data: data)]) { error in
-                        publishError = error
-                        channel.history { result, _ in
-                            publishedMessage = result?.items.first
+                    waitUntil(timeout: testTimeout) { done in
+                        channel.publish([ARTMessage(name: name, data: data)]) { error in
+                            publishError = error
+                            channel.history { result, _ in
+                                publishedMessage = result?.items.first
+                                done()
+                            }
                         }
                     }
 
-                    expect(publishError).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)
-                    expect(publishedMessage?.data).toEventually(beNil(), timeout: testTimeout)
+                    expect(publishError).to(beNil())
+                    expect(publishedMessage?.name).to(equal(name))
+                    expect(publishedMessage?.data as? String).to(equal(data))
                 }
             }
 


### PR DESCRIPTION
The `history` callback wasn’t called because the `expect(publishedMessage?.name).toEventually(beNil(), timeout: testTimeout)` won’t wait to `publishedMessage?.name` be nil because it’s already nil 😕 So, a `waitUntil` is a better approach.