### PR TITLE
Xcode 10 minimal support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.4
+osx_image: xcode10
 env:
   global:
   - LC_CTYPE=en_US.UTF-8
@@ -11,6 +11,7 @@ matrix:
     - env: NAME="ably-iOS" LANE=test_iOS9
 before_install:
   - gem install cocoapods -v '1.5.3'
+  - pod repo update > /dev/null
 install:
   - brew update
   - brew upgrade carthage

--- a/Podfile
+++ b/Podfile
@@ -2,11 +2,11 @@ platform :ios, '8.0'
 use_frameworks!
 
 def test_pods
-    pod 'Quick', '1.2.0'
-    pod 'Nimble', '7.0.3'
+    pod 'Quick', '1.3.2'
+    pod 'Nimble', '7.3.1'
     # Helpers
     pod 'Aspects'
-    pod 'SwiftyJSON', '3.1.4'
+    pod 'SwiftyJSON', '4.2.0'
 end
 
 target 'AblySpec' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - Aspects (1.4.1)
-  - Nimble (7.0.3)
-  - Quick (1.2.0)
-  - SwiftyJSON (3.1.4)
+  - Nimble (7.3.1)
+  - Quick (1.3.2)
+  - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
   - Aspects
-  - Nimble (= 7.0.3)
-  - Quick (= 1.2.0)
-  - SwiftyJSON (= 3.1.4)
+  - Nimble (= 7.3.1)
+  - Quick (= 1.3.2)
+  - SwiftyJSON (= 4.2.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -19,10 +19,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Aspects: 7595ba96a6727a58ebcbfc954497fc5d2fdde546
-  Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220
+  Nimble: 04f732da099ea4d153122aec8c2a88fd0c7219ae
+  Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
+  SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: bbc911685e19e03e4fc0bed9375d6679936a44f8
+PODFILE CHECKSUM: 9bf82af1364f7516b3cef23493c8ab32033ba654
 
 COCOAPODS: 1.5.3

--- a/Spec/RealtimeClientConnection.swift
+++ b/Spec/RealtimeClientConnection.swift
@@ -4292,7 +4292,7 @@ class RealtimeClientConnection: QuickSpec {
             }
 
             context("with fixture messages") {
-                let fixtures = JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))! as Data, options: .mutableContainers)
+                let fixtures = try! JSON(data: NSData(contentsOfFile: pathForTestResource(testResourcesPath + "messages-encoding.json"))! as Data, options: .mutableContainers)
 
                 func expectDataToMatch(_ message: ARTMessage, _ fixtureMessage: JSON) {
                     switch fixtureMessage["expectedType"].string! {
@@ -4378,7 +4378,7 @@ class RealtimeClientConnection: QuickSpec {
                                         done()
                                         return
                                     }
-                                    let persistedMessage = JSON(data: data!).array!.first!
+                                    let persistedMessage = try! JSON(data: data!).array!.first!
                                     expect(persistedMessage["data"]).to(equal(fixtureMessage["data"]))
                                     expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
                                     done()
@@ -4481,7 +4481,7 @@ class RealtimeClientConnection: QuickSpec {
                                         done()
                                         return
                                     }
-                                    let persistedMessage = JSON(data: data!).array!.first!
+                                    let persistedMessage = try! JSON(data: data!).array!.first!
                                     expect(persistedMessage["data"]).to(equal(persistedMessage["data"]))
                                     expect(persistedMessage["encoding"]).to(equal(fixtureMessage["encoding"]))
                                     done()

--- a/Spec/RestClientChannel.swift
+++ b/Spec/RestClientChannel.swift
@@ -852,7 +852,7 @@ class RestClientChannel: QuickSpec {
                                 if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
                                     // Array
                                     let json = AblyTests.msgpackToJSON(http as NSData)
-                                    expect(JSON(data: json["data"].stringValue.data(using: String.Encoding.utf8)!).asArray).to(equal(array as NSArray?))
+                                    expect(try! JSON(data: json["data"].stringValue.data(using: .utf8)!).asArray).to(equal(array as NSArray?))
                                     expect(json["encoding"].string).to(equal("json"))
                                 }
                                 else {
@@ -873,7 +873,7 @@ class RestClientChannel: QuickSpec {
                                 if let request = testHTTPExecutor.requests.last, let http = request.httpBody {
                                     // Dictionary
                                     let json = AblyTests.msgpackToJSON(http as NSData)
-                                    expect(JSON(data: json["data"].stringValue.data(using: String.Encoding.utf8)!).asDictionary).to(equal(dictionary as NSDictionary?))
+                                    expect(try! JSON(data: json["data"].stringValue.data(using: .utf8)!).asDictionary).to(equal(dictionary as NSDictionary?))
                                     expect(json["encoding"].string).to(equal("json"))
                                 }
                                 else {

--- a/Spec/TestUtilities.swift
+++ b/Spec/TestUtilities.swift
@@ -55,7 +55,7 @@ class AblyTests {
     class func msgpackToJSON(_ data: NSData) -> JSON {
         let decoded = try! ARTMsgPackEncoder().decode(data as Data)
         let encoded = try! ARTJsonEncoder().encode(decoded)
-        return JSON(data: encoded)
+        return try! JSON(data: encoded)
     }
 
     class func checkError(_ errorInfo: ARTErrorInfo?, withAlternative message: String) {
@@ -121,7 +121,7 @@ class AblyTests {
                 fatalError(error.localizedDescription)
             }
 
-            testApplication = JSON(data: responseData!)
+            testApplication = try! JSON(data: responseData!)
             
             if debug {
                 options.logLevel = .verbose


### PR DESCRIPTION
Can't use Xcode 9 to run tests anymore 😩 The [_Could not attach to pid_](https://stackoverflow.com/questions/44651029/xcode-9-could-not-attach-to-pid) is ruining my day. I tried many things and nothing fixed it.

But I can run tests using in Xcode 10 🤷‍♂️ So I did just the minimal changes to be able to work with Xcode 10.

@funkyboy Could you use this in your `xcode10-ios12-swift42` branch? Sorry, I tried to use yours but you have so many changes that I preferred to create mine with little changes.