### PR TITLE
Update RTN16b

### DIFF
--- a/Source/ARTConnection.m
+++ b/Source/ARTConnection.m
@@ -175,7 +175,7 @@ ART_TRY_OR_MOVE_TO_FAILED_START(_realtime) {
             if (recStr == nil) {
                 return nil;
             }
-            NSString *str = [recStr stringByAppendingString:[NSString stringWithFormat:@":%ld", (long)self.serial_nosync]];
+            NSString *str = [recStr stringByAppendingString:[NSString stringWithFormat:@":%ld:%ld", (long)self.serial_nosync, (long)_realtime.msgSerial]];
             return str;
         } default:
             return nil;

--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -1454,6 +1454,17 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
+- (void)realtimeTransportSetMsgSerial:(id<ARTRealtimeTransport>)transport msgSerial:(int64_t)msgSerial {
+ART_TRY_OR_MOVE_TO_FAILED_START(self) {
+    if (transport != self.transport) {
+        // Old connection
+        return;
+    }
+
+    self.msgSerial = msgSerial;
+} ART_TRY_OR_MOVE_TO_FAILED_END
+}
+
 - (void)onUncaughtException:(NSException *)e {
     if ([e isKindOfClass:[ARTException class]]) {
         @throw e;

--- a/Source/ARTRealtimeTransport.h
+++ b/Source/ARTRealtimeTransport.h
@@ -65,6 +65,8 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 - (void)realtimeTransportTooBig:(id<ARTRealtimeTransport>)transport;
 - (void)realtimeTransportFailed:(id<ARTRealtimeTransport>)transport withError:(ARTRealtimeTransportError *)error;
 
+- (void)realtimeTransportSetMsgSerial:(id<ARTRealtimeTransport>)transport msgSerial:(int64_t)msgSerial;
+
 @end
 
 @protocol ARTRealtimeTransport

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -149,7 +149,7 @@ NSString *WebSocketStateToStr(SRReadyState state);
 
     if (options.recover) {
         NSArray *recoverParts = [options.recover componentsSeparatedByString:@":"];
-        if ([recoverParts count] == 2) {
+        if (recoverParts.count > 1 && recoverParts.count <= 3) {
             NSString *key = [recoverParts objectAtIndex:0];
             NSString *serial = [recoverParts objectAtIndex:1];
             [self.logger info:@"R:%p WS:%p ARTWebSocketTransport: attempting recovery of connection %@", _delegate, self, key];
@@ -159,6 +159,11 @@ NSString *WebSocketStateToStr(SRReadyState state);
 
             NSURLQueryItem *connectionSerialParam = [NSURLQueryItem queryItemWithName:@"connectionSerial" value:serial];
             queryItems = [queryItems arrayByAddingObject:connectionSerialParam];
+
+            int64_t msgSerial = [[recoverParts lastObject] longLongValue];
+            if (msgSerial) {
+                [_delegate realtimeTransportSetMsgSerial:self msgSerial:msgSerial];
+            }
         }
         else {
             [self.logger error:@"R:%p WS:%p ARTWebSocketTransport: recovery string is malformed, ignoring: '%@'", _delegate, self, options.recover];

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -103,7 +103,7 @@ class RealtimeClient: QuickSpec {
                                 done()
                             case .connected:
                                 self.checkError(errorInfo)
-                                expect(client.connection.recoveryKey).to(equal("\(client.connection.key ?? ""):\(client.connection.serial)"), description: "recoveryKey wrong formed")
+                                expect(client.connection.recoveryKey).to(equal("\(client.connection.key ?? ""):\(client.connection.serial):\(client.msgSerial)"), description: "recoveryKey wrong formed")
                                 options.recover = client.connection.recoveryKey
                                 done()
                             default:

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2978,11 +2978,6 @@ class RealtimeClientConnection: QuickSpec {
                     expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.msgSerial)"))
                 }
 
-            }
-
-            // RTN16
-            context("Connection recovery") {
-
                 // RTN16d
                 it("when a connection is successfully recovered, Connection#id will be identical to the id of the connection that was recovered and Connection#key will always be updated to the ConnectionDetails#connectionKey provided in the first CONNECTED ProtocolMessage") {
                     let options = AblyTests.commonAppSetup()
@@ -3011,11 +3006,6 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
 
-            }
-
-            // RTN16
-            context("Connection recovery") {
-
                 // RTN16c
                 it("Connection#recoveryKey should become becomes null when a connection is explicitly CLOSED or CLOSED") {
                     let options = AblyTests.commonAppSetup()
@@ -3034,11 +3024,6 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
 
-            }
-
-            // RTN16
-            context("Connection recovery") {
-
                 // RTN16e
                 it("should connect anyway if the recoverKey is no longer valid") {
                     let options = AblyTests.commonAppSetup()
@@ -3047,10 +3032,61 @@ class RealtimeClientConnection: QuickSpec {
                     defer { client.dispose(); client.close() }
                     waitUntil(timeout: testTimeout) { done in
                         client.connection.once(.connected) { stateChange in
-                            expect(stateChange!.reason!.message).to(contain("Unable to recover connection"))
-                            expect(client.connection.errorReason).to(beIdenticalTo(stateChange!.reason))
+                            guard let reason = stateChange?.reason else {
+                                fail("Reason is empty"); done(); return
+                            }
+                            expect(reason.message).to(contain("Unable to recover connection"))
+                            expect(client.connection.errorReason).to(beIdenticalTo(reason))
                             done()
                         }
+                    }
+                }
+
+                // RTN16f
+                it("should use msgSerial from recoveryKey to set the client internal msgSerial but is not sent to Ably") {
+                    let options = AblyTests.commonAppSetup()
+                    options.autoConnect = false
+                    options.recover = "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx:-1:7"
+
+                    let client = AblyTests.newRealtime(options)
+                    defer { client.dispose(); client.close() }
+
+                    var urlConnections = [NSURL]()
+                    TestProxyTransport.networkConnectEvent = { transport, url in
+                        if client.transport !== transport {
+                            return
+                        }
+                        urlConnections.append(url as NSURL)
+                        if urlConnections.count == 1 {
+                            TestProxyTransport.network = nil
+                        }
+                    }
+                    defer { TestProxyTransport.networkConnectEvent = nil }
+
+                    waitUntil(timeout: testTimeout) { done in
+                        client.connection.once(.connected) { stateChange in
+                            guard let reason = stateChange?.reason else {
+                                fail("Reason is empty"); done(); return
+                            }
+
+                            expect(urlConnections.count) == 1
+                            guard let urlConnectionQuery = urlConnections.first?.query else {
+                                fail("Missing URL Connection query"); done(); return
+                            }
+
+                            expect(urlConnectionQuery).to(haveParam("recover", withValue: "99999!xxxxxx-xxxxxxxxx-xxxxxxxxx"))
+                            expect(urlConnectionQuery).to(haveParam("connectionSerial", withValue: "-1"))
+                            expect(urlConnectionQuery).toNot(haveParam("msgSerial"))
+
+                            // recover fails, the counter should be reset to 0
+                            expect(client.msgSerial) == 0
+
+                            expect(reason.message).to(contain("Unable to recover connection"))
+                            expect(client.connection.errorReason).to(beIdenticalTo(reason))
+                            done()
+                        }
+                        client.connect()
+                        expect(client.msgSerial) == 7
                     }
                 }
 

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2952,7 +2952,7 @@ class RealtimeClientConnection: QuickSpec {
                 }
 
                 // RTN16b
-                it("Connection#recoveryKey should be composed with the connection key and latest serial received") {
+                it("Connection#recoveryKey should be composed with the connection key and latest serial received and msgSerial") {
                     let options = AblyTests.commonAppSetup()
                     let client = ARTRealtime(options: options)
                     defer { client.dispose(); client.close() }
@@ -2961,7 +2961,7 @@ class RealtimeClientConnection: QuickSpec {
                         let partialDone = AblyTests.splitDone(2, done: done)
                         client.connection.once(.connected) { _ in
                             expect(client.connection.serial).to(equal(-1))
-                            expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial)"))
+                            expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.msgSerial)"))
                         }
                         channel.publish(nil, data: "message") { error in
                             expect(error).to(beNil())
@@ -2974,6 +2974,8 @@ class RealtimeClientConnection: QuickSpec {
                             partialDone()
                         }
                     }
+                    expect(client.msgSerial) == 1
+                    expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.msgSerial)"))
                 }
 
             }

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -1360,7 +1360,7 @@ public func beCloseTo(_ expectedValue: Date) -> Predicate<Date> {
 }
 
 /// A Nimble matcher that succeeds when a param exists.
-public func haveParam(_ key: String, withValue expectedValue: String?) -> Predicate<String> {
+public func haveParam(_ key: String, withValue expectedValue: String? = nil) -> Predicate<String> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         failureMessage.postfixMessage = "param <\(key)=\(expectedValue ?? "nil")> exists"
         guard let actualValue = try actualExpression.evaluate() else { return false }


### PR DESCRIPTION
Related #799.

> (RTN16b) Connection#recoveryKey is an attribute composed of the connectionKey, and the latest connectionSerial received on the connection, and the current msgSerial 
https://docs.ably.io/client-lib-development-guide/features/#RTN16b