### PR TITLE
Stop notifying Slack for every platform and every iOS build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,11 +8,6 @@ platform :ios do
       devices: ["iPhone XS (12.0)"],
       xcargs: { ABLY_ENV: ENV['ABLY_ENV'] }
     )
-    slack(
-      message: "Completed tests on iOS12",
-      success: :test_result,
-      default_payloads: [:test_result, :git_branch, :git_author, :last_git_commit_message]
-    )
   end
 
   lane :test_iOS11 do
@@ -21,11 +16,6 @@ platform :ios do
       devices: ["iPhone 8 (11.4)"],
       test_without_building: false,
       xcargs: { ABLY_ENV: ENV['ABLY_ENV'] }
-    )
-    slack(
-      message: "Completed tests on iOS11",
-      success: :test_result,
-      default_payloads: [:test_result, :git_branch, :git_author, :last_git_commit_message]
     )
   end
 
@@ -36,11 +26,6 @@ platform :ios do
       test_without_building: false,
       xcargs: { ABLY_ENV: ENV['ABLY_ENV'] }
     )
-    slack(
-      message: "Completed tests on iOS10",
-      success: :test_result,
-      default_payloads: [:test_result, :git_branch, :git_author, :last_git_commit_message]
-    )
   end
 
   lane :test_iOS9 do
@@ -50,11 +35,6 @@ platform :ios do
       test_without_building: false,
       xcargs: { ABLY_ENV: ENV['ABLY_ENV'] }
     )
-    slack(
-      message: "Completed tests on iOS9",
-      success: :test_result,
-      default_payloads: [:test_result, :git_branch, :git_author, :last_git_commit_message]
-    )
   end
 
   lane :test_tvOS12 do
@@ -63,11 +43,6 @@ platform :ios do
       devices: ["Apple TV 4K"],
       xcargs: { ABLY_ENV: ENV['ABLY_ENV'] }
     )
-    slack(
-      message: "Completed tests on tvOS12",
-      success: :test_result,
-      default_payloads: [:test_result, :git_branch, :git_author, :last_git_commit_message]
-    )
   end
 
   lane :test_macOS do
@@ -75,11 +50,6 @@ platform :ios do
       scheme: "Ably-macOS-Tests",
       test_without_building: false,
       xcargs: { ABLY_ENV: ENV['ABLY_ENV'] }
-    )
-    slack(
-      message: "Completed tests on macOS",
-      success: :test_result,
-      default_payloads: [:test_result, :git_branch, :git_author, :last_git_commit_message]
     )
   end
 


### PR DESCRIPTION
Now that we've disabled the Slack webhooks for every iOS build on every platform, the builds need to also stop attempting to notify Slack.

@ricardopereira I assume we still see the results of Fastlane in the build output itself so this change is fine?