### PR TITLE
Add TR3*

### DIFF
--- a/Source/ARTProtocolMessage+Private.h
+++ b/Source/ARTProtocolMessage+Private.h
@@ -8,9 +8,15 @@
 
 /// ARTProtocolMessageFlag bitmask
 typedef NS_OPTIONS(NSUInteger, ARTProtocolMessageFlag) {
-    ARTProtocolMessageFlagHasPresence = (1UL << 0), //1
-    ARTProtocolMessageFlagHasBacklog = (1UL << 1), //2
-    ARTProtocolMessageFlagResumed = (1UL << 2) //4
+    ARTProtocolMessageFlagHasPresence = (1UL << 0),
+    ARTProtocolMessageFlagHasBacklog = (1UL << 1),
+    ARTProtocolMessageFlagResumed = (1UL << 2),
+    ARTProtocolMessageFlagHasLocalPresence = (1UL << 3),
+    ARTProtocolMessageFlagTransient = (1UL << 4),
+    ARTProtocolMessageFlagPresence = (1UL << 16),
+    ARTProtocolMessageFlagPublish = (1UL << 17),
+    ARTProtocolMessageFlagSubscribe = (1UL << 18),
+    ARTProtocolMessageFlagPresenceSubscribe = (1UL << 19)
 };
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Adds missing flag values to a protocol message
```
(TR3) ProtocolMessage Flag enum has the following values, where a flag with value n is defined to be set if the bitwise AND of the flags field with 2ⁿ is nonzero
--
  | (TR3a) 0: HAS_PRESENCE
  | (TR3b) 1: HAS_BACKLOG
  | (TR3c) 2: RESUMED
  | (TR3d) 3: HAS_LOCAL_PRESENCE
  | (TR3e) 4: TRANSIENT
  | (TR3q) 16: PRESENCE
  | (TR3r) 17: PUBLISH
  | (TR3s) 18: SUBSCRIBE
  | (TR3t) 19: PRESENCE_SUBSCRIBE

```