### PR TITLE
Add rtl6d1

### DIFF
--- a/Spec/RealtimeClientChannel.swift
+++ b/Spec/RealtimeClientChannel.swift
@@ -2066,13 +2066,13 @@ class RealtimeClientChannel: QuickSpec {
                     defer { client.dispose(); client.close() }
                     let channel = client.channels.get("test-maxMessageSize")
                     // This amount of messages would be beyond maxMessageSize, if bundled together
-                    let messagesToBeSent = 5000
+                    let messagesToBeSent = 1000
                     
                     // call publish before connecting, so messages are queued
                     waitUntil(timeout: testTimeout*2) { done in
                         let partialDone = AblyTests.splitDone(messagesToBeSent, done: done)
                         for i in 1...messagesToBeSent {
-                            channel.publish("initial\(i)", data: "message\(i)") { error in
+                            channel.publish("initial initial\(i)", data: "message message\(i)") { error in
                                 expect(error).to(beNil())
                                 partialDone()
                             }


### PR DESCRIPTION
Adds `RTL6d1`
```
(RTL6d) Messages for a single channel that have been queued may be sent in a single ProtocolMessage by bundling them into the ProtocolMessage#messages array, subject to the following constraints:
    (RTL6d1) The resulting ProtocolMesssage must not exceed the maxMessageSize
```