### PR TITLE
RTN16f

### DIFF
--- a/Source/ARTRealtime.m
+++ b/Source/ARTRealtime.m
@@ -1454,6 +1454,17 @@ ART_TRY_OR_MOVE_TO_FAILED_START(self) {
 } ART_TRY_OR_MOVE_TO_FAILED_END
 }
 
+- (void)realtimeTransportSetMsgSerial:(id<ARTRealtimeTransport>)transport msgSerial:(int64_t)msgSerial {
+ART_TRY_OR_MOVE_TO_FAILED_START(self) {
+    if (transport != self.transport) {
+        // Old connection
+        return;
+    }
+
+    self.msgSerial = msgSerial;
+} ART_TRY_OR_MOVE_TO_FAILED_END
+}
+
 - (void)onUncaughtException:(NSException *)e {
     if ([e isKindOfClass:[ARTException class]]) {
         @throw e;

--- a/Source/ARTRealtimeTransport.h
+++ b/Source/ARTRealtimeTransport.h
@@ -65,6 +65,8 @@ typedef NS_ENUM(NSUInteger, ARTRealtimeTransportState) {
 - (void)realtimeTransportTooBig:(id<ARTRealtimeTransport>)transport;
 - (void)realtimeTransportFailed:(id<ARTRealtimeTransport>)transport withError:(ARTRealtimeTransportError *)error;
 
+- (void)realtimeTransportSetMsgSerial:(id<ARTRealtimeTransport>)transport msgSerial:(int64_t)msgSerial;
+
 @end
 
 @protocol ARTRealtimeTransport

--- a/Source/ARTWebSocketTransport.m
+++ b/Source/ARTWebSocketTransport.m
@@ -149,7 +149,7 @@ NSString *WebSocketStateToStr(SRReadyState state);
 
     if (options.recover) {
         NSArray *recoverParts = [options.recover componentsSeparatedByString:@":"];
-        if ([recoverParts count] == 2) {
+        if (recoverParts.count > 1 && recoverParts.count <= 3) {
             NSString *key = [recoverParts objectAtIndex:0];
             NSString *serial = [recoverParts objectAtIndex:1];
             [self.logger info:@"R:%p WS:%p ARTWebSocketTransport: attempting recovery of connection %@", _delegate, self, key];
@@ -159,6 +159,11 @@ NSString *WebSocketStateToStr(SRReadyState state);
 
             NSURLQueryItem *connectionSerialParam = [NSURLQueryItem queryItemWithName:@"connectionSerial" value:serial];
             queryItems = [queryItems arrayByAddingObject:connectionSerialParam];
+
+            int64_t msgSerial = [[recoverParts lastObject] longLongValue];
+            if (msgSerial) {
+                [_delegate realtimeTransportSetMsgSerial:self msgSerial:msgSerial];
+            }
         }
         else {
             [self.logger error:@"R:%p WS:%p ARTWebSocketTransport: recovery string is malformed, ignoring: '%@'", _delegate, self, options.recover];

--- a/Spec/RealtimeClient.swift
+++ b/Spec/RealtimeClient.swift
@@ -103,7 +103,7 @@ class RealtimeClient: QuickSpec {
                                 done()
                             case .connected:
                                 self.checkError(errorInfo)
-                                expect(client.connection.recoveryKey).to(equal("\(client.connection.key ?? ""):\(client.connection.serial)"), description: "recoveryKey wrong formed")
+                                expect(client.connection.recoveryKey).to(equal("\(client.connection.key ?? ""):\(client.connection.serial):\(client.msgSerial)"), description: "recoveryKey wrong formed")
                                 options.recover = client.connection.recoveryKey
                                 done()
                             default:

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -3032,8 +3032,11 @@ class RealtimeClientConnection: QuickSpec {
                     defer { client.dispose(); client.close() }
                     waitUntil(timeout: testTimeout) { done in
                         client.connection.once(.connected) { stateChange in
-                            expect(stateChange!.reason!.message).to(contain("Unable to recover connection"))
-                            expect(client.connection.errorReason).to(beIdenticalTo(stateChange!.reason))
+                            guard let reason = stateChange?.reason else {
+                                fail("Reason is empty"); done(); return
+                            }
+                            expect(reason.message).to(contain("Unable to recover connection"))
+                            expect(client.connection.errorReason).to(beIdenticalTo(reason))
                             done()
                         }
                     }

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -2978,11 +2978,6 @@ class RealtimeClientConnection: QuickSpec {
                     expect(client.connection.recoveryKey).to(equal("\(client.connection.key!):\(client.connection.serial):\(client.msgSerial)"))
                 }
 
-            }
-
-            // RTN16
-            context("Connection recovery") {
-
                 // RTN16d
                 it("when a connection is successfully recovered, Connection#id will be identical to the id of the connection that was recovered and Connection#key will always be updated to the ConnectionDetails#connectionKey provided in the first CONNECTED ProtocolMessage") {
                     let options = AblyTests.commonAppSetup()
@@ -3011,11 +3006,6 @@ class RealtimeClientConnection: QuickSpec {
                     }
                 }
 
-            }
-
-            // RTN16
-            context("Connection recovery") {
-
                 // RTN16c
                 it("Connection#recoveryKey should become becomes null when a connection is explicitly CLOSED or CLOSED") {
                     let options = AblyTests.commonAppSetup()
@@ -3033,11 +3023,6 @@ class RealtimeClientConnection: QuickSpec {
                         }
                     }
                 }
-
-            }
-
-            // RTN16
-            context("Connection recovery") {
 
                 // RTN16e
                 it("should connect anyway if the recoverKey is no longer valid") {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -1360,7 +1360,7 @@ public func beCloseTo(_ expectedValue: Date) -> Predicate<Date> {
 }
 
 /// A Nimble matcher that succeeds when a param exists.
-public func haveParam(_ key: String, withValue expectedValue: String?) -> Predicate<String> {
+public func haveParam(_ key: String, withValue expectedValue: String? = nil) -> Predicate<String> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         failureMessage.postfixMessage = "param <\(key)=\(expectedValue ?? "nil")> exists"
         guard let actualValue = try actualExpression.evaluate() else { return false }


### PR DESCRIPTION
> (RTN16f) The msgSerial component of the recoveryKey, unlike the other two components, is not sent to Ably, but rather is used to set the library internal msgSerial. (If the recover fails, the counter should be reset to 0 per RTN15c3) 
https://docs.ably.io/client-lib-development-guide/features/#RTN16f